### PR TITLE
Correct fzf-tmux tmux checking bug

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -82,7 +82,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 
-if [ -z "$TMUX_PANE" ]; then
+if [ -z "$TMUX" ]; then
   fzf "${args[@]}"
   exit $?
 fi


### PR DESCRIPTION
I think this method of checking whether we're in a tmux session is more robust.  Using `$TMUX_PANE` doesn't work when I do something like `bind-key t run -b foo`, where `foo` is a script that uses `fzf-tmux`.