### PR TITLE
fix fzf-tmux kill another pane when zoomed

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -121,13 +121,7 @@ args+=("--no-height")
 if tmux list-panes -F '#F' | grep -q Z; then
   zoomed=1
   original_window=$(tmux display-message -p "#{window_id}")
-
-  tmux set-option default-shell /bin/bash
-  tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - \\\\; do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
-
-  user_shell=`cat /etc/passwd | grep $USER | cut -d: -f 7`
-  tmux set-option default-shell $user_shell
-
+  tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - '\\;' do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
   tmux swap-pane -t $tmp_window \; select-window -t $tmp_window
 fi
 

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -121,7 +121,14 @@ args+=("--no-height")
 if tmux list-panes -F '#F' | grep -q Z; then
   zoomed=1
   original_window=$(tmux display-message -p "#{window_id}")
-  tmp_window=$(tmux new-window -d -P -F "#{window_id}")
+
+  tmux set-option default-shell /bin/bash
+  tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - \\\\; do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
+
+  if grep $USER /etc/passwd | grep -q fish; then
+    tmux set-option default-shell /bin/fish
+  fi
+
   tmux swap-pane -t $tmp_window \; select-window -t $tmp_window
 fi
 

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -125,9 +125,8 @@ if tmux list-panes -F '#F' | grep -q Z; then
   tmux set-option default-shell /bin/bash
   tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - \\\\; do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
 
-  if grep $USER /etc/passwd | grep -q fish; then
-    tmux set-option default-shell /bin/fish
-  fi
+  user_shell=`cat /etc/passwd | grep $USER | cut -d: -f 7`
+  tmux set-option default-shell $user_shell
 
   tmux swap-pane -t $tmp_window \; select-window -t $tmp_window
 fi

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -121,7 +121,7 @@ args+=("--no-height")
 if tmux list-panes -F '#F' | grep -q Z; then
   zoomed=1
   original_window=$(tmux display-message -p "#{window_id}")
-  tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - \\\\; do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
+  tmp_window=$(tmux new-window -d -P -F "#{window_id}")
   tmux swap-pane -t $tmp_window \; select-window -t $tmp_window
 fi
 


### PR DESCRIPTION
Hi, thanks for your great tool! 
FZF greatly changed my terminal life.

I'm sorry If this PR broke something or is duplicated issue, but I have the following problem.
When I zoom one pane, and use `fzf-tmux`, then a pane will be killed.

I took a short movie to describe it:

![out](https://cloud.githubusercontent.com/assets/10719495/24456029/9b30e0c0-14cc-11e7-8c51-9065315a763a.gif)

I read this pull request, but I couldn't understand why the line 
`bash -c 'while :; do for c in \\| .... ` is added...

https://github.com/junegunn/fzf/pull/433

It seems that swapping `tmp_window` and `original_window` is not working correctly.

Thanks!

# My environment

```
fzf --version
0.16.6

bash --version
GNU bash, version 4.4.12
```

# Issue template

<!-- Check all that apply [x] -->
- Category
    - [ ] fzf binary
    - [x] fzf-tmux script
    - [ ] Key bindings
    - [ ] Completion
    - [ ] Vim
    - [ ] Neovim
    - [ ] Etc.
- OS
    - [x] Linux
    - [ ] Mac OS X
    - [ ] Windows
    - [ ] Windows Subsystem for Linux
    - [ ] Etc.
- Shell
    - [x] bash
    - [x] zsh
    - [x] fish
