### PR TITLE
Fix #668

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -32,7 +32,7 @@ fi
 
 _fzf_orig_completion_filter() {
   sed 's/^\(.*-F\) *\([^ ]*\).* \([^ ]*\)$/export _fzf_orig_completion_\3="\1 %s \3 #\2";/' |
-  awk -F= '{gsub(/[^a-z0-9_= ;]/, "_", $1); print $1"="$2}'
+  awk -F= '{gsub(/[^A-Za-z0-9_= ;]/, "_", $1); print $1"="$2}'
 }
 
 _fzf_opts_completion() {
@@ -117,7 +117,7 @@ _fzf_handle_dynamic_completion() {
 __fzf_generic_path_completion() {
   local cur base dir leftover matches trigger cmd fzf
   [ "${FZF_TMUX:-1}" != 0 ] && fzf="fzf-tmux -d ${FZF_TMUX_HEIGHT:-40%}" || fzf="fzf"
-  cmd=$(echo "${COMP_WORDS[0]}" | sed 's/[^a-z0-9_=]/_/g')
+  cmd="${COMP_WORDS[0]//[^A-Za-z0-9_=]/_}"
   COMPREPLY=()
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
   cur="${COMP_WORDS[COMP_CWORD]}"
@@ -162,7 +162,7 @@ _fzf_complete() {
   type -t "$post" > /dev/null 2>&1 || post=cat
   [ "${FZF_TMUX:-1}" != 0 ] && fzf="fzf-tmux -d ${FZF_TMUX_HEIGHT:-40%}" || fzf="fzf"
 
-  cmd=$(echo "${COMP_WORDS[0]}" | sed 's/[^a-z0-9_=]/_/g')
+  cmd="${COMP_WORDS[0]//[^A-Za-z0-9_=]/_}"
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
   cur="${COMP_WORDS[COMP_CWORD]}"
   if [[ "$cur" == *"$trigger" ]]; then
@@ -277,7 +277,7 @@ _fzf_defc() {
   cmd="$1"
   func="$2"
   opts="$3"
-  orig_var="_fzf_orig_completion_$cmd"
+  orig_var="_fzf_orig_completion_${cmd//[^A-Za-z0-9_]/_}"
   orig="${!orig_var}"
   if [ -n "$orig" ]; then
     printf -v def "$orig" "$func"


### PR DESCRIPTION
Fix #668

Handle uppercase letters in program names. This also deals with `-` and
`.`, both of which are quite common in program names, e.g., `xdg-open`
and `foo.sh`.