### PR TITLE
Make C-t in bash/zsh respect FZF_DEFAULT_COMMAND.

### DIFF
--- a/install
+++ b/install
@@ -90,6 +90,17 @@ fzf() {
 }
 export -f fzf > /dev/null
 
+# Custom configuration
+# --------------------
+
+# Use this section to customize your fzf settings.
+
+# Use fzf with ag to respect .gitignore, .hgignore, and svn:ignore.
+# export FZF_DEFAULT_COMMAND='ag -l -g ""'
+
+# Adjust the default options for fzf:
+# export FZF_DEFAULT_OPTS="--sort 20000"
+
 # Auto-completion
 # ---------------
 $fzf_completion
@@ -102,13 +113,21 @@ EOF
 # Key bindings
 # ------------
 __fsel() {
-  command find * -path '*/\.*' -prune \
-    -o -type f -print \
-    -o -type d -print \
-    -o -type l -print 2> /dev/null | fzf -m | while read item; do
+  __fzf_list 2> /dev/null | fzf -m | while read item; do
     printf '%q ' "$item"
   done
   echo
+}
+
+__fzf_list() {
+  if [ -n "$FZF_DEFAULT_COMMAND" ]; then
+    eval "$FZF_DEFAULT_COMMAND"
+  else
+    command find * -path '*/\.*' -prune \
+      -o -type f -print \
+      -o -type d -print \
+      -o -type l -print
+  fi
 }
 
 if [[ $- =~ i ]]; then
@@ -181,13 +200,21 @@ EOFZF
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
   set -o nonomatch
-  command find * -path '*/\.*' -prune \
-    -o -type f -print \
-    -o -type d -print \
-    -o -type l -print 2> /dev/null | fzf -m | while read item; do
+  __fzf_list | fzf -m | while read item; do
     printf '%q ' "$item"
   done
   echo
+}
+
+__fzf_list() {
+  if [ -n "$FZF_DEFAULT_COMMAND" ]; then
+    eval "$FZF_DEFAULT_COMMAND"
+  else
+    command find * -path '*/\.*' -prune \
+      -o -type f -print \
+      -o -type d -print \
+      -o -type l -print
+  fi
 }
 
 if [[ $- =~ i ]]; then
@@ -362,6 +389,12 @@ if [ $key_bindings -eq 0 -a $has_fish -eq 1 ]; then
   echo '    - Place fzf executable in a directory included in $PATH'
   echo
 fi
+
+echo 'Customization'
+echo
+echo '  Please use the generated config files written above to configure fzf.'
+echo '  Setting FZF_* variables there will ensure that fzf works properly with tmux.'
+echo
 
 cat << EOF
 Finished. Restart your shell or reload config file.


### PR DESCRIPTION
I had to move the configuration into the generated config files instead
of where one would normally put it (e.g. ~/.bashrc). This is to properly
support tmux, since when using tmux a new shell is spawned that may not
be configured the same way.

I was unable to figure out how to make this work for fish. For some
reason the new shell in the tmux pane does not get variables set with
`set -x` (I tried placing them as the first lines of `fzf_key_bindings`).