### PR TITLE
Check if fzf#run() is already executing

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -98,6 +98,12 @@ function! s:upgrade(dict)
 endfunction
 
 function! fzf#run(...) abort
+  if has('nvim') && bufexists('[FZF]')
+    echohl WarningMsg
+    echomsg 'FZF is already running!'
+    echohl NONE
+    return []
+  endif
   let dict   = exists('a:1') ? s:upgrade(a:1) : {}
   let temps  = { 'result': tempname() }
   let optstr = get(dict, 'options', '')
@@ -325,12 +331,6 @@ function! s:cmd_callback(lines) abort
 endfunction
 
 function! s:cmd(bang, ...) abort
-  if bufexists('[FZF]')
-    echohl WarningMsg
-    echomsg 'FZF is already running!'
-    echohl NONE
-    return
-  endif
   let args = copy(a:000)
   if !s:legacy
     let args = insert(args, '--expect=ctrl-t,ctrl-x,ctrl-v', 0)


### PR DESCRIPTION
#180 only fixes invocations of `:FZF`. This simply moves the check to `fzf#run()` so that it works with all invocations of fzf.