### PR TITLE
use `fc -r` instead of `fzf --tac` in Zsh's CTRL-R

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -49,7 +49,7 @@ bindkey '\ec' fzf-cd-widget
 fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst pipefail 2> /dev/null
-  selected=( $(fc -l 1 | eval "$(__fzfcmd) +s --tac +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r $FZF_CTRL_R_OPTS -q ${(q)LBUFFER}") )
+  selected=( $(fc -r -l 1 | eval "$(__fzfcmd) +s +m -n2..,.. --tiebreak=index --toggle-sort=ctrl-r $FZF_CTRL_R_OPTS -q ${(q)LBUFFER}") )
   local ret=$?
   if [ -n "$selected" ]; then
     num=$selected[1]


### PR DESCRIPTION
When we press CTRL-R to search from history using fsf, it scrolls the history from top to bottom.
When the history size is large,(e.g. > 100,000) it is annoying since the scroll occurs each time we hit CTRL-R.
To avoid it, we should append `-r` to `fc` command so that it shows the history in reverse order, and remove `--tac` from `fzf`.