### PR TITLE
optimize fzf_default_completion binding

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -181,8 +181,11 @@ fzf-completion() {
   fi
 }
 
-[ -z "$fzf_default_completion" ] &&
-  fzf_default_completion=$(bindkey '^I' | \grep -v undefined-key | awk '{print $2}')
+[ -z "$fzf_default_completion" ] && {
+  binding=$(bindkey '^I')
+  [[ $binding =~ 'undefined-key' ]] || fzf_default_completion=$binding[(w)2]
+  unset binding
+}
 
 zle     -N   fzf-completion
 bindkey '^I' fzf-completion


### PR DESCRIPTION
I spent the past few hours doing a bit of yak shaving on speeding up my `zsh` startup time and discovered that one of the biggest bottlenecks was this chunk of code in `shell/completion.zsh`! 😮 

The slowdown is a result of launching the `grep` and `awk` programs to set the `fzf_default_completion` environment variable. I rewrote the code to use only zsh built-ins and got a reasonable speedup! Here are the results:
```
All times in microseconds (us), 100 samples each
=====
Control       -- Mean: 9035.12, Stddev: 326.39
Experiment    -- Mean: 5979.47, Stddev: 372.748
```

[Here is a gist of the script I used](https://gist.github.com/anonymous/3ecef48effacc72f205ed40a58b3112d) to profile the control (i.e. `junegunn master`) vs the experiment (i.e. this PR).

FYI: here are the 25 slowest lines evaluated via `source ~/.fzf.zsh` on `junegunn master` in descending order. Times are in milliseconds here, not microseconds.
```
04.17709351: /Users/Aleks/.fzf/shell/completion.zsh:185> fzf_default_completion=expand-or-complete-with-indicator 
00.76699257: /Users/Aleks/.fzf/shell/completion.zsh:23> declare -f _fzf_compgen_dir
00.33903122: /Users/Aleks/.fzf.zsh:19> source /Users/Aleks/.fzf/shell/key-bindings.zsh
00.22387505: /Users/Aleks/.fzf.zsh:15> source /Users/Aleks/.fzf/shell/completion.zsh
00.18501282: /Users/Aleks/.zshrc:311> source /Users/Aleks/.fzf.zsh
00.12683868: /Users/Aleks/.fzf.zsh:3> [[ ! /Users/Aleks/.rbenv/shims:/Users/Aleks/.pyenv/shims:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/X11/bin:/usr/local/git/bin:/usr/local/go/bin:/usr/texbin:/usr/local/opt/go/libexec/bin:/Users/Aleks/dotfiles/bin:/Users/Aleks/dotfiles/bin/darwin:/Users/Aleks/go/bin:/usr/local/berkeley_upc/bin:/Users/Aleks/.fzf/bin:/Users/Aleks/go/bin:/usr/local/berkeley_upc/bin:/Users/Aleks/go/bin:/usr/local/berkeley_upc/bin:/Users/Aleks/go/bin:/usr/local/berkeley_upc/bin:/Users/Aleks/go/bin:/usr/local/berkeley_upc/bin:/Users/Aleks/go/bin:/usr/local/berkeley_upc/bin == */Users/Aleks/.fzf/bin* ]]
00.09393692: /Users/Aleks/.fzf/shell/completion.zsh:188> bindkey '^I' fzf-completion
00.08702278: /Users/Aleks/.fzf/shell/completion.zsh:14> declare -f _fzf_compgen_path
00.07915497: /Users/Aleks/.zshrc:310> FZF_START_TIME=1465686345.8801810741 
00.05602837: /Users/Aleks/.fzf/shell/key-bindings.zsh:52> bindkey '^R' fzf-history-widget
00.04696846: /Users/Aleks/.fzf.zsh:9> [[ ! :/Users/Aleks/.fzf/man == */Users/Aleks/.fzf/man* ]]
00.04601479: /Users/Aleks/.fzf/shell/completion.zsh:187> zle -N fzf-completion
00.04315376: /Users/Aleks/.fzf.zsh:15> [[ 059CDEJNQRTWXZghimx == *i* ]]
00.03910065: /Users/Aleks/.fzf/shell/key-bindings.zsh:3> [[ 059CDEJNQRTWXZghimx == *i* ]]
00.02384186: /Users/Aleks/.fzf/shell/key-bindings.zsh:36> bindkey '\ec' fzf-cd-widget
00.02193451: /Users/Aleks/.fzf/shell/completion.zsh:184> [ -z '' ']'
00.02193451: /Users/Aleks/.fzf/shell/key-bindings.zsh:26> bindkey '^T' fzf-file-widget
00.02098083: /Users/Aleks/.fzf/shell/key-bindings.zsh:25> zle -N fzf-file-widget
00.01907349: /Users/Aleks/.fzf/shell/key-bindings.zsh:35> zle -N fzf-cd-widget
00.01811981: /Users/Aleks/.fzf/shell/key-bindings.zsh:51> zle -N fzf-history-widget
```

This PR speeds up the slowest line by about 4x, knocking it down to just under 1ms on average on my machine.