### PR TITLE
zsh completion script empty trigger and bound key personalisation

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -110,7 +110,7 @@ fzf-zsh-completion() {
   fi
 
   cmd=${tokens[1]}
-  trigger=${FZF_COMPLETION_TRIGGER:-**}
+  trigger=${FZF_COMPLETION_TRIGGER-'**'}
 
   # Trigger sequence given
   tail=${LBUFFER:$(( ${#LBUFFER} - ${#trigger} ))}

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -110,6 +110,8 @@ fzf-zsh-completion() {
   fi
 
   cmd=${tokens[1]}
+
+  # Explicitly allow for empty trigger.
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
 
   # Trigger sequence given

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -9,6 +9,7 @@
 # - $FZF_TMUX_HEIGHT        (default: '40%')
 # - $FZF_COMPLETION_TRIGGER (default: '**')
 # - $FZF_COMPLETION_OPTS    (default: empty)
+# - $FZF_COMPLETION_KEY     (default: '^I')
 
 _fzf_path_completion() {
   local base lbuf find_opts fzf_opts suffix tail fzf dir leftover matches nnm
@@ -145,6 +146,8 @@ fzf-zsh-completion() {
   fi
 }
 
-zle     -N   fzf-zsh-completion
-bindkey '^I' fzf-zsh-completion
+zle -N fzf-zsh-completion
+
+completion_key=${FZF_COMPLETION_KEY:-'^I'}
+bindkey ${completion_key} fzf-zsh-completion
 


### PR DESCRIPTION
This allows for the use case I mentioned in #230 by setting the following env variables:

```zsh
export FZF_COMPLETION_TRIGGER=''
export FZF_COMPLETION_KEY='^P'
```

I'm not super happy about the name of `FZF_COMPLETION_KEY`, please do let me know if you have any suggestions, or feel free to go ahead and rename it after merging,