### PR TITLE
make install script work with non GNU tar

### DIFF
--- a/install
+++ b/install
@@ -99,11 +99,11 @@ link_fzf_in_path() {
 }
 
 try_curl() {
-  command -v curl > /dev/null && curl -fL $1 | tar -xz
+  command -v curl > /dev/null && curl -fL $1 | tar -xzf -
 }
 
 try_wget() {
-  command -v wget > /dev/null && wget -O - $1 | tar -xz
+  command -v wget > /dev/null && wget -O - $1 | tar -xzf -
 }
 
 download() {


### PR DESCRIPTION
This change makes the install scripts work on non GNU tar systems as well (which at least includes FreeBSD).