### PR TITLE
Sleep when curses is unavailable

### DIFF
--- a/fzf
+++ b/fzf
@@ -40,6 +40,7 @@ begin
   require 'curses'
 rescue LoadError
   $stderr.puts 'curses gem is not installed. Try `gem install curses`.'
+  sleep 1
   exit 1
 end
 require 'thread'


### PR DESCRIPTION
When the curses gem is not installed and the session is running inside
tmux the user will see a flash of an opened and closed tmux pane but
will not have a chance to read the error message.