### PR TITLE
Default command outputs relative filepath for preview to work in Windows

### DIFF
--- a/src/constants.go
+++ b/src/constants.go
@@ -59,7 +59,7 @@ func init() {
 	} else if os.Getenv("TERM") == "cygwin" {
 		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	} else {
-		defaultCommand = `dir /s/b/a:-d-h`
+		defaultCommand = `dir /s/b/a:-d-h 2> nul`
 	}
 }
 

--- a/src/constants.go
+++ b/src/constants.go
@@ -59,7 +59,7 @@ func init() {
 	} else if os.Getenv("TERM") == "cygwin" {
 		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	} else {
-		defaultCommand = `dir /s/b`
+		defaultCommand = `dir /s/b/a:-d-h`
 	}
 }
 

--- a/src/constants.go
+++ b/src/constants.go
@@ -59,7 +59,7 @@ func init() {
 	} else if os.Getenv("TERM") == "cygwin" {
 		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	} else {
-		defaultCommand = `dir /s/b/a:-d-h 2> nul`
+		defaultCommand = `cmd.exe /q/V:ON/c "for /f %A in ('dir /s/b 2^> nul') do set RELPATH=%A & echo !RELPATH:%cd%\\=!"`
 	}
 }
 


### PR DESCRIPTION
Modified the default command in Windows to match the description in the README

> Without STDIN pipe, fzf will use find command to fetch the list of files excluding hidden ones. (You can override the default command with FZF_DEFAULT_COMMAND)