### PR TITLE
Quickmatch feature

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -130,6 +130,7 @@ type Options struct {
 	Margin      [4]string
 	Tabstop     int
 	Version     bool
+	QuickmatchLabels string
 }
 
 func defaultTheme() *curses.ColorTheme {
@@ -177,7 +178,8 @@ func defaultOptions() *Options {
 		HeaderLines: 0,
 		Margin:      defaultMargin(),
 		Tabstop:     8,
-		Version:     false}
+		Version:     false,
+		QuickmatchLabels: " asdfghjkqwertyuiozxcvbnm.12345,ASDFGQWERTZXCVB/"}
 }
 
 func help(code int) {
@@ -596,6 +598,9 @@ func parseKeymap(keymap map[int]actionType, execmap map[int]string, str string) 
 			keymap[key] = actNextHistory
 		case "toggle-sort":
 			keymap[key] = actToggleSort
+		case "quickmatch":
+			keymap[key] = actToggleQuickMatch
+
 		default:
 			if isExecuteAction(actLower) {
 				var offset int
@@ -892,6 +897,8 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.Tabstop = atoi(value)
 			} else if match, value := optString(arg, "--hscroll-off="); match {
 				opts.HscrollOff = atoi(value)
+			} else if match, value := optString(arg, "--quickmatch-labels="); match {
+				opts.QuickmatchLabels = " " + value
 			} else {
 				errorExit("unknown option: " + arg)
 			}


### PR DESCRIPTION
Fixes #124.

PR provides an alternative to navigation of candidates.

Instead of pressing consecutively a key for `up` and `down` action to iterate candidates, you can now pick any candidate by hit `quickmatch` (new action in --bind) toggle key and a label appeared on screen next to the candidate of choice.
In other words it's O(1) for any candidate on screen:

![gifrecord_2016-05-08_191443](https://cloud.githubusercontent.com/assets/4105701/15099482/dc155b48-155e-11e6-8538-f088de72d8be.gif)
![gifrecord_2016-05-08_193943](https://cloud.githubusercontent.com/assets/4105701/15099481/dc1415a8-155e-11e6-810c-c31255b25d1c.gif)

How to enable

- bind an easy-reached key to `quickmatch` action 
- provide set of labels you want to pick up from. optional

`export FZF_DEFAULT_OPTS="--bind \':quickmatch --quickmatch-labels=bgtasdfqwerzxcvhjklmnyuop12345,."`


