### PR TITLE
Split default zsh binding at the correct place

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -186,7 +186,7 @@ fzf-completion() {
 
 [ -z "$fzf_default_completion" ] && {
   binding=$(bindkey '^I')
-  [[ $binding =~ 'undefined-key' ]] || fzf_default_completion=$binding[(w)2]
+  [[ $binding =~ 'undefined-key' ]] || fzf_default_completion=$binding[(s: :w)2]
   unset binding
 }
 


### PR DESCRIPTION
The command substitution and following word splitting to determine the default
zle widget for ^I formerly only works if the IFS parameter contains a space. Now
it specifically splits at spaces, regardless of IFS.