### PR TITLE
install: wait for LF in non-interactive shell

### DIFF
--- a/install
+++ b/install
@@ -5,8 +5,15 @@ version=0.9.7
 cd $(dirname $BASH_SOURCE)
 fzf_base=$(pwd)
 
+# If stdin is a tty, we are "interactive".
+[ -t 0 ] && interactive=yes
+
 ask() {
-  read -p "$1 ([y]/n) " -n 1 -r
+  # non-interactive shell: wait for a linefeed
+  #     interactive shell: continue after a single keypress
+  [ -n "$interactive" ] && read_n='-n 1' || read_n=
+
+  read -p "$1 ([y]/n) " $read_n -r
   echo
   [[ ! $REPLY =~ ^[Nn]$ ]]
 }


### PR DESCRIPTION
Problem: `yes n | ./install` should answer "n" to every prompt, but instead it answers "n" to the first question, and the next question is getting some non-printable input which `ask()` interprets as "y". This means that shell keybindings are always installed. 

Solution: omit `-n 1` for non-interactive shells.