### PR TITLE
s:execute_term: switch_back: check that self.pbuf exists

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -464,7 +464,9 @@ function! s:execute_term(dict, command, temps) abort
             \ 'columns': &columns, 'command': a:command }
   function! fzf.switch_back(inplace)
     if a:inplace && bufnr('') == self.buf
-      execute 'keepalt b' self.pbuf
+      if bufexists(self.pbuf)
+        execute 'keepalt b' self.pbuf
+      endif
       " No other listed buffer
       if bufnr('') == self.buf
         enew


### PR DESCRIPTION
With a `bufhidden=wipe` buffer (e.g. vim-startify) the buffer would not
exist anymore, resulting in an error.