### PR TITLE
shell: Use '-mindepth 1' to omit root folder in 'find' output

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -1,10 +1,10 @@
 # Key bindings
 # ------------
 __fzf_select__() {
-  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type f -print \
     -o -type d -print \
-    -o -type l -print 2> /dev/null | sed 1d | cut -b3-"}"
+    -o -type l -print 2> /dev/null | cut -b3-"}"
   eval "$cmd | fzf -m $FZF_CTRL_T_OPTS" | while read -r item; do
     printf '%q ' "$item"
   done

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -16,10 +16,10 @@ function fzf_key_bindings
     # "-path \$dir'*/\\.*'" matches hidden files/folders inside $dir but not
     # $dir itself, even if hidden.
     set -q FZF_CTRL_T_COMMAND; or set -l FZF_CTRL_T_COMMAND "
-    command find -L \$dir \\( -path \$dir'*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' \\) -prune \
+    command find -L \$dir -mindepth 1 \\( -path \$dir'*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' \\) -prune \
     -o -type f -print \
     -o -type d -print \
-    -o -type l -print 2> /dev/null | sed '1d; s#^\./##'"
+    -o -type l -print 2> /dev/null | sed 's#^\./##'"
 
     eval "$FZF_CTRL_T_COMMAND | "(__fzfcmd)" -m $FZF_CTRL_T_OPTS" | while read -l r; set result $result $r; end
     if [ -z "$result" ]

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -4,10 +4,10 @@ if [[ $- == *i* ]]; then
 
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
-  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type f -print \
     -o -type d -print \
-    -o -type l -print 2> /dev/null | sed 1d | cut -b3-"}"
+    -o -type l -print 2> /dev/null | cut -b3-"}"
   setopt localoptions pipefail 2> /dev/null
   eval "$cmd | $(__fzfcmd) -m $FZF_CTRL_T_OPTS" | while read item; do
     echo -n "${(q)item} "


### PR DESCRIPTION
This removes the need for the 'sed' call. Faster, cleaner.