### PR TITLE
Use `fc` instead of `history` to avoid oh-my-zsh alias

### DIFF
--- a/install
+++ b/install
@@ -150,7 +150,7 @@ bindkey '\ec' fzf-cd-widget
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
-  LBUFFER=$('history' -$HISTSIZE | fzf +s | sed "s/ *[0-9]* *//")
+  LBUFFER=$(fc -l 1 | fzf +s | sed "s/ *[0-9]* *//")
   zle redisplay
 }
 zle     -N   fzf-history-widget


### PR DESCRIPTION
As discussed in #19.
