### PR TITLE
Removing error checking to allow clean installation

### DIFF
--- a/install
+++ b/install
@@ -342,8 +342,6 @@ EOF
 fi
 
 append_line() {
-  set -e
-
   local update line file pat lno
   update="$1"
   line="$2"
@@ -370,7 +368,6 @@ append_line() {
     fi
   fi
   echo
-  set +e
 }
 
 if [ $update_config -eq 2 ]; then


### PR DESCRIPTION
On the append_line method, when trying to discover if the pattern exists
or not the `grep -nF "$pat" "$file"` fails and the installation exits
due to the `set -e`.