### PR TITLE
[vim] Use backslash for Windows filepaths

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -51,6 +51,10 @@ function! s:fzf_expand(fmt)
   return s:fzf_call('expand', a:fmt)
 endfunction
 
+function! s:fzf_tempname()
+  return s:fzf_call('tempname')
+endfunction
+
 let s:default_layout = { 'down': '~40%' }
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']
 let s:is_win = has('win32') || has('win64')
@@ -311,7 +315,7 @@ try
     endif
   endif
   let dict   = exists('a:1') ? s:upgrade(a:1) : {}
-  let temps  = { 'result': tempname() }
+  let temps  = { 'result': s:fzf_tempname() }
   let optstr = get(dict, 'options', '')
   try
     let fzf_exec = s:fzf_exec()
@@ -324,7 +328,7 @@ try
   endif
 
   if !has_key(dict, 'source') && !empty($FZF_DEFAULT_COMMAND)
-    let temps.source = tempname().(s:is_win ? '.bat' : '')
+    let temps.source = s:fzf_tempname().(s:is_win ? '.bat' : '')
     call writefile((s:is_win ? ['@echo off'] : []) + split($FZF_DEFAULT_COMMAND, "\n"), temps.source)
     let dict.source = (empty($SHELL) ? &shell : $SHELL) . (s:is_win ? ' /c ' : ' ') . s:shellesc(temps.source)
   endif
@@ -335,7 +339,7 @@ try
     if type == 1
       let prefix = source.'|'
     elseif type == 3
-      let temps.input = tempname()
+      let temps.input = s:fzf_tempname()
       call writefile(source, temps.input)
       let prefix = (s:is_win ? 'type ' : 'cat ').s:shellesc(temps.input).'|'
     else

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -26,7 +26,7 @@ if exists('g:loaded_fzf')
 endif
 let g:loaded_fzf = 1
 
-function! s:without_shellescape(fn, ...)
+function! s:fzf_call(fn, ...)
   if s:is_win
     let shellslash = &shellslash
     try
@@ -40,15 +40,15 @@ function! s:without_shellescape(fn, ...)
 endfunction
 
 function! s:fzf_getcwd()
-  return s:without_shellescape('getcwd')
+  return s:fzf_call('getcwd')
 endfunction
 
 function! s:fzf_fnamemodify(fname, mods)
-  return s:without_shellescape('fnamemodify', a:fname, a:mods)
+  return s:fzf_call('fnamemodify', a:fname, a:mods)
 endfunction
 
 function! s:fzf_expand(fmt)
-  return s:without_shellescape('expand', a:fmt)
+  return s:fzf_call('expand', a:fmt)
 endfunction
 
 let s:default_layout = { 'down': '~40%' }
@@ -288,16 +288,7 @@ function! fzf#wrap(...)
 endfunction
 
 function! fzf#shellescape(path)
-  if s:is_win
-    let shellslash = &shellslash
-    try
-      set shellslash
-      return '"'.shellescape(a:path).'"'
-    finally
-      let &shellslash = shellslash
-    endtry
-  endif
-  return shellescape(a:path)
+  return s:fzf_call('shellescape', a:path)
 endfunction
 
 function! fzf#run(...) abort
@@ -716,7 +707,7 @@ function! s:cmd(bang, ...) abort
   else
     let prompt = s:shortpath()
   endif
-  let opts.options .= ' --prompt '.fzf#shellescape(prompt)
+  let opts.options .= ' --prompt '.fzf#shellescape(s:is_win ? escape(prompt, '\') : prompt)
   let opts.options .= ' '.join(args)
   call fzf#run(fzf#wrap('FZF', opts, a:bang))
 endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -44,9 +44,17 @@ if s:is_win
       let &shellslash = shellslash
     endtry
   endfunction
+
+  function! s:fzf_shellescape(path)
+    return substitute(s:fzf_call('shellescape', a:path), '[^\\]\zs\\"$', '\\\\"', '')
+  endfunction
 else
   function! s:fzf_call(fn, ...)
     return call(a:fn, a:000)
+  endfunction
+
+  function! s:fzf_shellescape(path)
+    return shellescape(a:path)
   endfunction
 endif
 
@@ -64,10 +72,6 @@ endfunction
 
 function! s:fzf_tempname()
   return s:fzf_call('tempname')
-endfunction
-
-function! s:fzf_shellescape(path)
-  return s:fzf_call('shellescape', a:path)
 endfunction
 
 let s:default_layout = { 'down': '~40%' }
@@ -501,7 +505,7 @@ function! s:execute(dict, command, use_height, temps) abort
   endif
   if s:is_win
     let batchfile = s:fzf_tempname().'.bat'
-    call writefile([command], batchfile)
+    call writefile(['@echo off', command], batchfile)
     let command = batchfile
     if has('nvim')
       let s:dict = a:dict
@@ -743,7 +747,7 @@ function! s:cmd(bang, ...) abort
   else
     let prompt = s:shortpath()
   endif
-  call extend(opts.options, ['--prompt', (s:is_win && !&shellslash) ? escape(prompt, '\') : prompt])
+  call extend(opts.options, ['--prompt', prompt])
   call extend(opts.options, args)
   call fzf#run(fzf#wrap('FZF', opts, a:bang))
 endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -44,51 +44,31 @@ if s:is_win
       let &shellslash = shellslash
     endtry
   endfunction
-
-  function! s:fzf_getcwd()
-    return s:fzf_call('getcwd')
-  endfunction
-
-  function! s:fzf_fnamemodify(fname, mods)
-    return s:fzf_call('fnamemodify', a:fname, a:mods)
-  endfunction
-
-  function! s:fzf_expand(fmt)
-    return s:fzf_call('expand', a:fmt)
-  endfunction
-
-  function! s:fzf_tempname()
-    return s:fzf_call('tempname')
-  endfunction
-
-  function! s:fzf_shellescape(path)
-    return s:fzf_call('shellescape', a:path)
-  endfunction
 else
   function! s:fzf_call(fn, ...)
     return call(a:fn, a:000)
   endfunction
-
-  function! s:fzf_getcwd()
-    return getcwd()
-  endfunction
-
-  function! s:fzf_fnamemodify(fname, mods)
-    return fnamemodify(a:fname, a:mods)
-  endfunction
-
-  function! s:fzf_expand(fmt)
-    return expand(a:fmt)
-  endfunction
-
-  function! s:fzf_tempname()
-    return tempname()
-  endfunction
-
-  function! s:fzf_shellescape(path)
-    return shellescape(a:path)
-  endfunction
 endif
+
+function! s:fzf_getcwd()
+  return s:fzf_call('getcwd')
+endfunction
+
+function! s:fzf_fnamemodify(fname, mods)
+  return s:fzf_call('fnamemodify', a:fname, a:mods)
+endfunction
+
+function! s:fzf_expand(fmt)
+  return s:fzf_call('expand', a:fmt)
+endfunction
+
+function! s:fzf_tempname()
+  return s:fzf_call('tempname')
+endfunction
+
+function! s:fzf_shellescape(path)
+  return s:fzf_call('shellescape', a:path)
+endfunction
 
 let s:default_layout = { 'down': '~40%' }
 let s:layout_keys = ['window', 'up', 'down', 'left', 'right']

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -36,16 +36,13 @@ else
 endif
 if s:is_win
   function! s:fzf_call(fn, ...)
-    if s:is_win
-      let shellslash = &shellslash
-      try
-        set noshellslash
-        return call(a:fn, a:000)
-      finally
-        let &shellslash = shellslash
-      endtry
-    endif
-    return call(a:fn, a:000)
+    let shellslash = &shellslash
+    try
+      set noshellslash
+      return call(a:fn, a:000)
+    finally
+      let &shellslash = shellslash
+    endtry
   endfunction
 
   function! s:fzf_getcwd()
@@ -68,6 +65,10 @@ if s:is_win
     return s:fzf_call('shellescape', a:path)
   endfunction
 else
+  function! s:fzf_call(fn, ...)
+    return call(a:fn, a:000)
+  endfunction
+
   function! s:fzf_getcwd()
     return getcwd()
   endfunction
@@ -745,8 +746,8 @@ let s:default_action = {
   \ 'ctrl-v': 'vsplit' }
 
 function! s:shortpath()
-  let short = pathshorten(s:fzf_fnamemodify(s:fzf_getcwd(), ':~:.'))
-  let slash = s:is_win ? '\' : '/'
+  let short = pathshorten(fnamemodify(getcwd(), ':~:.'))
+  let slash = (s:is_win && !&shellslash) ? '\' : '/'
   return empty(short) ? '~'.slash : short . (short =~ slash.'$' ? '' : slash)
 endfunction
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -497,8 +497,6 @@ function! s:execute(dict, command, use_height, temps) abort
         let lines = s:collect(s:temps)
         call s:callback(s:dict, lines)
       endfunction
-      let batchfile = s:fzf_tempname().'.bat'
-      call writefile([command], batchfile)
       let cmd = 'start /wait cmd /c '.command
       call jobstart(cmd, fzf)
       return []

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -756,14 +756,14 @@ function! s:cmd(bang, ...) abort
   let opts = { 'options': ['--multi'] }
   if len(args) && isdirectory(expand(args[-1]))
     let opts.dir = substitute(substitute(remove(args, -1), '\\\(["'']\)', '\1', 'g'), '[/\\]*$', '/', '')
-    if s:is_win
+    if s:is_win && !&shellslash
       let opts.dir = substitute(opts.dir, '/', '\\', 'g')
     endif
     let prompt = opts.dir
   else
     let prompt = s:shortpath()
   endif
-  call extend(opts.options, ['--prompt', s:is_win ? escape(prompt, '\') : prompt])
+  call extend(opts.options, ['--prompt', (s:is_win && !&shellslash) ? escape(prompt, '\') : prompt])
   call extend(opts.options, args)
   call fzf#run(fzf#wrap('FZF', opts, a:bang))
 endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -275,7 +275,8 @@ function! fzf#wrap(...)
     if !isdirectory(dir)
       call mkdir(dir, 'p')
     endif
-    let opts.options = join(['--history', s:escape(dir.'/'.name), opts.options])
+    let history = s:is_win ? fzf#shellescape(dir.'\'.name) : s:escape(dir.'/'.name)
+    let opts.options = join(['--history', history, opts.options])
   endif
 
   " Action: g:fzf_action


### PR DESCRIPTION
- Category
    - [ ] fzf binary
    - [ ] fzf-tmux script
    - [ ] Key bindings
    - [ ] Completion
    - [X] Vim
    - [X] Neovim (starting https://github.com/junegunn/fzf/pull/896/commits/3adea892331b158b2e0290cea519670d8670d739)
    - [ ] Etc.
- OS
    - [ ] Linux
    - [ ] Mac OS X
    - [X] Windows
    - [ ] Windows Subsystem for Linux
    - [ ] Etc.
- Shell
    - [ ] bash
    - [ ] zsh
    - [ ] fish


PR for the shellescaping issue I described in #882.

I added wrapper functions to handle filepath functions in vim.
- `set noshellslash` for backslash in filepaths
- `set shellslash` for `shellescape()` to single quote first, and then double quote its output   (ex. path --> "'path'")
     - Vim runs cmd.exe twice, one is a wrapper proxy, and the other is the actual command
     - cmd.exe strips the double quotes of each argument
     - `C:\Program Files (x86)\` (no quotes) breaks on `s:execute()` so it must be escaped with single/double quotes in cmd.exe and powershell

I wasn't sure where to put the new functions so I placed them just after if guard at the top of the file because I used `fzf#expand` for `s:base_dir`.