### PR TITLE
Exact matching unquote

### DIFF
--- a/fzf
+++ b/fzf
@@ -1295,11 +1295,8 @@ class FZF
             when /^\^(.*)\$$/
               Regexp.new('^' << Regexp.escape($1) << '$', rxflag_for(w))
             when /^'/
-              if @mode == :fuzzy && w.length > 1
-                exact_regex w[1..-1]
-              elsif @mode == :exact
-                exact_regex w
-              end
+              w.length > 1 ?
+                @mode == :fuzzy ? exact_regex(w[1..-1]) : fuzzy_regex(w[1..-1]) : nil
             when /^\^/
               w.length > 1 ?
                 Regexp.new('^' << Regexp.escape(w[1..-1]), rxflag_for(w)) : nil

--- a/fzf
+++ b/fzf
@@ -1233,18 +1233,16 @@ class FZF
     end
 
     def fuzzy_regex q
-      @regexp[q] ||= begin
-        q = q.downcase if @rxflag == Regexp::IGNORECASE
-        Regexp.new(q.split(//).inject('') { |sum, e|
-          e = Regexp.escape e
-          sum << (e.length > 1 ? "(?:#{e}).*?" :  # FIXME: not equivalent
-                                 "#{e}[^#{e}]*?")
-        }, rxflag_for(q))
-      end
+      q = q.downcase if @rxflag == Regexp::IGNORECASE
+      Regexp.new(q.split(//).inject('') { |sum, e|
+        e = Regexp.escape e
+        sum << (e.length > 1 ? "(?:#{e}).*?" :  # FIXME: not equivalent
+                               "#{e}[^#{e}]*?")
+      }, rxflag_for(q))
     end
 
     def match list, q, prefix, suffix
-      regexp = fuzzy_regex q
+      regexp = (@regexp[q] ||= fuzzy_regex q)
 
       cache = @caches[list.object_id]
       prefix_cache = nil


### PR DESCRIPTION
Fixes #547.

I've modified the ruby version of the script to treat `-e` option same as the Go version. There was an issue with caching so I had to do a change about that. Details in the commit log.
