### PR TITLE
add parens around piped source commands

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -366,7 +366,7 @@ try
     let source = dict.source
     let type = type(source)
     if type == 1
-      let prefix = source.'|'
+      let prefix = '( '.source.' )|'
     elseif type == 3
       let temps.input = s:fzf_tempname()
       call writefile(source, temps.input)


### PR DESCRIPTION
Previously a command like `echo a && echo b` would get transformed into
`echo a && echo b | fzf`, which only pipes the output of the second
command. Adding parentheses around the source command avoids this issue,
and works on both Unix and Windows.

Caveat: I haven't tested this change on Windows, just played with some example
commands in the cmd.exe terminal.