### PR TITLE
Add MinGW on Windows to install script

### DIFF
--- a/install
+++ b/install
@@ -171,6 +171,7 @@ case "$archi" in
   OpenBSD\ *64)  download fzf-$version-openbsd_${binary_arch:-amd64}.tgz ;;
   OpenBSD\ *86)  download fzf-$version-openbsd_${binary_arch:-386}.tgz   ;;
   CYGWIN*\ *64)  download fzf-$version-windows_${binary_arch:-amd64}.zip ;;
+  MINGW*\ *86)   download fzf-$version-windows_${binary_arch:-386}.zip   ;;
   *)             binary_available=0 binary_error=1 ;;
 esac
 


### PR DESCRIPTION
Add install support for http://www.mingw.org/

Running uname -sm yields:
MINGW32_NT-6.2 i686

The prebuilt windows 386 binary works well in this environment.