### PR TITLE
pipe fish history through tac to reverse the order

### DIFF
--- a/install
+++ b/install
@@ -294,8 +294,16 @@ function fzf_key_bindings
     rm -f $TMPDIR/fzf.result
   end
 
+  function __fzf_reverse
+    if which tac > /dev/null
+      tac $argv
+    else
+      tail -r $argv
+    end
+  end
+
   function __fzf_ctrl_r
-    history | fzf +s +m > $TMPDIR/fzf.result
+    history | __fzf_reverse | fzf +s +m > $TMPDIR/fzf.result
     and commandline (cat $TMPDIR/fzf.result)
     commandline -f repaint
     rm -f $TMPDIR/fzf.result


### PR DESCRIPTION
fishshell's history command outputs the command in first to last order, meaning the oldest command gets printed to screen last. When we pipe this to fzf it means that of the commands matching the search string, the command that we used last (and I think the one we are most likely go be wanting to use again) is at the top of the list, meaning we need to type more characters to narrow down the search or use the arrow keys before selecting it. 

tac simply reverses the out put of the history command. 

This brings it in to line with bash and zsh's ordering.
