### PR TITLE
[vim] handle SwapExists

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -405,6 +405,12 @@ function! s:cmd_callback(lines) abort
   endif
   let key = remove(a:lines, 0)
   let cmd = get(s:action, key, 'e')
+  if len(a:lines) > 1
+    augroup fzf_swap
+      autocmd SwapExists * let v:swapchoice='o'
+            \| call s:warn('fzf: E325: swap file exists: '.expand('<afile>'))
+    augroup END
+  endif
   try
     let autochdir = &autochdir
     set noautochdir
@@ -413,6 +419,7 @@ function! s:cmd_callback(lines) abort
     endfor
   finally
     let &autochdir = autochdir
+    silent! autocmd! fzf_swap
   endtry
 endfunction
 


### PR DESCRIPTION
The SwapExists dialog prevents multiple files from being opening if the
dialog occurs before all files are opened. Opening the files is more
important than showing the dialog, so choose "readonly" automatically
and continue opening files.

This problem exists in neovim and Vim 7.3. Not sure about others. To test, choose multiple files in the `:FZF` prompt; if a swap-exists dialog appears before all files are opened, those remaining files will not be opened.