### PR TITLE
Pass FZF_DEFAULT_OPTS to non-interactive bash instance

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -25,7 +25,8 @@ __fzf_select_tmux__() {
   else
     height="-l $height"
   fi
-  tmux split-window $height "cd $(printf %q "$PWD"); PATH=$(printf %q "$PATH") FZF_CTRL_T_COMMAND=$(printf %q "$FZF_CTRL_T_COMMAND") bash -c 'source \"${BASH_SOURCE[0]}\"; tmux send-keys -t $TMUX_PANE \"\$(__fzf_select__)\"'"
+
+  tmux split-window $height "cd $(printf %q "$PWD"); FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS") PATH=$(printf %q "$PATH") FZF_CTRL_T_COMMAND=$(printf %q "$FZF_CTRL_T_COMMAND") bash -c 'source \"${BASH_SOURCE[0]}\"; tmux send-keys -t $TMUX_PANE \"\$(__fzf_select__)\"'"
 }
 
 __fzf_select_tmux_auto__() {


### PR DESCRIPTION
FZF_DEFAULT_OPTS are lost when CTRL+T invokes `__fzf_select__` in a new tmux window.