### PR TITLE
Support fzf-tmux when zoomed

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -82,9 +82,17 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-if [ -z "$TMUX_PANE" ] || tmux list-panes -F '#F' | grep -q Z; then
+if [ -z "$TMUX_PANE" ]; then
   fzf "${args[@]}"
   exit $?
+fi
+
+# Handle zoomed tmux pane by moving it to a temp window
+if tmux list-panes -F '#F' | grep -q Z; then
+  zoomed=1
+  original_window=$(tmux display-message -p "#{window_id}")
+  tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - \\\\; do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
+  tmux swap-pane -t $tmp_window \; select-window -t $tmp_window
 fi
 
 set -e
@@ -97,6 +105,14 @@ fifo2="${TMPDIR:-/tmp}/fzf-fifo2-$id"
 fifo3="${TMPDIR:-/tmp}/fzf-fifo3-$id"
 cleanup() {
   rm -f $argsf $fifo1 $fifo2 $fifo3
+
+  # Remove temp window if we were zoomed
+  if [ -n "$zoomed" ]; then
+    tmux swap-pane -t $original_window \; \
+      select-window -t $original_window \; \
+      kill-window -t $tmp_window \; \
+      resize-pane -Z
+  fi
 }
 trap cleanup EXIT SIGINT SIGTERM
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -52,17 +52,13 @@ function! s:fzf_exec()
   return s:exec
 endfunction
 
-function! s:tmux_not_zoomed()
-  return system('tmux list-panes -F "#F"') !~# 'Z'
-endfunction
-
 function! s:tmux_enabled()
   if has('gui_running')
     return 0
   endif
 
   if exists('s:tmux')
-    return s:tmux && s:tmux_not_zoomed()
+    return s:tmux
   endif
 
   let s:tmux = 0
@@ -70,7 +66,7 @@ function! s:tmux_enabled()
     let output = system('tmux -V')
     let s:tmux = !v:shell_error && output >= 'tmux 1.7'
   endif
-  return s:tmux && s:tmux_not_zoomed()
+  return s:tmux
 endfunction
 
 function! s:shellesc(arg)


### PR DESCRIPTION
Here's a slightly hacky approach to supporting zoomed windows:
1. Create temporary window and move the zoomed pane to the tmp window
2. Do the normal fzf-tmux thing
3. Move the zoomed pane back to the original window, kill the tmp window, and re-zoom

It's a bit fragile, for a couple reasons:
- If the user starts moving around windows while fzf-tmux is open they'll notice that something is odd
- If the user tries to select one of the hidden panes while fzf-tmux is open they'll notice that they are not there

I generally don't do much tmuxing around while fzf is open, though, so this seems good enough for my workflow.  Btw, the approach of creating a tmp window is based on this stack overflow answer:

http://superuser.com/a/357799