### PR TITLE
use vi-fetch-history on zsh to get history line

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -26,7 +26,7 @@ bindkey '^T' fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  cd "${$(command find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
+  cd "${$(command \find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \
     -o -type d -print 2> /dev/null | sed 1d | cut -b3- | $(__fzfcmd) +m):-.}"
   zle reset-prompt
 }
@@ -36,16 +36,10 @@ bindkey '\ec' fzf-cd-widget
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected restore_no_bang_hist
-  if selected=$(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER"); then
-    num=$(echo "$selected" | head -n1 | awk '{print $1}' | sed 's/[^0-9]//g')
+  if selected=( $(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER") ); then
+    num=$selected[1]
     if [ -n "$num" ]; then
-      LBUFFER=!$num
-      if setopt | grep nobanghist > /dev/null; then
-        restore_no_bang_hist=1
-        unsetopt no_bang_hist
-      fi
-      zle expand-history
-      [ -n "$restore_no_bang_hist" ] && setopt no_bang_hist
+      zle vi-fetch-history -n $num
     fi
   fi
   zle redisplay


### PR DESCRIPTION
In addition to being simpler and not relying on zsh options, it allows subsequent up/down history or accept-line-and-down-history widgets to work.

I also replaced your pipeline for extracting the number with what I think is simpler: assign the output to an array and then take the first element.

Furthermore, The cd widget didn't work in my configuration because of two aliases I have defined:
  alias find='noglob find'
  alias command='command '
The later enables alias expansion after command. It'd be better to use zsh's autoloadable functions: put the functions each in their own file, .fzf.zsh would then need to add that directory to fpath:
  fpath+=( $fzf_base/shell/fpath )
and autoload them with the -U option to disable alias expansion:
  autoload -Uz fzf-history-widget fzf-file-widget fzf-cd-widget __fzfcmd __fsel
