### PR TITLE
[vim] use cmd.exe directly on GVim (launcher='%s')

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -382,7 +382,7 @@ function! s:xterm_launcher()
 endfunction
 unlet! s:launcher
 if has('win32') || has('win64')
-  let s:launcher = 'cmd.exe /C %s'
+  let s:launcher = '%s'
 else
   let s:launcher = function('s:xterm_launcher')
 endif
@@ -411,8 +411,6 @@ function! s:execute(dict, command, temps) abort
     let fmt = type(Launcher) == 2 ? call(Launcher, []) : Launcher
     if has('unix')
       let escaped = "'".substitute(escaped, "'", "'\"'\"'", 'g')."'"
-    elseif has('win32') || has('win64')
-      let escaped = '"'.(escaped).'"'
     endif
     let command = printf(fmt, escaped)
   else


### PR DESCRIPTION
PR for the commit https://github.com/janlazo/fzf/commit/4572bdcf7d710d8dcc4460319c0ac0f0a1878216, referenced in #786, for the gui launcher on Windows

Tested on GVim 8 and Windows 8.1