### PR TITLE
Alt-o shortcut to open file

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,9 @@ fish.
 - `ALT-C` - cd into the selected directory
     - Set `FZF_ALT_C_COMMAND` to override the default command
     - Set `FZF_ALT_C_OPTS` to pass additional options
+- `ALT-O` - open selected file with default application (`xdg-open`)
+    - Set `FZF_ALT_O_COMMAND` to override the default command
+    - Set `FZF_ALT_O_OPTS` to pass additional options
 
 If you're on a tmux session, fzf will start in a split pane. You may disable
 this tmux integration by setting `FZF_TMUX` to 0, or change the height of the

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -46,6 +46,13 @@ __fzf_cd__() {
   dir=$(eval "$cmd | $(__fzfcmd) +m $FZF_ALT_C_OPTS") && printf 'cd %q' "$dir"
 }
 
+__fzf_open__() {
+  local cmd file
+  cmd="${FZF_ALT_O_COMMAND:-"command find -L . \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+    -o -type f -print 2> /dev/null | sed 1d | cut -b3-"}"
+  file=$(eval "$cmd | $(__fzfcmd) +m $FZF_ALT_O_OPTS") && printf '/usr/bin/xdg-open %q/%q' "$PWD" "$file"
+}
+
 __fzf_history__() (
   local line
   shopt -u nocaseglob nocasematch
@@ -86,6 +93,9 @@ if [[ ! -o vi ]]; then
 
   # ALT-C - cd into the selected directory
   bind '"\ec": " \C-e\C-u`__fzf_cd__`\e\C-e\er\C-m"'
+
+  # ALT-O - open file
+  bind '"\eo": " \C-e\C-u`__fzf_open__`\e\C-e\er\C-m"'
 else
   # We'd usually use "\e" to enter vi-movement-mode so we can do our magic,
   # but this incurs a very noticeable delay of a half second or so,
@@ -118,6 +128,11 @@ else
   # ALT-C - cd into the selected directory
   bind '"\ec": "\C-x\C-addi`__fzf_cd__`\C-x\C-e\C-x\C-r\C-m"'
   bind -m vi-command '"\ec": "ddi`__fzf_cd__`\C-x\C-e\C-x\C-r\C-m"'
+
+  # ALT-O - open file
+  bind '"\eo": "\C-x\C-addi`__fzf_open__`\C-x\C-e\C-x\C-r\C-m"'
+  bind -m vi-command '"\eo": "ddi`__fzf_open__`\C-x\C-e\C-x\C-r\C-m"'
+
 fi
 
 unset -v __use_tmux __use_bind_x

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -53,6 +53,15 @@ function fzf_key_bindings
     commandline -f repaint
   end
 
+  function fzf-open-widget -d "Open file"
+    set -q FZF_ALT_O_COMMAND; or set -l FZF_ALT_O_COMMAND "
+    command find -L . \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' \\) -prune \
+    -o -type f -print 2> /dev/null | sed 1d | cut -b3-"
+    eval "$FZF_ALT_O_COMMAND | "(__fzfcmd)" +m $FZF_ALT_O_OPTS" | read -l result
+    [ "$result" ]; and /usr/bin/xdg-open $PWD/$result
+    commandline -f repaint
+  end
+
   function __fzfcmd
     set -q FZF_TMUX; or set FZF_TMUX 1
     if [ $FZF_TMUX -eq 1 ]
@@ -69,10 +78,12 @@ function fzf_key_bindings
   bind \ct fzf-file-widget
   bind \cr fzf-history-widget
   bind \ec fzf-cd-widget
+  bind \eo fzf-open-widget
 
   if bind -M insert > /dev/null 2>&1
     bind -M insert \ct fzf-file-widget
     bind -M insert \cr fzf-history-widget
     bind -M insert \ec fzf-cd-widget
+    bind -M insert \eo fzf-open-widget
   end
 end

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -45,6 +45,20 @@ fzf-cd-widget() {
 zle     -N    fzf-cd-widget
 bindkey '\ec' fzf-cd-widget
 
+# ALT-O - open file
+fzf-open-widget() {
+  local cmd="${FZF_ALT_O_COMMAND:-"command find -L . \\( -path '*/\\.*' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+    -o -type f -print 2> /dev/null | sed 1d | cut -b3-"}"
+  setopt localoptions pipefail 2> /dev/null
+  /usr/bin/xdg-open "${PWD}/${$(eval "$cmd | $(__fzfcmd) +m $FZF_ALT_O_OPTS"):-.}"
+  local ret=$?
+  zle reset-prompt
+  typeset -f zle-line-init >/dev/null && zle zle-line-init
+  return $ret
+}
+zle     -N    fzf-open-widget
+bindkey '\eo' fzf-open-widget
+
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected num

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -37,7 +37,7 @@ end
 class Shell
   class << self
     def unsets
-      'unset FZF_DEFAULT_COMMAND FZF_DEFAULT_OPTS FZF_CTRL_T_COMMAND FZF_CTRL_T_OPTS FZF_ALT_C_COMMAND FZF_ALT_C_OPTS FZF_CTRL_R_OPTS;'
+      'unset FZF_DEFAULT_COMMAND FZF_DEFAULT_OPTS FZF_CTRL_T_COMMAND FZF_CTRL_T_OPTS FZF_ALT_C_COMMAND FZF_ALT_C_OPTS FZF_ALT_O_COMMAND FZF_ALT_O_OPTS FZF_CTRL_R_OPTS;'
     end
 
     def bash
@@ -1305,6 +1305,10 @@ module TestShell
     tmux.prepare
     tmux.send_keys :pwd, :Enter
     tmux.until { |lines| lines[-1].end_with? '/tmp' }
+  end
+
+  def test_alt_o_command
+    # FIXME prepare test
   end
 
   def test_ctrl_r

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -1307,9 +1307,9 @@ module TestShell
     tmux.until { |lines| lines[-1].end_with? '/tmp' }
   end
 
-  def test_alt_o_command
-    # FIXME prepare test
-  end
+  # FIXME prepare test
+  # def test_alt_o_command
+  # end
 
   def test_ctrl_r
     tmux.prepare


### PR DESCRIPTION
!!! DRAFT !!!

Similarly to Alt-c (*cd into directory*), Alt-o command opens up the FZF
file selector view and invokes the default associated application with
the selected file.

Current implementation is based on Alt-c functionality. It is tested on
freedesktop compliant linux system (Ubuntu 16.04) and opens the selected
entry with `xdg-open`. It implements configuration parameters of
FZF_ALT_O_OPTIONS and FZF_ALT_O_COMMAND.

TODOs:
* `/usr/bin/xdg-open` is hard-coded. Other platforms need different
  configuration
* automatic testing stub is empty.