### PR TITLE
Not relying on exit status for CTRL-R

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -37,7 +37,8 @@ bindkey '\ec' fzf-cd-widget
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected num
-  if selected=( $(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER") ); then
+  selected=( $(fc -l 1 | $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r -q "$LBUFFER") )
+  if [ -n "$selected" ]; then
     num=$selected[1]
     if [ -n "$num" ]; then
       zle vi-fetch-history -n $num


### PR DESCRIPTION
In the case that fzf-tmux returns a user-selected result but with a
non-zero exit status (for reasons I haven't figured out quite yet) this
allows CTRL-R to continue working as expected.

Addresses #203 (Tranquility's comment)