### PR TITLE
using `command find` rather than `find` is safer, since aliases are expanded

### DIFF
--- a/install
+++ b/install
@@ -98,7 +98,7 @@ EOF
 # Key bindings
 # ------------
 __fsel() {
-  find * -path '*/\.*' -prune \
+  command find * -path '*/\.*' -prune \
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null | fzf -m | while read item; do
@@ -122,7 +122,7 @@ __fsel_tmux() {
 
 __fcd() {
   local dir
-  dir=$(find ${1:-*} -path '*/\.*' -prune -o -type d -print 2> /dev/null | fzf +m) && printf 'cd %q' "$dir"
+  dir=$(command find ${1:-*} -path '*/\.*' -prune -o -type d -print 2> /dev/null | fzf +m) && printf 'cd %q' "$dir"
 }
 
 __use_tmux=0
@@ -174,7 +174,7 @@ EOFZF
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
   set -o nonomatch
-  find * -path '*/\.*' -prune \
+  command find * -path '*/\.*' -prune \
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null | fzf -m | while read item; do
@@ -207,7 +207,7 @@ bindkey '^T' fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  cd "${$(set -o nonomatch; find * -path '*/\.*' -prune \
+  cd "${$(set -o nonomatch; command find * -path '*/\.*' -prune \
           -o -type d -print 2> /dev/null | fzf):-.}"
   zle reset-prompt
 }
@@ -248,7 +248,7 @@ EOFZF
     cat > ~/.config/fish/functions/fzf_key_bindings.fish << "EOFZF"
 function fzf_key_bindings
   function __fzf_select
-    find * -path '*/\.*' -prune \
+    command find * -path '*/\.*' -prune \
       -o -type f -print \
       -o -type d -print \
       -o -type l -print 2> /dev/null | fzf -m | while read item
@@ -283,7 +283,7 @@ function fzf_key_bindings
   end
 
   function __fzf_alt_c
-    find * -path '*/\.*' -prune -o -type d -print 2> /dev/null | fzf +m > $TMPDIR/fzf.result
+    command find * -path '*/\.*' -prune -o -type d -print 2> /dev/null | fzf +m > $TMPDIR/fzf.result
     if [ (cat $TMPDIR/fzf.result | wc -l) -gt 0 ]
       cd (cat $TMPDIR/fzf.result)
     end


### PR DESCRIPTION
in a shell function, and one might have an conflicting alias for find.
