### PR TITLE
Add an improved file-widget for zsh

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -25,6 +25,27 @@ fzf-file-widget() {
 zle     -N   fzf-file-widget
 bindkey '^T' fzf-file-widget
 
+fzf-file-widget-dwim() {
+  autoload -U modify-current-argument split-shell-arguments
+  local reply REPLY REPLY2
+
+  ((--CURSOR))
+  split-shell-arguments
+  ((++CURSOR))
+
+  local ROOTDIR
+  eval "ROOTDIR=(${reply[$REPLY]})"
+  if [ -d "$ROOTDIR"  ]; then
+    cd $ROOTDIR
+    modify-current-argument '${ARG%%/#}/'
+    fzf-file-widget
+    cd -
+  else
+    fzf-file-widget
+  fi
+}
+zle -N fzf-file-widget-dwim
+
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
   cd "${$(command \find -L . \( -path '*/\.*' -o -fstype 'dev' -o -fstype 'proc' \) -prune \


### PR DESCRIPTION
The new widget uses the already typed path as a root directory for the file search. It's not enabled by default.