### PR TITLE
fzf#run: improve "is already running" message

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -287,9 +287,12 @@ try
     set shell=sh
   endif
 
-  if has('nvim') && len(filter(range(1, bufnr('$')), 'bufname(v:val) =~# ";#FZF"'))
-    call s:warn('FZF is already running!')
-    return []
+  if has('nvim')
+    let running = filter(range(1, bufnr('$')), "bufname(v:val) =~# ';#FZF'")
+    if len(running)
+      call s:warn('FZF is already running (in buffer '.join(running, ', ').')!')
+      return []
+    endif
   endif
   let dict   = exists('a:1') ? s:upgrade(a:1) : {}
   let temps  = { 'result': tempname() }


### PR DESCRIPTION
This displays the buffer(s) in this case, which is useful when FZF got
stuck, and you have to manually remove the buffer.