### PR TITLE
Add fzf-tmux pane_height/pane_width fallback

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -16,8 +16,8 @@ skip=""
 swap=""
 close=""
 term=""
-[[ -n "$LINES" ]] && lines=$LINES || lines=$(tput lines)
-[[ -n "$COLUMNS" ]] && columns=$COLUMNS || columns=$(tput cols)
+[[ -n "$LINES" ]] && lines=$LINES || lines=$(tput lines) || lines=$(tmux display-message -p "#{pane_height}")
+[[ -n "$COLUMNS" ]] && columns=$COLUMNS || columns=$(tput cols) || columns=$(tmux display-message -p "#{pane_width}")
 
 help() {
   >&2 echo 'usage: fzf-tmux [-u|-d [HEIGHT[%]]] [-l|-r [WIDTH[%]]] [--] [FZF OPTIONS]


### PR DESCRIPTION
Based on [this issue](https://github.com/junegunn/fzf/issues/1032).

Adds a fix to the fzf-tmux script for newer distros that use a particular version of `tput`, specifically Fedora 26 and Debian 10, which causes fzf-tmux to fail when run inside tmux's `run-shell` command.

The fix falls back to using tmux's `pane_width` and `pane_height` command to set the `$lines` and `$columns` variable, but only if `tput lines` or `tput cols` fails.

Dockerfile for verifying that this works:

```Dockerfile
FROM docker.io/fedora:26

RUN dnf install -y tmux git curl

RUN git clone https://github.com/mike-hearn/fzf ~/.fzf && \
        cd ~/.fzf && \
        git checkout fedora26-tput-fix && \
        ~/.fzf/install --all
```

