### PR TITLE
[fish] Support multiline commands

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -44,7 +44,7 @@ function fzf_key_bindings
     set -q FZF_TMUX_HEIGHT; or set FZF_TMUX_HEIGHT 40%
     begin
       set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT $FZF_DEFAULT_OPTS --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m"
-      history | eval (__fzfcmd) -q '(commandline)' | read -l result
+      history -z | eval (__fzfcmd) --read0 -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
       and commandline -- $result
     end
     commandline -f repaint


### PR DESCRIPTION
Tested to work against fish 2.4 on Debian Stretch. I will be able to test against OS X tomorrow.

Fix found by @amosbird at https://github.com/junegunn/fzf/issues/953#issuecomment-310309055

closes #436