### PR TITLE
Allow forcing use of Neovim terminal emulation via g:fzf_use_term

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -35,6 +35,8 @@ else
   let s:base_dir = expand('<sfile>:h:h')
 endif
 if s:is_win
+  let s:term_marker = '&::FZF'
+
   function! s:fzf_call(fn, ...)
     let shellslash = &shellslash
     try
@@ -53,6 +55,8 @@ if s:is_win
           \ ['chcp %origchcp% > nul']
   endfunction
 else
+  let s:term_marker = ";#FZF"
+
   function! s:fzf_call(fn, ...)
     return call(a:fn, a:000)
   endfunction
@@ -343,7 +347,7 @@ try
   endif
 
   if has('nvim')
-    let running = filter(range(1, bufnr('$')), "bufname(v:val) =~# ';#FZF'")
+    let running = filter(range(1, bufnr('$')), "bufname(v:val) =~# '".s:term_marker."'")
     if len(running)
       call s:warn('FZF is already running (in buffer '.join(running, ', ').')!')
       return []
@@ -391,7 +395,7 @@ try
   let use_height = has_key(dict, 'down') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let use_term = exists('g:fzf_use_term')  || (has('nvim') && !s:is_win)
+  let use_term = exists('g:fzf_use_term') || (has('nvim') && !s:is_win)
   let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0
@@ -684,7 +688,7 @@ function! s:execute_term(dict, command, temps) abort
     if s:present(a:dict, 'dir')
       execute 'lcd' s:escape(a:dict.dir)
     endif
-    call termopen(a:command . ';#FZF', fzf)
+    call termopen(a:command.s:term_marker, fzf)
   finally
     if s:present(a:dict, 'dir')
       lcd -

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -391,7 +391,7 @@ try
   let use_height = has_key(dict, 'down') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let use_term = has('nvim') && !s:is_win
+  let use_term = exists('g:fzf_use_term')  || (has('nvim') && !s:is_win)
   let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0


### PR DESCRIPTION
This allows manually enabling the use of Neovim's terminal emulator on Windows. This isn't supported in Neovim's master branch yet, however after rebasing neovim/neovim#6383 onto master I was able to launch FZF via `:term:` without any major issues. The only annoyance is that gdamore/tcell#158 still needs fixed, but that just means you have to press enter twice for now.

Also, the use of `;#FZF` to identify the terminal buffer doesn't work with `cmd` since its comment syntax is different, so I put in a check which will use `&::FZF` instead on Windows.

This can also close #958, as it makes FZF usable on Windows without a popup.