### PR TITLE
don't use numbered history expansion for fzf-history-widget

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -35,18 +35,9 @@ bindkey '\ec' fzf-cd-widget
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
-  local selected restore_no_bang_hist
-  if selected=$(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER"); then
-    num=$(echo "$selected" | head -1 | awk '{print $1}' | sed 's/[^0-9]//g')
-    if [ -n "$num" ]; then
-      LBUFFER=!$num
-      if setopt | grep nobanghist > /dev/null; then
-        restore_no_bang_hist=1
-        unsetopt no_bang_hist
-      fi
-      zle expand-history
-      [ -n "$restore_no_bang_hist" ] && setopt no_bang_hist
-    fi
+  local selected="$(fc -nl 1 | $(__fzfcmd) -e +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER")"
+  if [[ "$selected" != '' ]]; then
+    LBUFFER="$(awk 'NR==1 {$1==""; print } <<< "$selected"')"
   fi
   zle redisplay
 }
@@ -54,4 +45,3 @@ zle     -N   fzf-history-widget
 bindkey '^R' fzf-history-widget
 
 fi
-


### PR DESCRIPTION
fzf already returns the command itself, deleting it and using history expansion seems silly. this is much simpler.