### PR TITLE
Vim plugin can use Windows filepaths with spaces

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -240,9 +240,11 @@ endfunction
 function! fzf#run(...) abort
 try
   let oshell = &shell
+  let useshellslash = &shellslash
 
   if has('win32') || has('win64')
     set shell=cmd.exe
+    set shellslash
   else
     set shell=sh
   endif
@@ -293,6 +295,7 @@ try
   return lines
 finally
   let &shell = oshell
+  let &shellslash = useshellslash
 endtry
 endfunction
 
@@ -609,9 +612,6 @@ function! s:shortpath()
 endfunction
 
 function! s:cmd(bang, ...) abort
-try
-  let useshellslash = &shellslash
-  set shellslash
   let args = copy(a:000)
   let opts = { 'options': '--multi ' }
   if len(args) && isdirectory(expand(args[-1]))
@@ -622,9 +622,6 @@ try
   endif
   let opts.options .= ' '.join(args)
   call fzf#run(fzf#wrap('FZF', opts, a:bang))
-finally
-  let &shellslash = useshellslash
-endtry
 endfunction
 
 command! -nargs=* -complete=dir -bang FZF call s:cmd(<bang>0, <f-args>)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -263,7 +263,7 @@ try
   if !has_key(dict, 'source') && !empty($FZF_DEFAULT_COMMAND)
     let temps.source = tempname()
     call writefile(split($FZF_DEFAULT_COMMAND, "\n"), temps.source)
-    let dict.source = (empty($SHELL) ? 'sh' : $SHELL) . ' ' . s:shellesc(temps.source)
+    let dict.source = (empty($SHELL) ? &shell : $SHELL) . ' ' . s:shellesc(temps.source)
   endif
 
   if has_key(dict, 'source')
@@ -366,7 +366,7 @@ function! s:xterm_launcher()
 endfunction
 unlet! s:launcher
 if has('win32') || has('win64')
-  let s:launcher = 'cmd.exe'
+  let s:launcher = 'cmd.exe /C %s'
 else
   let s:launcher = function('s:xterm_launcher')
 endif
@@ -393,7 +393,10 @@ function! s:execute(dict, command, temps) abort
   if has('gui_running')
     let Launcher = get(a:dict, 'launcher', get(g:, 'Fzf_launcher', get(g:, 'fzf_launcher', s:launcher)))
     let fmt = type(Launcher) == 2 ? call(Launcher, []) : Launcher
-    let command = printf(fmt, "'".substitute(escaped, "'", "'\"'\"'", 'g')."'")
+    if has('unix')
+      let escaped = "'".substitute(escaped, "'", "'\"'\"'", 'g')."'"
+    endif
+    let command = printf(fmt, escaped)
   else
     let command = escaped
   endif

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -80,13 +80,13 @@ function! s:shellesc(arg)
 endfunction
 
 function! s:escape(path)
-  let l:escaped_chars = '$%#''"'
+  let escaped_chars = '$%#''"'
 
   if has('unix')
-    let l:escaped_chars .= ' \'
+    let escaped_chars .= ' \'
   endif
 
-  return escape(a:path, l:escaped_chars)
+  return escape(a:path, escaped_chars)
 endfunction
 
 " Upgrade legacy options
@@ -607,7 +607,7 @@ endfunction
 
 function! s:cmd(bang, ...) abort
 try
-  let l:useshellslash = &shellslash
+  let useshellslash = &shellslash
   set shellslash
   let args = copy(a:000)
   let opts = { 'options': '--multi ' }
@@ -620,7 +620,7 @@ try
   let opts.options .= ' '.join(args)
   call fzf#run(fzf#wrap('FZF', opts, a:bang))
 finally
-  let &shellslash = l:useshellslash
+  let &shellslash = useshellslash
 endtry
 endfunction
 


### PR DESCRIPTION
This is an update on my previous PR for Vim plugin on Windows #785.
This PR enables terminal Vim and Gvim to run fzf on filepaths with spaces.
It uses `noshellslash` on both `s:cmd()` and `fzf#run()`  for strict filename expansion on both.
It ensures that shellescape() works as expected for fzf.
For the launcher, the fzf command is double-quoted for cmd.exe. 

Tested on Windows 8.1, (g)vim 8, and Con Emu + Powershell (to run terminal vim).