### PR TITLE
Trigger netrw autocommand when opening directory

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -416,6 +416,9 @@ function! s:cmd_callback(lines) abort
     set noautochdir
     for item in a:lines
       execute cmd s:escape(item)
+      if exists('#BufEnter') && isdirectory(item)
+        doautocmd BufEnter
+      endif
     endfor
   finally
     let &autochdir = autochdir


### PR DESCRIPTION
Attempting to edit a directory in a `try` block in Vim silently fails to trigger the autocommands used by file browsers (netrw, vimfiler, probably others). Adding a BufEnter autocommand after the edit command if the item was a directory allows netrw to work instead of opening a blank buffer.