### PR TITLE
Fix autocompletion for absolute paths

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -110,7 +110,8 @@ __fzf_generic_path_completion() {
       if [ -z "$dir" -o -d "$dir" ]; then
         leftover=${base/#"$dir"}
         leftover=${leftover/#\/}
-        [ -z "$dir" ] && dir='.' || dir="${dir/%\//}"
+        [ -z "$dir" ] && dir='.'
+        [ "$dir" != "/" ] && dir="${dir/%\//}"
         tput sc
         matches=$(\find -L "$dir" $1 -a -not -path "$dir" -print 2> /dev/null | sed 's@^\./@@' | $fzf $FZF_COMPLETION_OPTS $2 -q "$leftover" | while read item; do
           printf "%q$3 " "$item"

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -30,7 +30,8 @@ __fzf_generic_path_completion() {
     if [ -z "$dir" -o -d ${~dir} ]; then
       leftover=${base/#"$dir"}
       leftover=${leftover/#\/}
-      [ -z "$dir" ] && dir='.' || dir="${dir/%\//}"
+      [ -z "$dir" ] && dir='.'
+      [ "$dir" != "/" ] && dir="${dir/%\//}"
       dir=${~dir}
       matches=$(\find -L "$dir" ${=find_opts} -a -not -path "$dir" -print 2> /dev/null | sed 's@^\./@@' | ${=fzf} ${=FZF_COMPLETION_OPTS} ${=fzf_opts} -q "$leftover" | while read item; do
         printf "%q$suffix " "$item"


### PR DESCRIPTION
Should fix `ls /**` for both bash (tested) and zsh (not tested)

While testing I also noticed `ls dir**` is broken if both `dir` and `dirAbc` exist in your cwd (dirAbc[/*] not listed).

I'll have a look at it tomorrow, if not I'll create an issue.
