### PR TITLE
Make sure bash completion includes hidden files (see #456)

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -112,7 +112,7 @@ __fzf_generic_path_completion() {
         leftover=${leftover/#\/}
         [ "$dir" = './' ] && dir=''
         tput sc
-        matches=$(find -L "$dir"* $1 2> /dev/null | $fzf $FZF_COMPLETION_OPTS $2 -q "$leftover" | while read item; do
+        matches=$(find -L "${dir:-./}" $1 2> /dev/null | sed 's|^\./||' | $fzf $FZF_COMPLETION_OPTS $2 -q "$leftover" | while read item; do
           printf "%q$3 " "$item"
         done)
         matches=${matches% }


### PR DESCRIPTION
Not fixed for zsh, as it's such a trivial fix (and zsh scares me)

`ls .**` and `ls ..**` will respectively include `.` and `..`.  
but it seems pretty non-unixy to specifically exclude em.
