### PR TITLE
Fix missing reference to UNAME_M

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -7,7 +7,8 @@ else ifeq ($(UNAME_S),Linux)
 endif
 endif
 
-ifneq ($(shell uname -m),x86_64)
+UNAME_M := $(shell uname -m)
+ifneq ($(UNAME_M),x86_64)
 $(error "Build on $(UNAME_M) is not supported, yet.")
 endif
 


### PR DESCRIPTION
The `Build on $(UNAME_M) is not supported, yet` message was referencing an undefined UNAME_M. Fixed that.

Still I'm thinking is there sense to keep this warning? Apparently it builds just fine on my i686 system. So why should the Makefile be disabled forcefully?