### PR TITLE
[vader] uncomment test case to escape % in cmd.exe

### DIFF
--- a/test/fzf.vader
+++ b/test/fzf.vader
@@ -163,7 +163,7 @@ Execute (fzf#shellescape with cmd.exe):
 
   AssertEqual '^"C:\Program Files ^(x86^)\\^"', fzf#shellescape('C:\Program Files (x86)\', 'cmd.exe')
   AssertEqual '^"C:/Program Files ^(x86^)/^"', fzf#shellescape('C:/Program Files (x86)/', 'cmd.exe')
-  " AssertEqual '^"%%USERPROFILE%%^", fzf#shellescape('%USERPROFILE%', 'cmd.exe')
+  AssertEqual '^"%%USERPROFILE%%^"', fzf#shellescape('%USERPROFILE%', 'cmd.exe')
 
 Execute (Cleanup):
   unlet g:dir


### PR DESCRIPTION
I commented out a `shellescape` test case for cmd.exe in PR #916.
This PR uncomments it and fixes the runaway single quote.