### PR TITLE
quick and dirty hack to make fzf work better with fish

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -366,7 +366,11 @@ try
     let source = dict.source
     let type = type(source)
     if type == 1
-      let prefix = '( '.source.' )|'
+      if (empty($SHELL) ? &shell : $SHELL) =~ "fish$"
+        let prefix = 'begin; '.source.'; end|'
+      else
+        let prefix = '( '.source.' )|'
+      end
     elseif type == 3
       let temps.input = s:fzf_tempname()
       call writefile(source, temps.input)


### PR DESCRIPTION
Hi,

I'm having some issues using `fzf` with `neovim` and `fish`. Turns out `fish` doesn't use parenthesis as delimiters but `begin` and `end`. Here is a quick and dirty workaround. There has got to be a better way but I didn't want to report this without proving at least a workaround.

Kind regards,
raichoo 