### PR TITLE
Make fzf target correct session in group

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -161,14 +161,14 @@ done
 
 if [[ -n "$term" ]] || [[ -t 0 ]]; then
   cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" > $argsf
-  tmux set-window-option synchronize-panes off \;\
+  TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
     split-window $opt "cd $(printf %q "$PWD");$envs bash $argsf" $swap \
     > /dev/null 2>&1
 else
   mkfifo $fifo1
   cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" > $argsf
-  tmux set-window-option synchronize-panes off \;\
+  TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
     split-window $opt "$envs bash $argsf" $swap \
     > /dev/null 2>&1


### PR DESCRIPTION
Fixes #643
Doesn't break #648 

Note that this will break if the socket filename contains any commas, but in my testing, tmux completely stopped functioning when I put a comma in the socket filename.