### PR TITLE
[vim] Replace s:fzf_shellescape and s:shellesc with fzf#shellescape

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -46,7 +46,8 @@ if s:is_win
   endfunction
 
   function! s:shellesc(arg)
-    let escaped = substitute(a:arg, '[">]', '^&', 'g')
+    let escaped = substitute(a:arg, '>', '^&', 'g')
+    let escaped = substitute(escaped, '"', '\\^&', 'g')
     let escaped = substitute(escaped, '\\\\^', '\\^&', 'g')
     return '^"'.substitute(escaped, '[^\\]\zs\\$', '\\\\', '').'^"'
   endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -46,7 +46,7 @@ if s:is_win
   endfunction
 
   function! s:shellesc(arg)
-    let escaped = substitute(a:arg, '>', '^&', 'g')
+    let escaped = substitute(a:arg, '[&|<>()@^]', '^&', 'g')
     let escaped = substitute(escaped, '"', '\\^&', 'g')
     let escaped = substitute(escaped, '\\\\^', '\\^&', 'g')
     return '^"'.substitute(escaped, '[^\\]\zs\\$', '\\\\', '').'^"'

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -48,7 +48,7 @@ if s:is_win
   function! s:shellesc(arg)
     let escaped = substitute(a:arg, '[&|<>()@^]', '^&', 'g')
     let escaped = substitute(escaped, '"', '\\^&', 'g')
-    let escaped = substitute(escaped, '\\\\^', '\\^&', 'g')
+    let escaped = substitute(escaped, '\\\+\(\\^\)', '\\\\\1', 'g')
     return '^"'.substitute(escaped, '[^\\]\zs\\$', '\\\\', '').'^"'
   endfunction
 else

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -45,16 +45,16 @@ if s:is_win
     endtry
   endfunction
 
-  function! s:fzf_shellescape(path)
-    return substitute(s:fzf_call('shellescape', a:path), '[^\\]\zs\\"$', '\\\\"', '')
+  function! s:shellesc(arg)
+    return '^"'.substitute(substitute(a:arg, '"', '\\\^&', 'g'), '[^\\]\zs\\$', '\\\\', '').'^"'
   endfunction
 else
   function! s:fzf_call(fn, ...)
     return call(a:fn, a:000)
   endfunction
 
-  function! s:fzf_shellescape(path)
-    return shellescape(a:path)
+  function! s:shellesc(arg)
+    return '"'.substitute(a:arg, '"', '\\"', 'g').'"'
   endfunction
 endif
 
@@ -126,10 +126,6 @@ function! s:tmux_enabled()
     let s:tmux = !v:shell_error && output >= 'tmux 1.7'
   endif
   return s:tmux
-endfunction
-
-function! s:shellesc(arg)
-  return '"'.substitute(a:arg, '"', '\\"', 'g').'"'
 endfunction
 
 function! s:escape(path)
@@ -250,7 +246,7 @@ endfunction
 
 function! s:evaluate_opts(options)
   return type(a:options) == type([]) ?
-        \ join(map(copy(a:options), 's:fzf_shellescape(v:val)')) : a:options
+        \ join(map(copy(a:options), 's:shellesc(v:val)')) : a:options
 endfunction
 
 " [name string,] [opts dict,] [fullscreen boolean]
@@ -297,7 +293,7 @@ function! fzf#wrap(...)
     if !isdirectory(dir)
       call mkdir(dir, 'p')
     endif
-    let history = s:is_win ? s:fzf_shellescape(dir.'\'.name) : s:escape(dir.'/'.name)
+    let history = s:is_win ? s:shellesc(dir.'\'.name) : s:escape(dir.'/'.name)
     let opts.options = join(['--history', history, opts.options])
   endif
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -46,7 +46,9 @@ if s:is_win
   endfunction
 
   function! s:shellesc(arg)
-    return '^"'.substitute(a:arg, '["\\]', '\\^&', 'g').'^"'
+    let escaped = substitute(a:arg, '[">]', '^&', 'g')
+    let escaped = substitute(escaped, '\\\\^', '\\^&', 'g')
+    return '^"'.substitute(escaped, '[^\\]\zs\\$', '\\\\', '').'^"'
   endfunction
 else
   function! s:fzf_call(fn, ...)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -46,7 +46,7 @@ if s:is_win
   endfunction
 
   function! s:shellesc(arg)
-    return '^"'.substitute(substitute(a:arg, '"', '\\\^&', 'g'), '[^\\]\zs\\$', '\\\\', '').'^"'
+    return '^"'.substitute(a:arg, '["\\]', '\\^&', 'g').'^"'
   endfunction
 else
   function! s:fzf_call(fn, ...)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -63,7 +63,7 @@ function! fzf#shellescape(arg, ...)
   if shell =~# 'cmd.exe$'
     return s:shellesc_cmd(a:arg)
   endif
-  return shellescape(a:arg)
+  return s:fzf_call('shellescape', a:arg)
 endfunction
 
 function! s:fzf_getcwd()

--- a/test/fzf.vader
+++ b/test/fzf.vader
@@ -147,6 +147,23 @@ Execute (fzf#wrap):
   let opts = fzf#wrap({})
   Assert opts.options =~ '^--color=fg:'
 
+Execute (fzf#shellesc with sh):
+  AssertEqual '""', fzf#shellesc('', 'sh')
+  AssertEqual '"\"\""', fzf#shellesc('""', 'sh')
+  AssertEqual '"foobar>"', fzf#shellesc('foobar>', 'sh')
+  AssertEqual '"\\""', fzf#shellesc('\"', 'sh')
+  AssertEqual '"echo ''a'' && echo ''b''"', fzf#shellesc('echo ''a'' && echo ''b''', 'sh')
+
+Execute (fzf#shellesc with cmd.exe):
+  AssertEqual '^"^"', fzf#shellesc('', 'cmd.exe')
+  AssertEqual '^"\^"\^"^"', fzf#shellesc('""', 'cmd.exe')
+  AssertEqual '^"foobar^>^"', fzf#shellesc('foobar>', 'cmd.exe')
+  AssertEqual '^"\\\^"\\^"', fzf#shellesc('\\\\\\\\"\', 'cmd.exe')
+  AssertEqual '^"echo ''a'' ^&^& echo ''b''^"', fzf#shellesc('echo ''a'' && echo ''b''', 'cmd.exe')
+
+  AssertEqual '^"C:\Program Files ^(x86^)\\^"', fzf#shellesc('C:\Program Files (x86)\', 'cmd.exe')
+  AssertEqual '^"C:/Program Files ^(x86^)/^"', fzf#shellesc('C:/Program Files (x86)/', 'cmd.exe')
+
 Execute (Cleanup):
   unlet g:dir
   Restore

--- a/test/fzf.vader
+++ b/test/fzf.vader
@@ -147,22 +147,23 @@ Execute (fzf#wrap):
   let opts = fzf#wrap({})
   Assert opts.options =~ '^--color=fg:'
 
-Execute (fzf#shellesc with sh):
-  AssertEqual '""', fzf#shellesc('', 'sh')
-  AssertEqual '"\"\""', fzf#shellesc('""', 'sh')
-  AssertEqual '"foobar>"', fzf#shellesc('foobar>', 'sh')
-  AssertEqual '"\\""', fzf#shellesc('\"', 'sh')
-  AssertEqual '"echo ''a'' && echo ''b''"', fzf#shellesc('echo ''a'' && echo ''b''', 'sh')
+Execute (fzf#shellescape with sh):
+  AssertEqual '''''', fzf#shellescape('', 'sh')
+  AssertEqual '''""''', fzf#shellescape('""', 'sh')
+  AssertEqual '''foobar>''', fzf#shellescape('foobar>', 'sh')
+  AssertEqual '''\"''', fzf#shellescape('\"', 'sh')
+  AssertEqual '''echo ''\''''a''\'''' && echo ''\''''b''\''''''', fzf#shellescape('echo ''a'' && echo ''b''', 'sh')
 
-Execute (fzf#shellesc with cmd.exe):
-  AssertEqual '^"^"', fzf#shellesc('', 'cmd.exe')
-  AssertEqual '^"\^"\^"^"', fzf#shellesc('""', 'cmd.exe')
-  AssertEqual '^"foobar^>^"', fzf#shellesc('foobar>', 'cmd.exe')
-  AssertEqual '^"\\\^"\\^"', fzf#shellesc('\\\\\\\\"\', 'cmd.exe')
-  AssertEqual '^"echo ''a'' ^&^& echo ''b''^"', fzf#shellesc('echo ''a'' && echo ''b''', 'cmd.exe')
+Execute (fzf#shellescape with cmd.exe):
+  AssertEqual '^"^"', fzf#shellescape('', 'cmd.exe')
+  AssertEqual '^"\^"\^"^"', fzf#shellescape('""', 'cmd.exe')
+  AssertEqual '^"foobar^>^"', fzf#shellescape('foobar>', 'cmd.exe')
+  AssertEqual '^"\\\^"\\^"', fzf#shellescape('\\\\\\\\"\', 'cmd.exe')
+  AssertEqual '^"echo ''a'' ^&^& echo ''b''^"', fzf#shellescape('echo ''a'' && echo ''b''', 'cmd.exe')
 
-  AssertEqual '^"C:\Program Files ^(x86^)\\^"', fzf#shellesc('C:\Program Files (x86)\', 'cmd.exe')
-  AssertEqual '^"C:/Program Files ^(x86^)/^"', fzf#shellesc('C:/Program Files (x86)/', 'cmd.exe')
+  AssertEqual '^"C:\Program Files ^(x86^)\\^"', fzf#shellescape('C:\Program Files (x86)\', 'cmd.exe')
+  AssertEqual '^"C:/Program Files ^(x86^)/^"', fzf#shellescape('C:/Program Files (x86)/', 'cmd.exe')
+  " AssertEqual '^"%%USERPROFILE%%^", fzf#shellescape('%USERPROFILE%', 'cmd.exe')
 
 Execute (Cleanup):
   unlet g:dir


### PR DESCRIPTION
Continuation of #896.

Previous PR cannot escape double quotes properly in `s:evaluate_opts` because of escaping assumptions made by cmd.exe. Instead on relying `shellescape` which relies on `shellslash`, use `s:shellesc` to escape with `\` in Unix and `\^` in Windows. For now, only `"` is escaped this way. The last backslash is escaped the same way as in `s:fzf_shellescape`.

The outer double quotes are escaped via `^` so cmd.exe knows where the escaping starts and ends. Without it, shell redirection with `>` fails even if the double quote character is escaped.

```dosbatch
> fzf --prompt "C:/Program \" Files (x86)/" "--multi" > tmp.txt
unknown option: >
```