### PR TITLE
fix for broken CTRL-R in zsh

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -36,7 +36,8 @@ bindkey '\ec' fzf-cd-widget
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected restore_no_bang_hist
-  if selected=$(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER"); then
+  selected=$(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER")
+  if [ -n $selected ]; then
     num=$(echo "$selected" | head -n1 | awk '{print $1}' | sed 's/[^0-9]//g')
     if [ -n "$num" ]; then
       LBUFFER=!$num


### PR DESCRIPTION
fixes #241 and the followup of #203 
When looking for the bug I found that whenever CTRL-R is broken, it never entered the ```if selected=...```
This change fixes that and covers all cases I could think of. 