### PR TITLE
s:common_sink(): Avoid duplicate BufEnter.

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -155,7 +155,8 @@ function! s:common_sink(action, lines) abort
       else
         call s:open(cmd, item)
       endif
-      if exists('#BufEnter') && isdirectory(item)
+      if !has('patch-8.0.0177') && !has('nvim-0.2') && exists('#BufEnter')
+            \ && isdirectory(item)
         doautocmd BufEnter
       endif
     endfor


### PR DESCRIPTION
Later versions of Vim/Nvim handle `:edit <dir>` inside try-catch.

https://github.com/vim/vim/commit/e13b9afe1283f5ae43232b5992372a0eb570666c
https://github.com/vim/vim/pull/1375