### PR TITLE
Check if :FZF is already executing

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -318,6 +318,12 @@ function! s:cmd_callback(lines) abort
 endfunction
 
 function! s:cmd(bang, ...) abort
+  if bufexists('[FZF]')
+    echohl WarningMsg
+    echomsg 'FZF is already running!'
+    echohl NONE
+    return
+  endif
   let args = copy(a:000)
   if !s:legacy
     let args = insert(args, '--expect=ctrl-t,ctrl-x,ctrl-v', 0)


### PR DESCRIPTION
Hi, Junegunn!

Prior to this change, you'd get a longer error message if you did:

    :FZF
    <esc>
    :FZF

The main problem being that `:file [FZF]` can be used only once. This commit uses that to its advantage and just adds a simple `bufexists('[FZF]')` check (and a warning message, that you can remove if you want).

Probably easier than using an ugly `s:is_active` variable. :)