### PR TITLE
Add MinGW 64 to install fzf in Windows 64-bit

### DIFF
--- a/install
+++ b/install
@@ -172,6 +172,7 @@ case "$archi" in
   OpenBSD\ *86)  download fzf-$version-openbsd_${binary_arch:-386}.tgz   ;;
   CYGWIN*\ *64)  download fzf-$version-windows_${binary_arch:-amd64}.zip ;;
   MINGW*\ *86)   download fzf-$version-windows_${binary_arch:-386}.zip   ;;
+  MINGW*\ *64)   download fzf-$version-windows_${binary_arch:-amd64}.zip ;;
   *)             binary_available=0 binary_error=1 ;;
 esac
 


### PR DESCRIPTION
Need it for installing fzf in Windows 64-bit if running sh.exe (msysgit) from cmd.exe or powershell.exe

```dosbatch
:: within cmd.exe terminal
sh .\install --bin
```