### PR TITLE
Fix ssh completion's grep.

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -82,7 +82,7 @@ EOF
 
 _fzf_ssh_completion() {
   _fzf_list_completion "$1" "$2" '+m' << "EOF"
-    cat <(cat ~/.ssh/config /etc/ssh/ssh_config 2> /dev/null | \grep -i ^host | \grep -v '*') <(\grep -v '^\s*\(#\|$\)' /etc/hosts | \grep -Fv '0.0.0.0') | awk '{if (length($2) > 0) {print $2}}' | sort -u
+    cat <(cat ~/.ssh/config /etc/ssh/ssh_config 2> /dev/null | \grep -i "^host" | \grep -v '*') <(\grep -v '^\s*\(#\|$\)' /etc/hosts | \grep -Fv '0.0.0.0') | awk '{if (length($2) > 0) {print $2}}' | sort -u
 EOF
 }
 


### PR DESCRIPTION
Without the quote `"`, the grep will output unwanted results.
For example, in `~/.fzf`:

```
$ cat ~/.ssh/config 2> /dev/null | \grep -i ^host
grep: bin: Is a directory
grep: man: Is a directory
grep: plugin: Is a directory
grep: shell: Is a directory
grep: src: Is a directory
grep: test: Is a directory
```