### PR TITLE
Implement FZF_CTRL_R_COMMAND for custom history

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -53,9 +53,10 @@ __fzf_cd__() {
 
 __fzf_history__() (
   local line
+  local cmd="${FZF_CTRL_R_COMMAND:-"history"}"
   shopt -u nocaseglob nocasematch
   line=$(
-    HISTTIMEFORMAT= history |
+    HISTTIMEFORMAT= eval "$cmd" |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS +s --tac -n2..,.. --tiebreak=index --toggle-sort=ctrl-r $FZF_CTRL_R_OPTS +m" $(__fzfcmd) |
     command grep '^ *[0-9]') &&
     if [[ $- =~ H ]]; then

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -43,10 +43,11 @@ function fzf_key_bindings
   end
 
   function fzf-history-widget -d "Show command history"
+    set -q FZF_CTRL_R_COMMAND; or set -l FZF_CTRL_R_COMMAND "history"
     set -q FZF_TMUX_HEIGHT; or set FZF_TMUX_HEIGHT 40%
     begin
       set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT $FZF_DEFAULT_OPTS +s --tiebreak=index $FZF_CTRL_R_OPTS +m"
-      history | eval (__fzfcmd) -q '(commandline)' | read -l result
+      eval "$FZF_CTRL_R_COMMAND | "(__fzfcmd) -q '(commandline)' | read -l result
       and commandline -- $result
     end
     commandline -f repaint

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -53,8 +53,9 @@ bindkey '\ec' fzf-cd-widget
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected num
+  local cmd="${FZF_CTRL_R_COMMAND:-"fc -l 1"}"
   setopt localoptions noglobsubst pipefail 2> /dev/null
-  selected=( $(fc -l 1 |
+  selected=( $(eval "$cmd" |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS +s --tac -n2..,.. --tiebreak=index --toggle-sort=ctrl-r $FZF_CTRL_R_OPTS --query=${(q)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -37,7 +37,7 @@ end
 class Shell
   class << self
     def unsets
-      'unset FZF_DEFAULT_COMMAND FZF_DEFAULT_OPTS FZF_CTRL_T_COMMAND FZF_CTRL_T_OPTS FZF_ALT_C_COMMAND FZF_ALT_C_OPTS FZF_CTRL_R_OPTS;'
+      'unset FZF_DEFAULT_COMMAND FZF_DEFAULT_OPTS FZF_CTRL_T_COMMAND FZF_CTRL_T_OPTS FZF_ALT_C_COMMAND FZF_ALT_C_OPTS FZF_CTRL_R_COMMAND FZF_CTRL_R_OPTS;'
     end
 
     def bash
@@ -1348,6 +1348,17 @@ module TestShell
     tmux.until { |lines| lines[-1] == 'echo 3rd' }
     tmux.send_keys :Enter
     tmux.until { |lines| lines[-1] == '3rd' }
+  end
+
+  def test_ctrl_r_command
+    set_var "FZF_CTRL_R_COMMAND", "echo '1    foobar'"
+    tmux.prepare
+    retries do
+      tmux.prepare
+      tmux.send_keys 'C-r'
+      tmux.until { |lines| lines[-2].include?('1/1') }
+    end
+    tmux.send_keys :Enter
   end
 
   def retries times = 3, &block


### PR DESCRIPTION
I'd like the ability to specify a custom history command to be able to use something like:
`fc -l 1 | grep ${(q)LBUFFER}`

to limit the results to history that exactly matches the full text entered on the command line.