### PR TITLE
Add support for ANSI color codes

### DIFF
--- a/src/algo/algo.go
+++ b/src/algo/algo.go
@@ -12,6 +12,10 @@ import "strings"
 
 // FuzzyMatch performs fuzzy-match
 func FuzzyMatch(caseSensitive bool, input *string, pattern []rune) (int, int) {
+	if len(pattern) == 0 {
+		return 0, 0
+	}
+
 	runes := []rune(*input)
 
 	// 0. (FIXME) How to find the shortest match?
@@ -66,6 +70,10 @@ func FuzzyMatch(caseSensitive bool, input *string, pattern []rune) (int, int) {
 // ExactMatchStrings performs exact-match using strings package.
 // Currently not used.
 func ExactMatchStrings(caseSensitive bool, input *string, pattern []rune) (int, int) {
+	if len(pattern) == 0 {
+		return 0, 0
+	}
+
 	var str string
 	if caseSensitive {
 		str = *input
@@ -88,6 +96,10 @@ func ExactMatchStrings(caseSensitive bool, input *string, pattern []rune) (int, 
 // We might try to implement better algorithms in the future:
 // http://en.wikipedia.org/wiki/String_searching_algorithm
 func ExactMatchNaive(caseSensitive bool, input *string, pattern []rune) (int, int) {
+	if len(pattern) == 0 {
+		return 0, 0
+	}
+
 	runes := []rune(*input)
 	numRunes := len(runes)
 	plen := len(pattern)

--- a/src/algo/algo_test.go
+++ b/src/algo/algo_test.go
@@ -42,3 +42,11 @@ func TestSuffixMatch(t *testing.T) {
 	assertMatch(t, SuffixMatch, false, "fooBarbaz", "baz", 6, 9)
 	assertMatch(t, SuffixMatch, true, "fooBarbaz", "Baz", -1, -1)
 }
+
+func TestEmptyPattern(t *testing.T) {
+	assertMatch(t, FuzzyMatch, true, "foobar", "", 0, 0)
+	assertMatch(t, ExactMatchStrings, true, "foobar", "", 0, 0)
+	assertMatch(t, ExactMatchNaive, true, "foobar", "", 0, 0)
+	assertMatch(t, PrefixMatch, true, "foobar", "", 0, 0)
+	assertMatch(t, SuffixMatch, true, "foobar", "", 6, 6)
+}

--- a/src/ansi.go
+++ b/src/ansi.go
@@ -1,0 +1,141 @@
+package fzf
+
+import (
+	"bytes"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+type AnsiOffset struct {
+	offset [2]int32
+	color  ansiState
+}
+
+type ansiState struct {
+	fg   int
+	bg   int
+	bold bool
+}
+
+func (s *ansiState) colored() bool {
+	return s.fg != -1 || s.bg != -1 || s.bold
+}
+
+func (s *ansiState) equals(t *ansiState) bool {
+	if t == nil {
+		return !s.colored()
+	}
+	return s.fg == t.fg && s.bg == t.bg && s.bold == t.bold
+}
+
+var ansiRegex *regexp.Regexp
+
+func init() {
+	ansiRegex = regexp.MustCompile("\x1b\\[[0-9;]*m")
+}
+
+func ExtractColor(str *string) (*string, []AnsiOffset) {
+	offsets := make([]AnsiOffset, 0)
+
+	var output bytes.Buffer
+	var state *ansiState
+
+	idx := 0
+	for _, offset := range ansiRegex.FindAllStringIndex(*str, -1) {
+		output.WriteString((*str)[idx:offset[0]])
+		newLen := int32(output.Len())
+		newState := interpretCode((*str)[offset[0]:offset[1]], state)
+
+		if !newState.equals(state) {
+			if state != nil {
+				// Update last offset
+				(&offsets[len(offsets)-1]).offset[1] = int32(output.Len())
+			}
+
+			if newState.colored() {
+				// Append new offset
+				state = newState
+				offsets = append(offsets, AnsiOffset{[2]int32{newLen, newLen}, *state})
+			} else {
+				// Discard state
+				state = nil
+			}
+		}
+
+		idx = offset[1]
+	}
+
+	rest := (*str)[idx:]
+	if len(rest) > 0 {
+		output.WriteString(rest)
+		if state != nil {
+			// Update last offset
+			(&offsets[len(offsets)-1]).offset[1] = int32(output.Len())
+		}
+	}
+	outputStr := output.String()
+	return &outputStr, offsets
+}
+
+func interpretCode(ansiCode string, prevState *ansiState) *ansiState {
+	// State
+	var state *ansiState
+	if prevState == nil {
+		state = &ansiState{-1, -1, false}
+	} else {
+		state = &ansiState{prevState.fg, prevState.bg, prevState.bold}
+	}
+
+	ptr := &state.fg
+	state256 := 0
+
+	init := func() {
+		state.fg = -1
+		state.bg = -1
+		state.bold = false
+		state256 = 0
+	}
+
+	ansiCode = ansiCode[2 : len(ansiCode)-1]
+	for _, code := range strings.Split(ansiCode, ";") {
+		if num, err := strconv.Atoi(code); err == nil {
+			switch state256 {
+			case 0:
+				switch num {
+				case 38:
+					ptr = &state.fg
+					state256++
+				case 48:
+					ptr = &state.bg
+					state256++
+				case 39:
+					state.fg = -1
+				case 49:
+					state.bg = -1
+				case 1:
+					state.bold = true
+				case 0:
+					init()
+				default:
+					if num >= 30 && num <= 37 {
+						state.fg = num - 30
+					} else if num >= 40 && num <= 47 {
+						state.bg = num - 40
+					}
+				}
+			case 1:
+				switch num {
+				case 5:
+					state256++
+				default:
+					state256 = 0
+				}
+			case 2:
+				*ptr = num
+				state256 = 0
+			}
+		}
+	}
+	return state
+}

--- a/src/ansi_test.go
+++ b/src/ansi_test.go
@@ -1,0 +1,91 @@
+package fzf
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestExtractColor(t *testing.T) {
+	assert := func(offset AnsiOffset, b int32, e int32, fg int, bg int, bold bool) {
+		if offset.offset[0] != b || offset.offset[1] != e ||
+			offset.color.fg != fg || offset.color.bg != bg || offset.color.bold != bold {
+			t.Error(offset, b, e, fg, bg, bold)
+		}
+	}
+
+	src := "hello world"
+	clean := "\x1b[0m"
+	check := func(assertion func(ansiOffsets []AnsiOffset)) {
+		output, ansiOffsets := ExtractColor(&src)
+		if *output != "hello world" {
+			t.Errorf("Invalid output: {}", output)
+		}
+		fmt.Println(src, ansiOffsets, clean)
+		assertion(ansiOffsets)
+	}
+
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) > 0 {
+			t.Fail()
+		}
+	})
+
+	src = "\x1b[0mhello world"
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) > 0 {
+			t.Fail()
+		}
+	})
+
+	src = "\x1b[1mhello world"
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) != 1 {
+			t.Fail()
+		}
+		assert(offsets[0], 0, 11, -1, -1, true)
+	})
+
+	src = "hello \x1b[34;45;1mworld"
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) != 1 {
+			t.Fail()
+		}
+		assert(offsets[0], 6, 11, 4, 5, true)
+	})
+
+	src = "hello \x1b[34;45;1mwor\x1b[34;45;1mld"
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) != 1 {
+			t.Fail()
+		}
+		assert(offsets[0], 6, 11, 4, 5, true)
+	})
+
+	src = "hello \x1b[34;45;1mwor\x1b[0mld"
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) != 1 {
+			t.Fail()
+		}
+		assert(offsets[0], 6, 9, 4, 5, true)
+	})
+
+	src = "hello \x1b[34;48;5;233;1mwo\x1b[38;5;161mr\x1b[0ml\x1b[38;5;161md"
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) != 3 {
+			t.Fail()
+		}
+		assert(offsets[0], 6, 8, 4, 233, true)
+		assert(offsets[1], 8, 9, 161, 233, true)
+		assert(offsets[2], 10, 11, 161, -1, false)
+	})
+
+	// {38,48};5;{38,48}
+	src = "hello \x1b[38;5;38;48;5;48;1mwor\x1b[38;5;48;48;5;38ml\x1b[0md"
+	check(func(offsets []AnsiOffset) {
+		if len(offsets) != 2 {
+			t.Fail()
+		}
+		assert(offsets[0], 6, 9, 38, 48, true)
+		assert(offsets[1], 9, 10, 48, 38, true)
+	})
+}

--- a/src/curses/curses_test.go
+++ b/src/curses/curses_test.go
@@ -1,0 +1,14 @@
+package curses
+
+import (
+	"testing"
+)
+
+func TestPairFor(t *testing.T) {
+	if PairFor(30, 50) != PairFor(30, 50) {
+		t.Fail()
+	}
+	if PairFor(-1, 10) != PairFor(-1, 10) {
+		t.Fail()
+	}
+}

--- a/src/item_test.go
+++ b/src/item_test.go
@@ -3,6 +3,8 @@ package fzf
 import (
 	"sort"
 	"testing"
+
+	"github.com/junegunn/fzf/src/curses"
 )
 
 func TestOffsetSort(t *testing.T) {
@@ -71,4 +73,32 @@ func TestItemRank(t *testing.T) {
 		items[4] != &item5 || items[5] != &item3 {
 		t.Error(items)
 	}
+}
+
+func TestColorOffset(t *testing.T) {
+	// ------------ 20 ----  --  ----
+	//   ++++++++        ++++++++++
+	// --++++++++--    --++++++++++---
+	item := Item{
+		offsets: []Offset{Offset{5, 15}, Offset{25, 35}},
+		colors: []AnsiOffset{
+			AnsiOffset{[2]int32{0, 20}, ansiState{1, 5, false}},
+			AnsiOffset{[2]int32{22, 27}, ansiState{2, 6, true}},
+			AnsiOffset{[2]int32{30, 32}, ansiState{3, 7, false}},
+			AnsiOffset{[2]int32{33, 40}, ansiState{4, 8, true}}}}
+	// [{[0 5] 9 false} {[5 15] 99 false} {[15 20] 9 false} {[22 25] 10 true} {[25 35] 99 false} {[35 40] 11 true}]
+
+	offsets := item.ColorOffsets(99, false, true)
+	assert := func(idx int, b int32, e int32, c int, bold bool) {
+		o := offsets[idx]
+		if o.offset[0] != b || o.offset[1] != e || o.color != c || o.bold != bold {
+			t.Error(o)
+		}
+	}
+	assert(0, 0, 5, curses.ColUser, false)
+	assert(1, 5, 15, 99, false)
+	assert(2, 15, 20, curses.ColUser, false)
+	assert(3, 22, 25, curses.ColUser+1, true)
+	assert(4, 25, 35, 99, false)
+	assert(5, 35, 40, curses.ColUser+2, true)
 }

--- a/src/options.go
+++ b/src/options.go
@@ -29,6 +29,7 @@ const usage = `usage: fzf [options]
 
   Interface
     -m, --multi           Enable multi-select with tab/shift-tab
+        --ansi            Interpret ANSI color codes and remove from output
         --no-mouse        Disable mouse
     +c, --no-color        Disable colors
     +2, --no-256          Disable 256-color
@@ -81,6 +82,7 @@ type Options struct {
 	Sort       int
 	Tac        bool
 	Multi      bool
+	Ansi       bool
 	Mouse      bool
 	Color      bool
 	Color256   bool
@@ -106,6 +108,7 @@ func defaultOptions() *Options {
 		Sort:       1000,
 		Tac:        false,
 		Multi:      false,
+		Ansi:       false,
 		Mouse:      true,
 		Color:      true,
 		Color256:   strings.Contains(os.Getenv("TERM"), "256"),
@@ -227,6 +230,10 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.Multi = true
 		case "+m", "--no-multi":
 			opts.Multi = false
+		case "--ansi":
+			opts.Ansi = true
+		case "--no-ansi":
+			opts.Ansi = false
 		case "--no-mouse":
 			opts.Mouse = false
 		case "+c", "--no-color":

--- a/src/pattern.go
+++ b/src/pattern.go
@@ -264,6 +264,7 @@ func dupItem(item *Item, offsets []Offset) *Item {
 		transformed: item.transformed,
 		index:       item.index,
 		offsets:     offsets,
+		colors:      item.colors,
 		rank:        Rank{0, 0, item.index}}
 }
 

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -333,10 +333,8 @@ func (*Terminal) printHighlighted(item *Item, bold bool, col1 int, col2 int, cur
 				b += 2 - diff
 				e += 2 - diff
 				b = util.Max32(b, 2)
-				if b < e {
-					offsets[idx].offset[0] = b
-					offsets[idx].offset[1] = e
-				}
+				offsets[idx].offset[0] = b
+				offsets[idx].offset[1] = util.Max32(b, e)
 			}
 			text = append([]rune(".."), text...)
 		}
@@ -353,8 +351,10 @@ func (*Terminal) printHighlighted(item *Item, bold bool, col1 int, col2 int, cur
 		substr, prefixWidth = processTabs(text[index:b], prefixWidth)
 		C.CPrint(col1, bold, substr)
 
-		substr, prefixWidth = processTabs(text[b:e], prefixWidth)
-		C.CPrint(offset.color, bold, substr)
+		if b < e {
+			substr, prefixWidth = processTabs(text[b:e], prefixWidth)
+			C.CPrint(offset.color, bold, substr)
+		}
 
 		index = e
 		if index >= maxOffset {

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -251,7 +251,7 @@ func (t *Terminal) printItem(item *Item, current bool) {
 		} else {
 			C.CPrint(C.ColCurrent, true, " ")
 		}
-		t.printHighlighted(item, true, C.ColCurrent, C.ColCurrentMatch)
+		t.printHighlighted(item, true, C.ColCurrent, C.ColCurrentMatch, true)
 	} else {
 		C.CPrint(C.ColCursor, true, " ")
 		if selected {
@@ -259,7 +259,7 @@ func (t *Terminal) printItem(item *Item, current bool) {
 		} else {
 			C.Print(" ")
 		}
-		t.printHighlighted(item, false, 0, C.ColMatch)
+		t.printHighlighted(item, false, 0, C.ColMatch, false)
 	}
 }
 
@@ -299,7 +299,7 @@ func trimLeft(runes []rune, width int) ([]rune, int32) {
 	return runes, trimmed
 }
 
-func (*Terminal) printHighlighted(item *Item, bold bool, col1 int, col2 int) {
+func (*Terminal) printHighlighted(item *Item, bold bool, col1 int, col2 int, current bool) {
 	var maxe int32
 	for _, offset := range item.offsets {
 		if offset[1] > maxe {
@@ -309,7 +309,7 @@ func (*Terminal) printHighlighted(item *Item, bold bool, col1 int, col2 int) {
 
 	// Overflow
 	text := []rune(*item.text)
-	offsets := item.offsets
+	offsets := item.ColorOffsets(col2, bold, current)
 	maxWidth := C.MaxX() - 3
 	fullWidth := displayWidth(text)
 	if fullWidth > maxWidth {
@@ -328,37 +328,40 @@ func (*Terminal) printHighlighted(item *Item, bold bool, col1 int, col2 int) {
 			text, diff = trimLeft(text, maxWidth-2)
 
 			// Transform offsets
-			offsets = make([]Offset, len(item.offsets))
-			for idx, offset := range item.offsets {
-				b, e := offset[0], offset[1]
+			for idx, offset := range offsets {
+				b, e := offset.offset[0], offset.offset[1]
 				b += 2 - diff
 				e += 2 - diff
 				b = util.Max32(b, 2)
 				if b < e {
-					offsets[idx] = Offset{b, e}
+					offsets[idx].offset[0] = b
+					offsets[idx].offset[1] = e
 				}
 			}
 			text = append([]rune(".."), text...)
 		}
 	}
 
-	sort.Sort(ByOrder(offsets))
 	var index int32
 	var substr string
 	var prefixWidth int
+	maxOffset := int32(len(text))
 	for _, offset := range offsets {
-		b := util.Max32(index, offset[0])
-		e := util.Max32(index, offset[1])
+		b := util.Constrain32(offset.offset[0], index, maxOffset)
+		e := util.Constrain32(offset.offset[1], index, maxOffset)
 
 		substr, prefixWidth = processTabs(text[index:b], prefixWidth)
 		C.CPrint(col1, bold, substr)
 
 		substr, prefixWidth = processTabs(text[b:e], prefixWidth)
-		C.CPrint(col2, bold, substr)
+		C.CPrint(offset.color, bold, substr)
 
 		index = e
+		if index >= maxOffset {
+			break
+		}
 	}
-	if index < int32(len(text)) {
+	if index < maxOffset {
 		substr, _ = processTabs(text[index:], prefixWidth)
 		C.CPrint(col1, bold, substr)
 	}

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -27,6 +27,17 @@ func Max32(first int32, second int32) int32 {
 	return second
 }
 
+// Constrain32 limits the given 32-bit integer with the upper and lower bounds
+func Constrain32(val int32, min int32, max int32) int32 {
+	if val < min {
+		return min
+	}
+	if val > max {
+		return max
+	}
+	return val
+}
+
 // Constrain limits the given integer with the upper and lower bounds
 func Constrain(val int, min int, max int) int {
 	if val < min {


### PR DESCRIPTION
Interpret ANSI color codes from the input.

### Why?

Because... colors.

#### Use cases

- https://github.com/D630/fzf-fs
- https://github.com/peco/peco/issues/188

### How does it look like?

#### `CLICOLOR_FORCE=1 ls -al | fzf`
![fzf-ls](https://cloud.githubusercontent.com/assets/700826/6714463/bae03e64-cddb-11e4-9be1-92a237140d78.png)

#### `CLICOLOR_FORCE=1 ls -al | fzf --ansi`
![fzf-ansi-ls](https://cloud.githubusercontent.com/assets/700826/6714465/bae23afc-cddb-11e4-802e-67795caf821a.png)

#### `screenshotTable.sh | fzf --ansi`
![screenshot-table](https://cloud.githubusercontent.com/assets/700826/6714464/bae0daa4-cddb-11e4-9630-0cb7157d8498.png)

### Then, why hesitate?

- Code complexity
- Performance overhead in reader (*how much?*)
- Increased memory footprint for large input (> 1M items)
- A typical command-line program suppresses ANSI color codes when its output is redirected
    - Must explicitly enable colors.
        - OSX: `CLICOLOR_FORCE=1 ls -al`
        - Linux: `ls --color=always -al`
- :sleepy: 

### TBD

- Should fzf remove ANSI codes from its output?
    - Probably. It might make it less flexible, but more convenient/suitable for most cases.