### PR TITLE
Add fzf.plugin.zsh for oh-my-zsh plugin style usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,34 @@ Or you can have [vim-plug](https://github.com/junegunn/vim-plug) manage fzf
 Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 ```
 
+#### Install as oh-my-zsh plugin
+
+Firstly clone the repository to `oh-my-zsh/custom/plugins`
+
+```sh
+git clone --depth 1 https://github.com/junegunn/fzf.git oh-my-zsh/custom/plugins/fzf
+```
+
+Then follow below command to install fzf binary only
+
+```sh
+oh-my-zsh/custom/plugins/fzf/install --bin
+```
+
+Then add `fzf` to your oh-my-zsh plugins list in your `.zshrc`
+
+```sh
+plugins=(... fzf ...)
+```
+
+When used as oh-my-zsh plugin, only keybindings is enabled default. If you want
+to enable autocompletion, you can uncomment below lines in
+`oh-my-zsh/custom/plugins/fzf/fzf.plugin.zsh`
+
+```sh
+# source "$fzf_path/shell/completion.zsh"
+```
+
 #### Upgrading fzf
 
 fzf is being actively developed and you might want to upgrade it once in a

--- a/fzf.plugin.zsh
+++ b/fzf.plugin.zsh
@@ -1,0 +1,27 @@
+## get the real path of plugin
+# fzf_dir="${BASH_SOURCE[0]}" in zsh is equivalent to below
+fzf_dir="${(%):-%N}"
+# resolve $SOURCE until the file is no longer a symlink
+while [ -L "$fzf_dir" ]; do
+  APP_PATH="$( cd -P "$( dirname "$fzf_dir" )" && pwd )"
+  fzf_dir="$(readlink "$fzf_dir")"
+  # if $fzf_dir was a relative symlink, we need to resolve it relative to the path
+  # where the symlink file was located
+  [[ $fzf_dir != /* ]] && fzf_dir="$APP_PATH/$fzf_dir"
+done
+fzf_path="$( cd -P "$( dirname "$fzf_dir" )" && pwd )"
+
+# only enable plugins when fzf and fzf-tmux are installed correctly
+if [ -x $fzf_path/bin/fzf ] && [ -x $fzf_path/bin/fzf-tmux ]; then
+
+  # export $PAHT and $MANPATH
+  export PATH="$PATH:$fzf_path/bin"
+  export MANPATH="$MANPATH:$fzf_path/man"
+
+  # auto completion is broken with zsh-autosuggestion plugin
+  # so comment out this line
+  # export FZF_COMPLETION_TRIGGER='~~'
+  # source "$fzf_path/shell/completion.zsh"
+
+  source "$fzf_path/shell/key-bindings.zsh"
+fi;


### PR DESCRIPTION
Maybe someone want to use fzf plugin in oh-my-zsh plugin style.
So I created a [fzf-zsh](https://github.com/Treri/fzf-zsh) plugin for my own use.

But I think if fzf itself support oh-my-zsh plugin, it would be better. So I opened the PR.

The user can clone fzf repo to oh-my-zsh/custom/plugins and execute
`oh-my-zsh/custom/plugins/fzf/install --bin`, then add fzf to zsh `plugins` list

In my zshrc, I found  fzf autocompletion is broken with zsh-autosuggestion plugin,
so I only enabled fzf keybindings.

If the user didn't use zsh-autosuggestion, he can enable fzf autocompletion manually.