### PR TITLE
Improve `find` command for cd widgets: exclude proc/dev

### DIFF
--- a/install
+++ b/install
@@ -202,10 +202,10 @@ EOF
 # Key bindings
 # ------------
 __fsel() {
-  command find * -path '*/\.*' -prune \
+  command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
     -o -type f -print \
     -o -type d -print \
-    -o -type l -print 2> /dev/null | fzf -m | while read item; do
+    -o -type l -print 2> /dev/null | sed 1d | cut -b3- | fzf -m | while read item; do
     printf '%q ' "$item"
   done
   echo
@@ -226,7 +226,8 @@ __fsel_tmux() {
 
 __fcd() {
   local dir
-  dir=$(command find -L ${1:-*} -path '*/\.*' -prune -o -type d -print 2> /dev/null | fzf +m) && printf 'cd %q' "$dir"
+  dir=$(command find -L ${1:-.} \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
+    -o -type d -print 2> /dev/null | sed 1d | cut -b3- | fzf +m) && printf 'cd %q' "$dir"
 }
 
 __use_tmux=0
@@ -274,17 +275,16 @@ unset __use_tmux
 
 fi
 EOFZF
-    else
+    else  # zsh
       cat >> $src << "EOFZF"
 # Key bindings
 # ------------
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
-  set -o nonomatch
-  command find * -path '*/\.*' -prune \
+  command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
     -o -type f -print \
     -o -type d -print \
-    -o -type l -print 2> /dev/null | fzf -m | while read item; do
+    -o -type l -print 2> /dev/null | sed 1d | cut -b3- | fzf -m | while read item; do
     printf '%q ' "$item"
   done
   echo
@@ -314,8 +314,8 @@ bindkey '^T' fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  cd "${$(set -o nonomatch; command find -L * -path '*/\.*' -prune \
-          -o -type d -print 2> /dev/null | fzf):-.}"
+  cd "${$(command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
+    -o -type d -print 2> /dev/null | sed 1d | cut -b3- | fzf +m):-.}"
   zle reset-prompt
 }
 zle     -N    fzf-cd-widget
@@ -369,14 +369,15 @@ function fzf_key_bindings
   end
 
   function __fzf_list
-    command find * -path '*/\.*' -prune \
+    command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
       -o -type f -print \
       -o -type d -print \
-      -o -type l -print 2> /dev/null
+      -o -type l -print 2> /dev/null | sed 1d | cut -b3-
   end
 
   function __fzf_list_dir
-    command find -L * -path '*/\.*' -prune -o -type d -print 2> /dev/null
+    command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) \
+      -prune -o -type d -print 2> /dev/null | sed 1d | cut -b3-
   end
 
   function __fzf_escape


### PR DESCRIPTION
When using the widget in "/", it would descend into 'dev/'.
Using '*' for the starting path would do so also with the new '-fstype'
excludes.

The drawback / change now is that the './' prefix is being added, which
I don't mind.  This could be fixed by throwing in some `cut -b3-` into
the pipe.