### PR TITLE
Removed the useless `.R` macros

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -71,7 +71,7 @@ e.g. \fBhistory | fzf --tac --no-sort\fR
 .BI "--tiebreak=" "CRI[,..]"
 Comma-separated list of sort criteria to apply when the scores are tied.
 .br
-.R ""
+
 .br
 .BR length "  Prefers item with shorter length"
 .br
@@ -81,7 +81,7 @@ Comma-separated list of sort criteria to apply when the scores are tied.
 .br
 .BR index "   Prefers item that appeared earlier in the input stream"
 .br
-.R ""
+
 .br
 - Each criterion should appear only once in the list
 .br
@@ -144,7 +144,7 @@ Reverse orientation
 .BI "--margin=" MARGIN
 Comma-separated expression for margins around the finder.
 .br
-.R ""
+
 .br
 .RS
 .BR TRBL "     Same margin for top, right, bottom, and left"
@@ -155,12 +155,12 @@ Comma-separated expression for margins around the finder.
 .br
 .BR T,R,B,L "  Top, right, bottom, left margin"
 .br
-.R ""
+
 .br
 Each part can be given in absolute number or in percentage relative to the
 terminal size with \fB%\fR suffix.
 .br
-.R ""
+
 .br
 e.g. \fBfzf --margin 10%\fR
      \fBfzf --margin 1,5%\fR
@@ -431,7 +431,7 @@ Junegunn Choi (\fIjunegunn.c@gmail.com\fR)
 .I https://github.com/junegunn/fzf
 .RE
 .br
-.R ""
+
 .br
 .B Extra Vim plugin:
 .RS


### PR DESCRIPTION
If you do `man fzf > /dev/null`, you'll get the following output

`R' is a string (producing the registered sign), not a macro.`
`R' is a string (producing the registered sign), not a macro.`
`R' is a string (producing the registered sign), not a macro.`
`R' is a string (producing the registered sign), not a macro.`
`R' is a string (producing the registered sign), not a macro.`
`R' is a string (producing the registered sign), not a macro.`

Removing these `.R` macros has no effect on the rendering of the page but
gets rid of the error.