### PR TITLE
Support cygwin vim via cygpath and Windows binary

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -550,7 +550,14 @@ function! s:execute(dict, command, use_height, temps) abort
       return []
     endif
   elseif has('win32unix')
-    let command = 'TERM=""; '.command
+    if $TERM ==# 'cygwin' || $TERM ==# ''
+      let command = 'TERM=""; '.command
+    else
+      let shellscript = s:fzf_tempname()
+      call writefile([command], shellscript)
+      let command = 'cmd.exe /C ''set TERM="" & start /WAIT sh -c '.s:cygpath(shellscript).''''
+      let a:temps.shellscript = shellscript
+    endif
   endif
   if a:use_height
     let stdin = has_key(a:dict, 'source') ? '' : '< /dev/tty'

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -550,7 +550,7 @@ function! s:execute(dict, command, use_height, temps) abort
       return []
     endif
   elseif has('win32unix')
-    if $TERM ==# 'cygwin' || $TERM ==# ''
+    if $TERM ==# 'cygwin'
       let command = 'TERM=""; '.command
     else
       let shellscript = s:fzf_tempname()

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -549,15 +549,11 @@ function! s:execute(dict, command, use_height, temps) abort
       call jobstart(cmd, fzf)
       return []
     endif
-  elseif has('win32unix')
-    if $TERM ==# 'cygwin'
-      let command = 'TERM=""; '.command
-    else
-      let shellscript = s:fzf_tempname()
-      call writefile([command], shellscript)
-      let command = 'cmd.exe /C ''set TERM="" & start /WAIT sh -c '.s:cygpath(shellscript).''''
-      let a:temps.shellscript = shellscript
-    endif
+  elseif has('win32unix') && $TERM !=# 'cygwin'
+    let shellscript = s:fzf_tempname()
+    call writefile([command], shellscript)
+    let command = 'cmd.exe /C ''set "TERM=" & start /WAIT sh -c '.s:cygpath(shellscript).''''
+    let a:temps.shellscript = shellscript
   endif
   if a:use_height
     let stdin = has_key(a:dict, 'source') ? '' : '< /dev/tty'

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -220,9 +220,6 @@ function! s:common_sink(action, lines) abort
     let empty = empty(s:fzf_expand('%')) && line('$') == 1 && empty(getline(1)) && !&modified
     let autochdir = &autochdir
     set noautochdir
-    if has('win32unix')
-      call map(a:lines, 's:fzf_fnamemodify(v:val, ":p")')
-    endif
     for item in a:lines
       if empty
         execute 'e' s:escape(item)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -158,7 +158,10 @@ function! s:escape(path)
   let escaped_chars = '$%#''"'
 
   if has('unix')
-    let escaped_chars .= ' \()'
+    let escaped_chars .= ' \'
+  endif
+  if has('win32unix')
+    let escaped_chars .= '()'
   endif
 
   return escape(a:path, escaped_chars)
@@ -410,6 +413,7 @@ try
     let optstr .= ' --no-height'
   endif
   let command = prefix.(use_tmux ? s:fzf_tmux(dict) : fzf_exec).' '.optstr.' > '.temps.result
+
   if use_term
     return s:execute_term(dict, command, temps)
   endif

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -401,7 +401,7 @@ try
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right')) &&
         \ executable('tput') && filereadable('/dev/tty')
   let use_term = has('nvim') && !s:is_win
-  let use_tmux = (!use_height && !use_term || prefer_tmux) && s:tmux_enabled() && s:splittable(dict)
+  let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0
     let use_term = 0

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -80,7 +80,7 @@ endfunction
 
 function! s:cygpath(path, ...)
   let use_win_path = get(a:000, 0, 0)
-  let args = '-a'.(use_win_path ? 'm' : 'u').' '.a:path
+  let args = '-a'.(use_win_path ? 'm' : 'u').' '.fzf#shellescape(a:path)
   return substitute(system('cygpath '.args), '\n', '', 'g')
 endfunction
 
@@ -227,7 +227,7 @@ function! s:common_sink(action, lines) abort
     let autochdir = &autochdir
     set noautochdir
     if has('win32unix')
-      call map(a:lines, 's:cygpath(s:escape(v:val))')
+      call map(a:lines, 's:cygpath(v:val)')
     endif
     for item in a:lines
       if empty
@@ -467,8 +467,7 @@ function! s:pushd(dict)
       return 1
     endif
     let a:dict.prev_dir = cwd
-    let dir = s:escape(a:dict.dir)
-    execute 'lcd' has('win32unix') ? s:escape(s:cygpath(dir)) : dir
+    execute 'lcd' s:escape(has('win32unix') ? s:cygpath(a:dict.dir) : a:dict.dir)
     let a:dict.dir = s:fzf_getcwd()
     return 1
   endif
@@ -776,7 +775,7 @@ function! s:cmd(bang, ...) abort
     if s:is_win && !&shellslash
       let opts.dir = substitute(opts.dir, '/', '\\', 'g')
     elseif has('win32unix')
-      let opts.dir = s:cygpath(s:escape(opts.dir))
+      let opts.dir = s:cygpath(opts.dir)
     endif
     let prompt = opts.dir
   else

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -497,7 +497,7 @@ function! s:xterm_launcher()
     \ &columns, &lines/2, getwinposx(), getwinposy())
 endfunction
 unlet! s:launcher
-if s:is_win
+if s:is_win || has('win32unix')
   let s:launcher = '%s'
 else
   let s:launcher = function('s:xterm_launcher')

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -154,9 +154,6 @@ function! s:escape(path)
   if has('unix')
     let escaped_chars .= ' \'
   endif
-  if has('win32unix')
-    let escaped_chars .= '()'
-  endif
 
   return escape(a:path, escaped_chars)
 endfunction


### PR DESCRIPTION
Since cygwin sh/bash runs cmd.exe in the back (sh/bash by itself is run in a cmd.exe terminal) and use  `TERM=cygwin`, we can run cygwin vim and the fzf (Windows) binary in cmd.exe/powershell. Benefit of including cygwin support to the vim plugin is running the tests as is in Windows. I'm currently using this for the Vader tests.

By unsetting TERM, fzf runs as if vim (Windows) is used. cygpath (via `s:cygpath`) is used for path conversion between Windows and cygwin filepaths. I updated `s:escape` to escape `()` for Windows filepaths.

Currently, this PR does not support mintty (`TERM=xterm`) because fzf is run inline (no shell script or batchfile) and I can't get the start command to work with shell redirection yet. Neovim TUI in cygwin sh/bash is not supported in the vim plugin even though it runs fine (without mintty) in sh/bash. I'll work on that along with `:terminal` when 0.2.1 is released.

I'm using the cygwin environment from [Git For Windows](https://git-for-windows.github.io/) and tested this PR in `sh.exe` with `TERM=cygwin`.