### PR TITLE
[vim] use utf-8 for cmd.exe

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -46,7 +46,7 @@ if s:is_win
   endfunction
 
   " Use utf-8 for fzf.vim commands
-: " Return array of shell commands for cmd.exe
+  " Return array of shell commands for cmd.exe
   function! s:wrap_cmds(cmds)
     return ['@echo off', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001 > nul'] +
           \ (type(a:cmds) == type([]) ? a:cmds : [a:cmds]) +

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -48,9 +48,9 @@ if s:is_win
   " Use utf-8 for fzf.vim commands
 : " Return array of shell commands for cmd.exe
   function! s:wrap_cmds(cmds)
-    return ['@echo off', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001'] +
+    return ['@echo off', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001 > nul'] +
           \ (type(a:cmds) == type([]) ? a:cmds : [a:cmds]) +
-          \ ['chcp %origchcp%']
+          \ ['chcp %origchcp% > nul']
   endfunction
 else
   function! s:fzf_call(fn, ...)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -44,9 +44,21 @@ if s:is_win
       let &shellslash = shellslash
     endtry
   endfunction
+
+  " Use utf-8 for fzf.vim commands
+: " Return array of shell commands for cmd.exe
+  function! s:wrap_cmds(cmds)
+    return ['@echo off', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001'] +
+          \ (type(a:cmds) == type([]) ? a:cmds : [a:cmds]) +
+          \ ['chcp %origchcp%']
+  endfunction
 else
   function! s:fzf_call(fn, ...)
     return call(a:fn, a:000)
+  endfunction
+
+  function! s:wrap_cmds(cmds)
+    return a:cmds
   endfunction
 endif
 
@@ -352,7 +364,7 @@ try
 
   if !has_key(dict, 'source') && !empty($FZF_DEFAULT_COMMAND)
     let temps.source = s:fzf_tempname().(s:is_win ? '.bat' : '')
-    call writefile((s:is_win ? ['@echo off'] : []) + split($FZF_DEFAULT_COMMAND, "\n"), temps.source)
+    call writefile(s:wrap_cmds(split($FZF_DEFAULT_COMMAND, "\n")), temps.source)
     let dict.source = (empty($SHELL) ? &shell : $SHELL) . (s:is_win ? ' /c ' : ' ') . fzf#shellescape(temps.source)
   endif
 
@@ -510,7 +522,7 @@ function! s:execute(dict, command, use_height, temps) abort
   endif
   if s:is_win
     let batchfile = s:fzf_tempname().'.bat'
-    call writefile(['@echo off', command], batchfile)
+    call writefile(s:wrap_cmds(command), batchfile)
     let command = batchfile
     if has('nvim')
       let s:dict = a:dict


### PR DESCRIPTION
Some commands in fzf.vim use utf-8 characters but cmd.exe doesn't use utf-8 by default.
Permanently changing the encoding in cmd.exe or powershell affects other terminal programs so a temporary variable is required to store the current encoding and reverting to it after fzf runs successfully.
Issue is if the command fails, then terminal users are left in a bad state with a permanently changed encoding.

This change is limited to Windows and GUIs that use external terminals for fzf should be unaffected if the fzf fails.

This PR should resolve fzf.vim commands that use utf-8 characters such as `Commands`

Reference:
https://ss64.com/nt/chcp.html