### PR TITLE
Change tmux pane title for fzf splits

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -144,14 +144,14 @@ if [ -n "$term" -o -t 0 ]; then
   cat <<< "$fzf $opts > $fifo2; echo \$? > $fifo3 $close" > $argsf
   tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
-    split-window $opt "cd $(printf %q "$PWD");$envs bash $argsf" $swap \
+    split-window $opt "printf '\033]2;fzf\033\\'; cd $(printf %q "$PWD");$envs bash $argsf" $swap \
     > /dev/null 2>&1
 else
   mkfifo $fifo1
   cat <<< "$fzf $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" > $argsf
   tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
-    split-window $opt "$envs bash $argsf" $swap \
+    split-window $opt "printf '\033]2;fzf\033\\'; $envs bash $argsf" $swap \
     > /dev/null 2>&1
   cat <&0 > $fifo1 &
 fi


### PR DESCRIPTION
Hello!
I'm having the following problem while using fzf with custom tmux keybindings required to work with vim-tmux-navigator:
I use C-h/j/k/l shortcut to navigate between vim and tmux splits, but the same shortcuts are used to iterate over lists in fzf split. vim-tmux-navigator basically solves the problem of shortcuts clash between tmux and vim using *if-shell* statement inside tmux config that detects the current command of the pane and sends appropriate commands to current pane.
The same solution would apply to fzf if only there were a way to detect that current split is running fzf. Currently it's impossible because there is no identity of fzf in the tmux pane - the active command is bash.
This commit changes the tmux pane title to "fzf" which allows to differentiate it in tmux if-shell command.