### PR TITLE
Allow user to specify path to find binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ or `py`.
 - `FZF_DEFAULT_OPTS`
     - Default options
     - e.g. `export FZF_DEFAULT_OPTS="--reverse --inline-info"`
+- `FZF_FIND_COMMAND:`
+    - The `find` command to use when autocompleting files and directories.
+    - When unset, defaults to `find`.
+    - e.g. `export FZF_FIND_COMMAND="/usr/local/bin/find"`
 
 #### Options
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -14,7 +14,8 @@
 if ! declare -f _fzf_compgen_path > /dev/null; then
   _fzf_compgen_path() {
     echo "$1"
-    command find -L "$1" \
+    local fzffind="${FZF_FIND_COMMAND:-"find"}"
+    command ${fzffind} -L "$1" \
       -name .git -prune -o -name .svn -prune -o \( -type d -o -type f -o -type l \) \
       -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
   }
@@ -22,7 +23,8 @@ fi
 
 if ! declare -f _fzf_compgen_dir > /dev/null; then
   _fzf_compgen_dir() {
-    command find -L "$1" \
+    local fzffind="${FZF_FIND_COMMAND:-"find"}"
+    command ${fzffind} -L "$1" \
       -name .git -prune -o -name .svn -prune -o -type d \
       -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
   }

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -1,7 +1,8 @@
 # Key bindings
 # ------------
 __fzf_select__() {
-  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local fzffind="${FZF_FIND_COMMAND:-"find"}"
+  local cmd="${FZF_CTRL_T_COMMAND:-"command ${fzffind} -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null | cut -b3-"}"


### PR DESCRIPTION
This change allows the user to define the FZF_FIND_COMMAND environment variable
to specify which find binary to use. If the variable is unset, `find` is used
(the old default behaviour).

Basically on my system I need to source an environment for building older software, and as part of that the PATH is modified to point to an older find that doesn't work properly with the flags fzf uses. This change will let me use the working `/usr/bin/find` for fzf while letting the other build scripts use the older find.
