### PR TITLE
use tmux buffers for sending output to preserve character encoding

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -26,7 +26,7 @@ __fzf_select_tmux__() {
     height="-l $height"
   fi
 
-  tmux split-window $height "cd $(printf %q "$PWD"); FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS") PATH=$(printf %q "$PATH") FZF_CTRL_T_COMMAND=$(printf %q "$FZF_CTRL_T_COMMAND") FZF_CTRL_T_OPTS=$(printf %q "$FZF_CTRL_T_OPTS") bash -c 'source \"${BASH_SOURCE[0]}\"; tmux send-keys -t $TMUX_PANE \"\$(__fzf_select__)\"'"
+  tmux split-window $height "cd $(printf %q "$PWD"); FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS") PATH=$(printf %q "$PATH") FZF_CTRL_T_COMMAND=$(printf %q "$FZF_CTRL_T_COMMAND") FZF_CTRL_T_OPTS=$(printf %q "$FZF_CTRL_T_OPTS") bash -c 'source \"${BASH_SOURCE[0]}\"; tmux setb -b \"fzf\" \"\$(__fzf_select__)\"; tmux pasteb -b \"fzf\" -t $TMUX_PANE; tmux deleteb -b \"fzf\"'"
 }
 
 fzf-file-widget() {


### PR DESCRIPTION
The command `tmux send-keys` is really not intended for text I don't believe. Instead, we should use a buffer. The buffer can be deleted right after it's used.

This solves the problem of if you select a filename with ctrl+t that has unicode characters in them. I noticed this when selecting song files that were in different languages. The output was corrupted, and could not be used in commands.

This should fix the problem, and I do not believe this problem is anywhere else in the code.

Actually I'm not sure why ctrl+t needs a special function like this in bash only, but I haven't looked at the other shells' implementations to see how it works for them.

(Also I am working on a keybindings port to mksh, if you are interested in merging that as well.)