### PR TITLE
Support for vi insert mode in upcoming fish 2.2.0

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -76,5 +76,11 @@ function fzf_key_bindings
   bind \ct '__fzf_ctrl_t'
   bind \cr '__fzf_ctrl_r'
   bind \ec '__fzf_alt_c'
+
+  if bind -M insert > /dev/null 2>&1
+    bind -M insert \ct '__fzf_ctrl_t'
+    bind -M insert \cr '__fzf_ctrl_r'
+    bind -M insert \ec '__fzf_alt_c'
+  end
 end
 


### PR DESCRIPTION
Turns out fish key bindings support different modes, so that adding the functionality was a matter of binding the given shortcuts also to the insert mode.