### PR TITLE
Feed all zsh history into fzf (not only most recent)

### DIFF
--- a/install
+++ b/install
@@ -150,7 +150,7 @@ bindkey '\ec' fzf-cd-widget
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
-  LBUFFER=$(history | fzf +s | sed "s/ *[0-9]* *//")
+  LBUFFER=$(history -$HISTSIZE | fzf +s | sed "s/ *[0-9]* *//")
   zle redisplay
 }
 zle     -N   fzf-history-widget


### PR DESCRIPTION
When I execute `history` in Zsh I see only the 16 most recent commands. Fuzzy finding on them doesn't make much sense. Adding `-$HISTSIZE` shows all commands from the history that are saved.

Also adding `-n` removes the command index, so the `sed` command can be removed.
