### PR TITLE
Update install

### DIFF
--- a/install
+++ b/install
@@ -216,7 +216,7 @@ bindkey '\ec' fzf-cd-widget
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
-  LBUFFER=$(fc -l 1 | fzf +s | sed "s/ *[0-9]* *//")
+  LBUFFER=$(fc -l 1 | fzf +s | sed "s/ *[0-9]*\*\? *//")
   zle redisplay
 }
 zle     -N   fzf-history-widget


### PR DESCRIPTION
- Add ability to run install without any prompts using `fzf_quiet_install` env var.
- Update sed regex to strip `*` from history lines when using `tmux` and `fc`
  e.g. when using tmux and fc in different windows can cause output such as:
  
  > 632\* vim ~/.tmux.conf
  > 633 tmux -2 a
  > 635\* git diff
  > 636\* git commit -a
