### PR TITLE
Neovim: event handlers always expect three arguments

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -471,7 +471,7 @@ function! s:execute_term(dict, command, temps) abort
       endif
     endif
   endfunction
-  function! fzf.on_exit(id, code)
+  function! fzf.on_exit(id, code, _event)
     if s:getpos() == self.ppos " {'window': 'enew'}
       for [opt, val] in items(self.winopts)
         execute 'let' opt '=' val


### PR DESCRIPTION
This is the case for very recent Neovim builds, but works with older versions
as well.

---

Explanation: https://github.com/neovim/neovim/wiki/Following-HEAD#20161212

Closes #765.