### PR TITLE
Key bindings fixes

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -49,7 +49,7 @@ __fzf_history__() (
   shopt -u nocaseglob nocasematch
   line=$(
     HISTTIMEFORMAT= history |
-    $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r |
+    $(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --bind=ctrl-r:up,ctrl-s:down |
     \grep '^ *[0-9]') &&
     if [[ $- =~ H ]]; then
       sed 's/^ *\([0-9]*\)\** .*/!\1/' <<< "$line"

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -67,46 +67,86 @@ fi
 
 if [ -z "$(set -o | \grep '^vi.*on')" ]; then
   # Required to refresh the prompt after fzf
-  bind '"\er": redraw-current-line'
-  bind '"\e^": history-expand-line'
+  __redraw_current_line="\er"    # Redraw current line
+  __history_expand_line="\e^"    # Expand !num history commands
+  bind '"'${__redraw_current_line}'": redraw-current-line'
+  bind '"'${__history_expand_line}'": history-expand-line'
+  # Other variables to make reading easier
+  # Movements
+  __beginning_of_line="\C-a"     # Move to beginning of line
+  __end_of_line="\C-e"           # Move to end of line
+  # Deletions
+  __delete_char="\C-d"           # Delete char under point, add to kill ring
+  __backward_delete_char="\C-h"  # Delete char behind point, add to kill ring
+  __unix_line_discard="\C-u"     # Delete from point to start of line, add to kill ring
+  __kill_line="\C-k"             # Delete from point to end of line, add to kill ring
+  # Pastes
+  __yank="\C-y"                  # Yank top of kill ring
+  __yank_pop="\ey"               # Rotate kill ring, then yank
+  # Other
+  __shell_expand_line="\e\C-e"   # Expand $() commands
+  __accept_line="\C-m"           # Run the command
 
   # CTRL-T - Paste the selected file path into the command line
   if [ $__use_tmux_auto -eq 1 ]; then
     bind -x '"\C-t": "__fzf_select_tmux_auto__"'
   elif [ $__use_tmux -eq 1 ]; then
-    bind '"\C-t": " \C-u \C-a\C-k$(__fzf_select_tmux__)\e\C-e\C-y\C-a\C-d\C-y\ey\C-h"'
+    bind '"\C-t": " '${__unix_line_discard}' '${__beginning_of_line}''${__kill_line}'$(__fzf_select_tmux__)'${__shell_expand_line}''${__yank}''${__beginning_of_line}''${__delete_char}''${__yank}''${__yank_pop}''${__backward_delete_char}'"'
   else
-    bind '"\C-t": " \C-u \C-a\C-k$(__fzf_select__)\e\C-e\C-y\C-a\C-y\ey\C-h\C-e\er \C-h"'
+    bind '"\C-t": " '${__unix_line_discard}' '${__beginning_of_line}''${__kill_line}'$(__fzf_select__)'${__shell_expand_line}''${__yank}''${__beginning_of_line}''${__yank}''${__yank_pop}''${__backward_delete_char}''${__end_of_line}''${__redraw_current_line}' '${__backward_delete_char}'"'
   fi
 
   # CTRL-R - Paste the selected command from history into the command line
-  bind '"\C-r": " \C-e\C-u$(__fzf_history__)\e\C-e\e^\er"'
+  bind '"\C-r": " '${__end_of_line}''${__unix_line_discard}'$(__fzf_history__)'${__shell_expand_line}''${__history_expand_line}''${__redraw_current_line}'"'
 
   # ALT-C - cd into the selected directory
-  bind '"\ec": " \C-e\C-u$(__fzf_cd__)\e\C-e\er\C-m"'
+  bind '"\ec": " '${__end_of_line}''${__unix_line_discard}'$(__fzf_cd__)'${__shell_expand_line}''${__redraw_current_line}''${__accept_line}'"'
+
+  unset -v __redraw_current_line __history_expand_line __beginning_of_line __end_of_line __delete_char __backward_delete_char __unix_line_discard __kill_line __yank __yank_pop __shell_expand_line __accept_line
 else
-  bind '"\C-x\C-e": shell-expand-line'
-  bind '"\C-x\C-r": redraw-current-line'
-  bind '"\C-x^": history-expand-line'
+  # Required to refresh the prompt after fzf
+  __shell_expand_line="\C-x\C-e"     # Expand $() commands
+  __redraw_current_line="\C-x\C-r"   # Redraw current line
+  __history_expand_line="\C-x^"      # Expand !num history commands
+  bind '"'${__shell_expand_line}'": shell-expand-line'
+  bind '"'${__redraw_current_line}'": redraw-current-line'
+  bind '"'${__history_expand_line}'": history-expand-line'
+  # Other variables to make reading easier
+  # Vi-Modes
+  __vi_command_mode="\e"             # Enter vi-command mode
+  __vi_insertion_mode="i"            # Enter vi-inserstion mode
+  __vi_append_mode="a"               # Enter vi-append mode
+  # Movements
+  __beginning_of_line="0"            # Move to beginning of line
+  __end_of_line="$"                  # Move to end of line
+  # Deletions
+  __forward_backward_delete_char="x" # Delete character at point, unless EOL, then character behind point
+  __kill_whole_line="dd"             # Delete entire line
+  # Pastes
+  __put_before="P"                   # Put the last killed text behind point, no readline equivalent function name
+  # Other
+  __accept_line="\C-m"               # Run the command
 
   # CTRL-T - Paste the selected file path into the command line
   # - FIXME: Selected items are attached to the end regardless of cursor position
   if [ $__use_tmux_auto -eq 1 ]; then
     bind -x '"\C-t": "__fzf_select_tmux_auto__"'
   elif [ $__use_tmux -eq 1 ]; then
-    bind '"\C-t": "\e$a \eddi$(__fzf_select_tmux__)\C-x\C-e\e0P$xa"'
+    bind '"\C-t": "'${__vi_command_mode}${__end_of_line}${__vi_append_mode}' '${__vi_command_mode}${__kill_whole_line}${__vi_insertion_mode}'$(__fzf_select_tmux__)'${__shell_expand_line}''${__vi_command_mode}${__beginning_of_line}${__put_before}${__forward_backward_delete_char}${__end_of_line}${__vi_append_mode}'"'
   else
-    bind '"\C-t": "\e$a \eddi$(__fzf_select__)\C-x\C-e\e0Px$a \C-x\C-r\exa "'
+    bind '"\C-t": "'${__vi_command_mode}${__end_of_line}${__vi_append_mode}' '${__vi_command_mode}${__kill_whole_line}${__vi_insertion_mode}'$(__fzf_select__)'${__shell_expand_line}''${__vi_command_mode}${__beginning_of_line}${__put_before}${__forward_backward_delete_char}${__end_of_line}${__vi_append_mode}' '${__redraw_current_line}''${__vi_command_mode}${__forward_backward_delete_char}${__vi_append_mode}' "'
   fi
   bind -m vi-command '"\C-t": "i\C-t"'
 
   # CTRL-R - Paste the selected command from history into the command line
-  bind '"\C-r": "\eddi$(__fzf_history__)\C-x\C-e\C-x^\e$a\C-x\C-r"'
+  bind '"\C-r": "'${__vi_command_mode}${__kill_whole_line}${__vi_insertion_mode}'$(__fzf_history__)'${__shell_expand_line}''${__history_expand_line}''${__vi_command_mode}${__end_of_line}${__vi_append_mode}''${__redraw_current_line}'"'
   bind -m vi-command '"\C-r": "i\C-r"'
 
   # ALT-C - cd into the selected directory
-  bind '"\ec": "\eddi$(__fzf_cd__)\C-x\C-e\C-x\C-r\C-m"'
+  bind '"\ec": "'${__vi_command_mode}${__kill_whole_line}${__vi_insertion_mode}'$(__fzf_cd__)'${__shell_expand_line}''${__redraw_current_line}''${__accept_line}'"'
   bind -m vi-command '"\ec": "i\ec"'
+
+  unset -v __shell_expand_line __redraw_current_line __history_expand_line __vi_command_mode __vi_insertion_mode __vi_append_mode __beginning_of_line __end_of_line __forward_backward_delete_char __kill_whole_line __put_before __accept_line
 fi
 
 unset -v __use_tmux __use_tmux_auto

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -98,6 +98,27 @@ __fzf_history__() {
   fi
 }
 
+__fzf_previous_history__() {
+  if [ -v _fzf_history_scrollable ]; then
+    if [ -v _fzf_history_ctrl_o_difference ]; then
+      let _fzf_history_ctrl_o_difference++
+    else
+      _fzf_history_ctrl_o_difference=0
+    fi
+  fi
+  bind '"\C-x\C-f": previous-history'
+}
+__fzf_next_history__() {
+  if [ -v _fzf_history_scrollable -a -v _fzf_history_ctrl_o_difference ]; then
+    if [ $_fzf_history_ctrl_o_difference -eq 0 ]; then
+      unset -v _fzf_history_ctrl_o_difference
+    else
+      let _fzf_history_ctrl_o_difference--
+    fi
+  fi
+  bind '"\C-x\C-f": next-history'
+}
+
 __fzf_accept_line__() {
   if [ -v _fzf_history_ctrl_o_present ]; then
     # We are inside ctrl-o, but next time we might not
@@ -105,6 +126,7 @@ __fzf_accept_line__() {
   else
     # We are not inside ctrl-o, reset counters
     unset -v _fzf_history_ctrl_o_difference
+    export _fzf_history_scrollable=""
   fi
   bind '"\C-x\C-f": accept-line'
 }
@@ -114,6 +136,7 @@ __fzf_ctrl_o__() {
 
   keyseq=${__accept_line}
   export _fzf_history_ctrl_o_present=1
+  unset -v _fzf_history_scrollable
 
   if [ \! -v _fzf_history_ctrl_o_difference -a -z "$READLINE_LINE" ]; then
     # We have done ctrl-o without typing anything in, just do accept-line
@@ -180,6 +203,11 @@ if [ -z "$(set -o | \grep '^vi.*on')" ]; then
   bind '"\C-o": "\C-x\C-o\C-x\C-f"'
   bind -x '"\C-x'${__accept_line}'": "__fzf_accept_line__"'
   bind '"'${__accept_line}'": "\C-x'${__accept_line}'\C-x\C-f"'
+  bind -x '"\C-x[A": "__fzf_previous_history__"'
+  bind '"\e[A": "\C-x[A\C-x\C-f"'
+  bind -x '"\C-x[B": "__fzf_next_history__"'
+  bind '"\e[B": "\C-x[B\C-x\C-f"'
+  export _fzf_history_scrollable=""
 
   # ALT-C - cd into the selected directory
   bind '"\ec": " '${__end_of_line}''${__unix_line_discard}'$(__fzf_cd__)'${__shell_expand_line}''${__redraw_current_line}''${__accept_line}'"'


### PR DESCRIPTION
Hey,

This PR is a set of fixes to make this act more like bash does for CTRL-R mode. I start by adding variable names to all the readline commands, just to make it easier to read. Then I set some directional keybindings while in CTRL-R mode, and then also allow CTRL-g to abort unchanged. This changed the way the history replacement worked, and now uses $READLINE_LINE instead of shell expansion of $(__fzf_history__). Finally I added the CTRL-o mode, which lets you cycle through a bunch of commands. This also required overloading the up and down keys.

See commit messages for further details of each thing. Let me know if there is anything you would like me to change.

Cheers,

Hugh