### PR TITLE
fix bug with __fcd /path/to/dir

### DIFF
--- a/install
+++ b/install
@@ -202,10 +202,10 @@ EOF
 # Key bindings
 # ------------
 __fsel() {
-  command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
+  command find -L ${1:-.} \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
     -o -type f -print \
     -o -type d -print \
-    -o -type l -print 2> /dev/null | sed 1d | cut -b3- | fzf -m | while read item; do
+    -o -type l -print 2> /dev/null | sed -e 1d -e s#^\./## | fzf -m | while read item; do
     printf '%q ' "$item"
   done
   echo
@@ -227,7 +227,7 @@ __fsel_tmux() {
 __fcd() {
   local dir
   dir=$(command find -L ${1:-.} \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
-    -o -type d -print 2> /dev/null | sed 1d | cut -b3- | fzf +m) && printf 'cd %q' "$dir"
+    -o -type d -print 2> /dev/null | sed -e 1d -e s#^\./## | fzf +m) && printf 'cd %q' "$dir"
 }
 
 __use_tmux=0
@@ -281,10 +281,10 @@ EOFZF
 # ------------
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
-  command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
+  command find -L ${1:-.} \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
     -o -type f -print \
     -o -type d -print \
-    -o -type l -print 2> /dev/null | sed 1d | cut -b3- | fzf -m | while read item; do
+    -o -type l -print 2> /dev/null | sed -e 1d -e s#^\./## | fzf -m | while read item; do
     printf '%q ' "$item"
   done
   echo
@@ -314,8 +314,8 @@ bindkey '^T' fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  cd "${$(command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
-    -o -type d -print 2> /dev/null | sed 1d | cut -b3- | fzf +m):-.}"
+  cd "${$(command find -L ${1:-.} \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
+    -o -type d -print 2> /dev/null | sed -e 1d -e s#^\./## | fzf +m):-.}"
   zle reset-prompt
 }
 zle     -N    fzf-cd-widget
@@ -369,15 +369,15 @@ function fzf_key_bindings
   end
 
   function __fzf_list
-    command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
+    command find -L ${1:-.} \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
       -o -type f -print \
       -o -type d -print \
-      -o -type l -print 2> /dev/null | sed 1d | cut -b3-
+      -o -type l -print 2> /dev/null | sed -e 1d -e s#^\./##
   end
 
   function __fzf_list_dir
-    command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) \
-      -prune -o -type d -print 2> /dev/null | sed 1d | cut -b3-
+    command find -L #{1:-.} \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) \
+      -prune -o -type d -print 2> /dev/null | sed -e 1d -e s#^\./##
   end
 
   function __fzf_escape


### PR DESCRIPTION
There is a bug in the way `__fcd` is currently implemented.

To observe the problem, simply run on your shell `$(__fcd $HOME)`.

*Expected behavior:* You are displayed a list of directories inside `$HOME` and can use `fzf` to select one of them.
*Observed behavior:* You get a truncated list of directories, and on selection `fzf` fails to change folder (since the paths are truncated).

This bug was caused due to a naive use of cut to remove the "./" prefix from folders. However, this prefix is absent if using absolute paths.

I replaced the use of cut by `sed`, this also has the side benefit of require less pipes, since `sed` was already being used to remove the first line (and `sed` allows you to chain several operations in the same call).

In this commit I also made allowed other `fzf` commands, such as `__fsel`, receive the starting path as a parameter (as `__fcd` already did) using the current directory as the default when nothing else is specified.

Another change which I was tempted to make, was to add a global variable `FZF_DEFAULT_STARTPATH` that allows the users to specify in which directory they want to start fcd or fsel by default, allowing them to specify something else other than the current directory (aka "."). For instance, in my own use case I have the default be $HOME/src, since I rarely want to use fzf outside that. I thought I should get some feedback before creating that pull-request.