### PR TITLE
[fish] Fix ctrl-r regression in versions <2.4

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -47,11 +47,11 @@ function fzf_key_bindings
       # history's -z flag was added in fish 2.4.0, so don't use it for versions
       # before 2.4.0.
       if [ "$FISH_MAJOR" -gt 2 -o \( "$FISH_MAJOR" -eq 2 -a "$FISH_MINOR" -ge 4 \) ];
-          history -z | eval (__fzfcmd) --read0 -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
-          and commandline -- $result
+        history -z | eval (__fzfcmd) --read0 -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
+        and commandline -- $result
       else
-          history | eval (__fzfcmd) -q '(commandline)' | read -l result
-          and commandline -- $result
+        history | eval (__fzfcmd) -q '(commandline)' | read -l result
+        and commandline -- $result
       end
     end
     commandline -f repaint

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -1,7 +1,7 @@
 # Key bindings
 # ------------
 function fzf_key_bindings
-  
+
   # Store current token in $dir as root for the 'find' command
   function fzf-file-widget -d "List files and folders"
     set -l commandline (__fzf_parse_commandline)

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -1,7 +1,9 @@
 # Key bindings
 # ------------
 function fzf_key_bindings
-
+  set -g __FZF_FISH_MAJOR (echo $FISH_VERSION | cut -f1 -d.)
+  set -g __FZF_FISH_MINOR (echo $FISH_VERSION | cut -f2 -d.)
+  
   # Store current token in $dir as root for the 'find' command
   function fzf-file-widget -d "List files and folders"
     set -l commandline (__fzf_parse_commandline)
@@ -39,8 +41,17 @@ function fzf_key_bindings
     set -q FZF_TMUX_HEIGHT; or set FZF_TMUX_HEIGHT 40%
     begin
       set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT $FZF_DEFAULT_OPTS --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m"
-      history -z | eval (__fzfcmd) --read0 -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
-      and commandline -- $result
+
+      # history's -z flag is needed for multi-line support.
+      # history's -z flag was added in fish 2.4.0, so don't use it for versions
+      # before 2.4.0.
+      if [ "$__FZF_FISH_MAJOR" -gt 2 -o \( "$__FZF_FISH_MAJOR" -eq 2 -a "$__FZF_FISH_MINOR" -ge 4 \) ];
+          history -z | eval (__fzfcmd) --read0 -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
+          and commandline -- $result
+      else
+          history | eval (__fzfcmd) -q '(commandline)' | read -l result
+          and commandline -- $result
+      end
     end
     commandline -f repaint
   end

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -1,8 +1,6 @@
 # Key bindings
 # ------------
 function fzf_key_bindings
-  set -g __FZF_FISH_MAJOR (echo $FISH_VERSION | cut -f1 -d.)
-  set -g __FZF_FISH_MINOR (echo $FISH_VERSION | cut -f2 -d.)
   
   # Store current token in $dir as root for the 'find' command
   function fzf-file-widget -d "List files and folders"
@@ -42,10 +40,13 @@ function fzf_key_bindings
     begin
       set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT $FZF_DEFAULT_OPTS --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m"
 
+      set -l FISH_MAJOR (echo $FISH_VERSION | cut -f1 -d.)
+      set -l FISH_MINOR (echo $FISH_VERSION | cut -f2 -d.)
+
       # history's -z flag is needed for multi-line support.
       # history's -z flag was added in fish 2.4.0, so don't use it for versions
       # before 2.4.0.
-      if [ "$__FZF_FISH_MAJOR" -gt 2 -o \( "$__FZF_FISH_MAJOR" -eq 2 -a "$__FZF_FISH_MINOR" -ge 4 \) ];
+      if [ "$FISH_MAJOR" -gt 2 -o \( "$FISH_MAJOR" -eq 2 -a "$FISH_MINOR" -ge 4 \) ];
           history -z | eval (__fzfcmd) --read0 -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
           and commandline -- $result
       else


### PR DESCRIPTION
... but multiline won't be supported in versions <2.4

Issue #966

I have yet to test this on version 2.3, but will.