### PR TITLE
[vim] Start new terminal for nvim in Windows

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -479,11 +479,7 @@ function! s:execute(dict, command, use_height, temps) abort
   if has('unix') && !a:use_height
     silent! !clear 2> /dev/null
   endif
-  let escaped_chars = '%#!'
-  if s:is_win
-      let escaped_chars .= '\'
-  endif
-  let escaped = escape(substitute(a:command, '\n', '\\n', 'g'), escaped_chars)
+  let escaped = escape(substitute(a:command, '\n', '\\n', 'g'), '%#!')
   if has('gui_running')
     let Launcher = get(a:dict, 'launcher', get(g:, 'Fzf_launcher', get(g:, 'fzf_launcher', s:launcher)))
     let fmt = type(Launcher) == 2 ? call(Launcher, []) : Launcher
@@ -718,7 +714,8 @@ let s:default_action = {
 function! s:shortpath()
   let short = pathshorten(fzf#fnamemodify(fzf#getcwd(), ':~:.'))
   let slash = s:is_win ? '\' : '/'
-  return empty(short) ? '~'.slash : short . (short =~ '/$' ? '' : slash)
+  let path = empty(short) ? '~'.slash : short . (short =~ '/$' ? '' : slash)
+  return s:is_win ? escape(path, ' \') : path
 endfunction
 
 function! s:cmd(bang, ...) abort
@@ -729,7 +726,8 @@ function! s:cmd(bang, ...) abort
     if s:is_win
         let opts.dir = substitute(opts.dir, '/', '\\', 'g')
     endif
-    let opts.options .= ' --prompt '.fzf#shellescape(opts.dir)
+    let path = s:is_win ? escape(opts.dir, ' \') : opts.dir
+    let opts.options .= ' --prompt '.fzf#shellescape(path)
   else
     let opts.options .= ' --prompt '.fzf#shellescape(s:shortpath())
   endif

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -715,7 +715,7 @@ function! s:shortpath()
   let short = pathshorten(fzf#fnamemodify(fzf#getcwd(), ':~:.'))
   let slash = s:is_win ? '\' : '/'
   let path = empty(short) ? '~'.slash : short . (short =~ '/$' ? '' : slash)
-  return s:is_win ? escape(path, ' \') : path
+  return (s:is_win && !has('nvim')) ? escape(path, ' \') : path
 endfunction
 
 function! s:cmd(bang, ...) abort
@@ -726,11 +726,11 @@ function! s:cmd(bang, ...) abort
     if s:is_win
         let opts.dir = substitute(opts.dir, '/', '\\', 'g')
     endif
-    let path = s:is_win ? escape(opts.dir, ' \') : opts.dir
-    let opts.options .= ' --prompt '.fzf#shellescape(path)
+    let dir = (s:is_win && !has('nvim')) ? escape(opts.dir, ' \') : opts.dir
   else
-    let opts.options .= ' --prompt '.fzf#shellescape(s:shortpath())
+    let dir = s:shortpath()
   endif
+  let opts.options .= ' --prompt '.fzf#shellescape(dir)
   let opts.options .= ' '.join(args)
   call fzf#run(fzf#wrap('FZF', opts, a:bang))
 endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -479,7 +479,11 @@ function! s:execute(dict, command, use_height, temps) abort
   if has('unix') && !a:use_height
     silent! !clear 2> /dev/null
   endif
-  let escaped = escape(substitute(a:command, '\n', '\\n', 'g'), '%#!')
+  let escaped_chars = '%#!'
+  if s:is_win
+      let escaped_chars .= '\'
+  endif
+  let escaped = escape(substitute(a:command, '\n', '\\n', 'g'), escaped_chars)
   if has('gui_running')
     let Launcher = get(a:dict, 'launcher', get(g:, 'Fzf_launcher', get(g:, 'fzf_launcher', s:launcher)))
     let fmt = type(Launcher) == 2 ? call(Launcher, []) : Launcher

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -83,11 +83,10 @@ function! s:tmux_enabled()
 endfunction
 
 function! s:shellesc(arg)
-  let escaped = substitute(a:arg, '"', '\\"', 'g')
   if s:is_win
-      return escaped
+      return a:arg
   endif
-  return '"'.escaped.'"'
+  return '"'.substitute(a:arg, '"', '\\"', 'g').'"'
 endfunction
 
 function! s:escape(path)


### PR DESCRIPTION
This PR starts allows the vim plugin to work for Neovim in Windows by starting a new and separate terminal via cmd.exe and the start command. This is a workaround for the missing `:terminal` support.

I used jobstart() and on_exit to mimic s:execute() for Vim in Windows.

Tested only in Windows 8.1 and a recent March build of Neovim for Windows.