### PR TITLE
[zsh] Re-initialize zle when widgets finish

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -58,6 +58,7 @@ __fzf_generic_path_completion() {
         LBUFFER="$lbuf$matches$tail"
       fi
       zle redisplay
+      typeset -f zle-line-init >/dev/null && zle zle-line-init
       break
     fi
     dir=$(dirname "$dir")
@@ -97,6 +98,7 @@ _fzf_complete() {
     LBUFFER="$lbuf$matches"
   fi
   zle redisplay
+  typeset -f zle-line-init >/dev/null && zle zle-line-init
   rm -f "$fifo"
 }
 
@@ -161,6 +163,7 @@ fzf-completion() {
       LBUFFER="$LBUFFER$matches"
     fi
     zle redisplay
+    typeset -f zle-line-init >/dev/null && zle zle-line-init
   # Trigger sequence given
   elif [ ${#tokens} -gt 1 -a "$tail" = "$trigger" ]; then
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS:-cd pushd rmdir})

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -25,6 +25,7 @@ fzf-file-widget() {
   LBUFFER="${LBUFFER}$(__fsel)"
   local ret=$?
   zle redisplay
+  typeset -f zle-line-init >/dev/null && zle zle-line-init
   return $ret
 }
 zle     -N   fzf-file-widget
@@ -38,6 +39,7 @@ fzf-cd-widget() {
   cd "${$(eval "$cmd | $(__fzfcmd) +m $FZF_ALT_C_OPTS"):-.}"
   local ret=$?
   zle reset-prompt
+  typeset -f zle-line-init >/dev/null && zle zle-line-init
   return $ret
 }
 zle     -N    fzf-cd-widget
@@ -56,6 +58,7 @@ fzf-history-widget() {
     fi
   fi
   zle redisplay
+  typeset -f zle-line-init >/dev/null && zle zle-line-init
   return $ret
 }
 zle     -N   fzf-history-widget


### PR DESCRIPTION
zle automatically calls zle-line-init when it starts to read a new line. Many
Zsh setups use this hook to set the terminal into application mode, since this
will then allow defining keybinds based on the $terminfo variable (the escape
codes in said variable are only valid in application mode).

However, fzf resets the terminal into raw mode, rendering $terminfo values
invalid once the widget has finished. Accordingly, keyboard bindings defined
via $terminfo won’t work anymore.

This fixes the issue by calling zle-line-init when widgets finish. Care is taken
to not call this widget when it is undefined.

Fixes #279