### PR TITLE
[vim] Don't pipe FZF_DEFAULT_COMMAND in Windows

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -365,10 +365,10 @@ try
     let dict.dir = fnamemodify(dict.dir, ':p')
   endif
 
-  if !has_key(dict, 'source') && !empty($FZF_DEFAULT_COMMAND)
-    let temps.source = s:fzf_tempname().(s:is_win ? '.bat' : '')
+  if !has_key(dict, 'source') && !empty($FZF_DEFAULT_COMMAND) && !s:is_win
+    let temps.source = s:fzf_tempname()
     call writefile(s:wrap_cmds(split($FZF_DEFAULT_COMMAND, "\n")), temps.source)
-    let dict.source = (empty($SHELL) ? &shell : $SHELL) . (s:is_win ? ' /c ' : ' ') . fzf#shellescape(temps.source)
+    let dict.source = (empty($SHELL) ? &shell : $SHELL).' '.fzf#shellescape(temps.source)
   endif
 
   if has_key(dict, 'source')


### PR DESCRIPTION
cmd.exe leaves the pipe hanging for the source command after fzf finishes so powershell and ag keep running and cmd.exe does not close. Putting `FZF_DEFAULT_COMMAND` in a batchfile hides the issue from cmd.exe so Vim is stuck waiting and Neovim does not run the exit callback. Letting fzf run `FZF_DEFAULT_COMMAND` passes the responsibility of stopping the source program to fzf executable so Vim/Neovim don't have to wait for the source command to finish executing.

This issue does not happen when running the fzf executable directly in the shell if `FZF_DEFAULT_COMMAND` is using powershell. ag still gets stuck.

I did not consider ack because it requires perl and is too slow as a default command.