### PR TITLE
Prefer tmux for launching in Vim

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -140,14 +140,17 @@ try
   else
     let prefix = ''
   endif
-  let tmux = !has('nvim') && s:tmux_enabled() && s:splittable(dict)
+  let tmux = s:tmux_enabled() && s:splittable(dict)
   let command = prefix.(tmux ? s:fzf_tmux(dict) : fzf_exec).' '.optstr.' > '.temps.result
 
-  if has('nvim')
+  if tmux
+    let ret = s:execute_tmux(dict, command, temps)
+  elseif has('nvim')
     return s:execute_term(dict, command, temps)
+  else
+    let ret = s:execute(dict, command, temps)
   endif
 
-  let ret = tmux ? s:execute_tmux(dict, command, temps) : s:execute(dict, command, temps)
   call s:popd(dict, ret)
   return ret
 finally


### PR DESCRIPTION
There is currently a [bug in Neovim][1] where opening a terminal buffer
by exec'ing a command that has a pipe in it causes the buffer to be
blank until `<ESC>` is pressed. While not strictly an issue with fzf, it
affects users like me who use a custom `FZF_DEFAULT_COMMAND`.

This change makes fzf prefer tmux over Neovim for launching a fzf split.
It's reasonable to assume that if a Neovim user under tmux either
- Doesn't care about the type of split, or
- Prefers tmux panes to nvim embedded terminals, as panes the main
  purpose of tmux.

Thus, this change works around the Neovim issue in a non-temporary,
non-hacky way; looks like a win-win.

[1]: https://github.com/neovim/neovim/issues/4487