### PR TITLE
[vim] escape backslashes in fzf#shellescape

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -67,7 +67,7 @@ function! s:shellesc_cmd(arg)
   let escaped = substitute(escaped, '%', '%%', 'g')
   let escaped = substitute(escaped, '"', '\\^&', 'g')
   let escaped = substitute(escaped, '\\\+\(\\^\)', '\\\\\1', 'g')
-  return '^"'.substitute(escaped, '[^\\]\zs\\$', '\\\\', '').'^"'
+  return '^"'.substitute(escaped, '\\\+$', '\\\\', '').'^"'
 endfunction
 
 function! fzf#shellescape(arg, ...)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -66,8 +66,8 @@ function! s:shellesc_cmd(arg)
   let escaped = substitute(a:arg, '[&|<>()@^]', '^&', 'g')
   let escaped = substitute(escaped, '%', '%%', 'g')
   let escaped = substitute(escaped, '"', '\\^&', 'g')
-  let escaped = substitute(escaped, '\\\+\(\\^\)', '\\\\\1', 'g')
-  return '^"'.substitute(escaped, '\\\+$', '\\\\', '').'^"'
+  let escaped = substitute(escaped, '\(\\\+\)\(\\^\)', '\1\1\2', 'g')
+  return '^"'.substitute(escaped, '\(\\\+\)$', '\1\1', '').'^"'
 endfunction
 
 function! fzf#shellescape(arg, ...)

--- a/test/fzf.vader
+++ b/test/fzf.vader
@@ -152,7 +152,7 @@ Execute (fzf#shellescape with sh):
   AssertEqual '''\''', fzf#shellescape('\', 'sh')
   AssertEqual '''""''', fzf#shellescape('""', 'sh')
   AssertEqual '''foobar>''', fzf#shellescape('foobar>', 'sh')
-  AssertEqual '''\"''', fzf#shellescape('\"', 'sh')
+  AssertEqual '''\\\"\\\''', fzf#shellescape('\\\"\\\', 'sh')
   AssertEqual '''echo ''\''''a''\'''' && echo ''\''''b''\''''''', fzf#shellescape('echo ''a'' && echo ''b''', 'sh')
 
 Execute (fzf#shellescape with cmd.exe):
@@ -160,7 +160,7 @@ Execute (fzf#shellescape with cmd.exe):
   AssertEqual '^"\\^"', fzf#shellescape('\', 'cmd.exe')
   AssertEqual '^"\^"\^"^"', fzf#shellescape('""', 'cmd.exe')
   AssertEqual '^"foobar^>^"', fzf#shellescape('foobar>', 'cmd.exe')
-  AssertEqual '^"\\\^"\\^"', fzf#shellescape('\\\\\\\\"\', 'cmd.exe')
+  AssertEqual '^"\\\\\\\^"\\\\\\^"', fzf#shellescape('\\\"\\\', 'cmd.exe')
   AssertEqual '^"echo ''a'' ^&^& echo ''b''^"', fzf#shellescape('echo ''a'' && echo ''b''', 'cmd.exe')
 
   AssertEqual '^"C:\Program Files ^(x86^)\\^"', fzf#shellescape('C:\Program Files (x86)\', 'cmd.exe')

--- a/test/fzf.vader
+++ b/test/fzf.vader
@@ -149,6 +149,7 @@ Execute (fzf#wrap):
 
 Execute (fzf#shellescape with sh):
   AssertEqual '''''', fzf#shellescape('', 'sh')
+  AssertEqual '''\''', fzf#shellescape('\', 'sh')
   AssertEqual '''""''', fzf#shellescape('""', 'sh')
   AssertEqual '''foobar>''', fzf#shellescape('foobar>', 'sh')
   AssertEqual '''\"''', fzf#shellescape('\"', 'sh')
@@ -156,6 +157,7 @@ Execute (fzf#shellescape with sh):
 
 Execute (fzf#shellescape with cmd.exe):
   AssertEqual '^"^"', fzf#shellescape('', 'cmd.exe')
+  AssertEqual '^"\\^"', fzf#shellescape('\', 'cmd.exe')
   AssertEqual '^"\^"\^"^"', fzf#shellescape('""', 'cmd.exe')
   AssertEqual '^"foobar^>^"', fzf#shellescape('foobar>', 'cmd.exe')
   AssertEqual '^"\\\^"\\^"', fzf#shellescape('\\\\\\\\"\', 'cmd.exe')


### PR DESCRIPTION
Forgot to handle the single backslash case which breaks the surrounding `^"` to wrap the entire string.
A use case is searching for backslash in `Lines`, `BLines`.
Requires `s:q` using `fzf#shellescape` in fzf.vim (commit: https://github.com/janlazo/fzf.vim/commit/32756d271a580c9d189dcc8dd053f8dd0731d9c8)