### PR TITLE
[fish] Fix <C-t> completion for current dir search

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -29,9 +29,7 @@ function fzf_key_bindings
     if [ -z "$result" ]
       commandline -f repaint
       return
-    end
-
-    if [ "$dir" != . ]
+    else
       # Remove last token from commandline.
       commandline -t ""
     end


### PR DESCRIPTION
Fixes #945. If a selection is successfully chosen, the current commandline token should be "consumed".