### PR TITLE
Go 1.3 compatibility

### DIFF
--- a/src/matcher.go
+++ b/src/matcher.go
@@ -200,7 +200,7 @@ func (m *Matcher) scan(request MatchRequest) (*Merger, bool) {
 	}
 
 	partialResults := make([][]*Item, numSlices)
-	for range slices {
+	for _, _ = range slices {
 		partialResult := <-resultChan
 		partialResults[partialResult.index] = partialResult.matches
 	}


### PR DESCRIPTION
Fixes the following error:
```
src/matcher.go:203: syntax error: unexpected range, expecting {
src/matcher.go:207: non-declaration statement outside function body
src/matcher.go:208: syntax error: unexpected }
```

While not all distributions ship Go 1.4 (Debian 8, Ubuntu 15.04) yet, this negligible fix makes it possible to build against 1.3.