### PR TITLE
Enable exact matching in zsh history search (Ctrl-R)

### DIFF
--- a/install
+++ b/install
@@ -216,7 +216,7 @@ bindkey '\ec' fzf-cd-widget
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
-  LBUFFER=$(fc -l 1 | fzf +s | sed "s/ *[0-9*]* *//")
+  LBUFFER=$(fc -ln 1 | fzf +s -e)
   zle redisplay
 }
 zle     -N   fzf-history-widget


### PR DESCRIPTION
Searches like `^git checkout` aren't possible because fzf is matching on the first characters of the return of `fc -l 1` which are the commands id (e.g. `21453 git checkout why-is-this-branch-name-so-long`). Using `fc -ln 1` drops the number prefix and eliminates the need for `sed` here. Adding `-e` allows for extend matching (regex).
