### PR TITLE
Work with vanilla zsh settings

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -142,6 +142,7 @@ _fzf_complete_unalias() {
 }
 
 fzf-completion() {
+  emulate zsh
   local tokens cmd prefix trigger tail fzf matches lbuf d_cmds
   setopt localoptions noshwordsplit noksh_arrays
 


### PR DESCRIPTION
Zsh is very customisable and some of the customisations will break the
completion function.  Restore the state to its default for the duration
of the function.