### PR TITLE
add support to nil-byte separated input strings; closes #121

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -113,7 +113,7 @@ func Run(opts *Options) {
 	// Reader
 	streamingFilter := opts.Filter != nil && !sort && !opts.Tac && !opts.Sync
 	if !streamingFilter {
-		reader := Reader{func(str string) { chunkList.Push(str) }, eventBox}
+		reader := Reader{func(str string) { chunkList.Push(str) }, eventBox, opts.ReadZero}
 		go reader.ReadSource()
 	}
 
@@ -139,7 +139,7 @@ func Run(opts *Options) {
 					if pattern.MatchItem(item) {
 						fmt.Println(*item.text)
 					}
-				}, eventBox}
+				}, eventBox, opts.ReadZero}
 			reader.ReadSource()
 		} else {
 			eventBox.Unwatch(EvtReadNew)

--- a/src/options.go
+++ b/src/options.go
@@ -50,7 +50,8 @@ const usage = `usage: fzf [options]
     -1, --select-1        Automatically select the only match
     -0, --exit-0          Exit immediately when there's no match
     -f, --filter=STR      Filter mode. Do not start interactive finder.
-        --print-query     Print query as the first line
+		--null            Read null-byte separated strings from input.
+		--print-query     Print query as the first line
         --expect=KEYS     Comma-separated list of keys to complete fzf
         --sync            Synchronous search for multi-staged filtering
 
@@ -117,6 +118,7 @@ type Options struct {
 	Expect     []int
 	Keymap     map[int]actionType
 	PrintQuery bool
+	ReadZero   bool
 	Sync       bool
 	Version    bool
 }
@@ -155,6 +157,7 @@ func defaultOptions() *Options {
 		Expect:     []int{},
 		Keymap:     defaultKeymap(),
 		PrintQuery: false,
+		ReadZero:   false,
 		Sync:       false,
 		Version:    false}
 }
@@ -525,6 +528,8 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.Exit0 = true
 		case "+0", "--no-exit-0":
 			opts.Exit0 = false
+		case "--null":
+			opts.ReadZero = true
 		case "--print-query":
 			opts.PrintQuery = true
 		case "--no-print-query":


### PR DESCRIPTION
Simplified reader and added a configurable delimiter. Added "--null" option to interface.

Not sure I added the help line in the right place. Feel free to fix it yourself.