### PR TITLE
Updates git ls-tree example

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ speed of the traversal.
 ```sh
 export FZF_DEFAULT_COMMAND='
   (git ls-tree -r --name-only HEAD ||
-   find * -name ".*" -prune -o -type f -print -o -type l -print) 2> /dev/null'
+   \find * -name ".*" -prune -o -type f -print -o -type l -print) 2> /dev/null'
 ```
 
 #### Using fzf with tmux panes


### PR DESCRIPTION
Following up on https://github.com/junegunn/fzf/issues/168,
this PR fixes the snippet using `git ls-tree`

`find` had an incorrect syntax.