### PR TITLE
Use the terminal by default for nvim-0.2.1 or GVim (nightly)

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -389,7 +389,7 @@ try
   let use_height = has_key(dict, 'down') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let use_term = has('nvim-0.2.1') || (has('nvim') && !s:is_win)
+  let use_term = has('nvim-0.2.1') || (has('nvim') && !s:is_win) || (has('terminal') && has('gui_running') && has('patch-8.0.995'))
   let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0
@@ -647,7 +647,7 @@ function! s:execute_term(dict, command, temps) abort
       endif
     endif
   endfunction
-  function! fzf.on_exit(id, code, _event)
+  function! fzf.on_exit(id, code, ...)
     if s:getpos() == self.ppos " {'window': 'enew'}
       for [opt, val] in items(self.winopts)
         execute 'let' opt '=' val
@@ -692,7 +692,12 @@ function! s:execute_term(dict, command, temps) abort
     else
       let command = a:command
     endif
-    call termopen(command.s:term_marker, fzf)
+    let command .= s:term_marker
+    if has('nvim')
+      call termopen(command, fzf)
+    else
+      call term_start([&shell, &shellcmdflag, command], {'curwin': fzf.buf, 'exit_cb': function(fzf.on_exit)})
+    endif
   finally
     if s:present(a:dict, 'dir')
       lcd -

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -385,7 +385,7 @@ try
   let use_height = has_key(dict, 'down') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let use_term = has('nvim') && !s:is_win
+  let use_term = has('nvim-0.2.1') || (has('nvim') && !s:is_win)
   let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -685,7 +685,14 @@ function! s:execute_term(dict, command, temps) abort
     if s:present(a:dict, 'dir')
       execute 'lcd' s:escape(a:dict.dir)
     endif
-    call termopen(a:command.s:term_marker, fzf)
+    if s:is_win
+      let fzf.temps.batchfile = s:fzf_tempname().'.bat'
+      call writefile(s:wrap_cmds(a:command), fzf.temps.batchfile)
+      let command = fzf.temps.batchfile
+    else
+      let command = a:command
+    endif
+    call termopen(command.s:term_marker, fzf)
   finally
     if s:present(a:dict, 'dir')
       lcd -

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -389,7 +389,7 @@ try
   let use_height = has_key(dict, 'down') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let use_term = has('nvim-0.2.1') || (has('nvim') && !s:is_win) || (has('terminal') && has('gui_running') && has('patch-8.0.995'))
+  let use_term = has('nvim-0.2.1') || (has('nvim') && !s:is_win) || (has('terminal') && has('patch-8.0.995') && (has('gui_running') || s:is_win))
   let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -35,6 +35,8 @@ else
   let s:base_dir = expand('<sfile>:h:h')
 endif
 if s:is_win
+  let s:term_marker = '&::FZF'
+
   function! s:fzf_call(fn, ...)
     let shellslash = &shellslash
     try
@@ -53,6 +55,8 @@ if s:is_win
           \ ['chcp %origchcp% > nul']
   endfunction
 else
+  let s:term_marker = ";#FZF"
+
   function! s:fzf_call(fn, ...)
     return call(a:fn, a:000)
   endfunction
@@ -681,7 +685,7 @@ function! s:execute_term(dict, command, temps) abort
     if s:present(a:dict, 'dir')
       execute 'lcd' s:escape(a:dict.dir)
     endif
-    call termopen(a:command . ';#FZF', fzf)
+    call termopen(a:command.s:term_marker, fzf)
   finally
     if s:present(a:dict, 'dir')
       lcd -

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -400,6 +400,9 @@ try
     let optstr .= ' --height='.height
   elseif use_term
     let optstr .= ' --no-height'
+    if !has('nvim') && !s:is_win
+      let optstr .= ' --bind ctrl-j:accept'
+    endif
   endif
   let command = prefix.(use_tmux ? s:fzf_tmux(dict) : fzf_exec).' '.optstr.' > '.temps.result
 


### PR DESCRIPTION
Initial work to use the neovim terminal by default in Windows.
The double keypress remains for Windows 8+ because https://github.com/gdamore/tcell/pull/159 is unresolved.

I prefer to keep this open/unmerged until the 0.2.1 release while I test this with my pull requests in fzf.vim.

@mikesmiffy128 I cherry-pick the commit as you suggested in https://github.com/junegunn/fzf/pull/962#issuecomment-322936545