### PR TITLE
Fix Bash+vimode pre-launch delay

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -115,7 +115,7 @@ else
 
   # ALT-C - cd into the selected directory
   bind '"\ec": "\C-x\C-addi$(__fzf_cd__)\C-x\C-e\C-x\C-r\C-m"'
-  bind -m vi-command '"\C-ac": "i\C-ac"'
+  bind -m vi-command '"\ec": "ddi$(__fzf_cd__)\C-x\C-e\C-x\C-r\C-m"'
 fi
 
 unset -v __use_tmux __use_tmux_auto

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -85,6 +85,15 @@ if [ -z "$(set -o | \grep '^vi.*on')" ]; then
   # ALT-C - cd into the selected directory
   bind '"\ec": " \C-e\C-u$(__fzf_cd__)\e\C-e\er\C-m"'
 else
+  # We'd usually use "\e" to enter vi-movement-mode so we can do our magic,
+  # but this incurs a very noticeable delay of a half second or so,
+  # because many other commands start with "\e".
+  # Instead, we bind an unused key, "\C-x\C-a",
+  # to also enter vi-movement-mode,
+  # and then use that thereafter.
+  # (We imagine that "\C-x\C-a" is relatively unlikely to be in use.)
+  bind '"\C-x\C-a": vi-movement-mode'
+
   bind '"\C-x\C-e": shell-expand-line'
   bind '"\C-x\C-r": redraw-current-line'
   bind '"\C-x^": history-expand-line'
@@ -94,19 +103,19 @@ else
   if [ $__use_tmux_auto -eq 1 ]; then
     bind -x '"\C-t": "__fzf_select_tmux_auto__"'
   elif [ $__use_tmux -eq 1 ]; then
-    bind '"\C-t": "\e$a \eddi$(__fzf_select_tmux__)\C-x\C-e\e0P$xa"'
+    bind '"\C-t": "\C-x\C-a$a \C-x\C-addi$(__fzf_select_tmux__)\C-x\C-e\C-x\C-a0P$xa"'
   else
-    bind '"\C-t": "\e$a \eddi$(__fzf_select__)\C-x\C-e\e0Px$a \C-x\C-r\exa "'
+    bind '"\C-t": "\C-x\C-a$a \C-x\C-addi$(__fzf_select__)\C-x\C-e\C-x\C-a0Px$a \C-x\C-r\C-x\C-axa "'
   fi
   bind -m vi-command '"\C-t": "i\C-t"'
 
   # CTRL-R - Paste the selected command from history into the command line
-  bind '"\C-r": "\eddi$(__fzf_history__)\C-x\C-e\C-x^\e$a\C-x\C-r"'
+  bind '"\C-r": "\C-x\C-addi$(__fzf_history__)\C-x\C-e\C-x^\C-x\C-a$a\C-x\C-r"'
   bind -m vi-command '"\C-r": "i\C-r"'
 
   # ALT-C - cd into the selected directory
-  bind '"\ec": "\eddi$(__fzf_cd__)\C-x\C-e\C-x\C-r\C-m"'
-  bind -m vi-command '"\ec": "i\ec"'
+  bind '"\ec": "\C-x\C-addi$(__fzf_cd__)\C-x\C-e\C-x\C-r\C-m"'
+  bind -m vi-command '"\C-ac": "i\C-ac"'
 fi
 
 unset -v __use_tmux __use_tmux_auto


### PR DESCRIPTION
Summary:
Fix from: https://adamheins.com/blog/fzf-vi-mode-and-fixing-delays
(Thanks, @adamheins!)
The basic problem is that
fzf presses <Esc> to enter vi-movement-mode
(as opposed to insert mode)
and then presses a bunch of keys to set up the buffer.
But the <Esc> keypress is also the prefix for a bunch of other commands,
so Bash will dutifully wait an excruciating half-second
before actually executing this command.
Instead, we bind <C-a>, which is unused by default,
to be another way to enter vi-movement-mode;
this binding is unambiguous, so fzf can use it without delay.

This change was made by just `:s/\\e/\\C-a/gc` in the relevant section,
after adding the actual binding and comment at the top.