### PR TITLE
fix typo in argument of head (zsh completion)

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -37,7 +37,7 @@ bindkey '\ec' fzf-cd-widget
 fzf-history-widget() {
   local selected restore_no_bang_hist
   if selected=$(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER"); then
-    num=$(echo "$selected" | head -1 | awk '{print $1}' | sed 's/[^0-9]//g')
+    num=$(echo "$selected" | head -n1 | awk '{print $1}' | sed 's/[^0-9]//g')
     if [ -n "$num" ]; then
       LBUFFER=!$num
       if setopt | grep nobanghist > /dev/null; then


### PR DESCRIPTION
at least my version of head wants -n1 to only display the first line