### PR TITLE
new zsh widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,8 +196,8 @@ bindkey '^T' fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  cd ${$(find * -path '*/\.*' -prune \
-         -o -type d -print 2> /dev/null | fzf):-.}
+  cd "${$(find * -path '*/\.*' -prune \
+          -o -type d -print 2> /dev/null | fzf):-.}"
   zle reset-prompt
 }
 zle     -N    fzf-cd-widget


### PR DESCRIPTION
- new fzf-cd-widget for running cd
- fzf-file-widget now properly escapes the special characters and supports
  multi-selection
- fzf-history-widget replaces the current line instead of appending to it
