### PR TITLE
[vim] escape slash in s:shortpath

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -756,7 +756,7 @@ let s:default_action = {
 function! s:shortpath()
   let short = pathshorten(fnamemodify(getcwd(), ':~:.'))
   let slash = (s:is_win && !&shellslash) ? '\' : '/'
-  return empty(short) ? '~'.slash : short . (short =~ slash.'$' ? '' : slash)
+  return empty(short) ? '~'.slash : short . (short =~ '\'.slash.'$' ? '' : slash)
 endfunction
 
 function! s:cmd(bang, ...) abort


### PR DESCRIPTION
Fix for the regexp comparison for checking if directory filepath ends in a slash.
I need this issue resolved before porting it to `Files` in fzf.vim