### PR TITLE
Only source in rc if file exists.

### DIFF
--- a/install
+++ b/install
@@ -330,7 +330,7 @@ append_line() {
 
 echo
 for shell in bash zsh; do
-  append_line "source ~/.fzf.${shell}" ~/.${shell}rc
+  append_line "[[ -f ~/.fzf.${shell} ]] && source ~/.fzf.${shell}" ~/.${shell}rc
 done
 
 if [ $key_bindings -eq 0 -a $has_fish -eq 1 ]; then


### PR DESCRIPTION
Adding a check to make sure the script exists before sourcing it, useful if you have the same shell rc file in different places where fzf may or may not be installed.
