### PR TITLE
Quote query value for zsh Ctrl-R

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -55,7 +55,7 @@ fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst pipefail 2> /dev/null
   selected=( $(fc -l 1 |
-    FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS +s --tac -n2..,.. --tiebreak=index --toggle-sort=ctrl-r $FZF_CTRL_R_OPTS +m --query=${(q)LBUFFER}" $(__fzfcmd)) )
+    FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS +s --tac -n2..,.. --tiebreak=index --toggle-sort=ctrl-r $FZF_CTRL_R_OPTS +m --query=\"${(q)LBUFFER}\"" $(__fzfcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then
     num=$selected[1]


### PR DESCRIPTION
This fixes pre-populating the query value from the typed command so far,
which broke in 208d4f2.