### PR TITLE
[vim] do not pathshorten prompt in cygwin

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -772,7 +772,10 @@ let s:default_action = {
   \ 'ctrl-v': 'vsplit' }
 
 function! s:shortpath()
-  let short = pathshorten(fnamemodify(getcwd(), ':~:.'))
+  let short = fnamemodify(getcwd(), ':~:.')
+  if !has('win32unix')
+    let short = pathshorten(short)
+  endif
   let slash = (s:is_win && !&shellslash) ? '\' : '/'
   return empty(short) ? '~'.slash : short . (short =~ escape(slash, '\').'$' ? '' : slash)
 endfunction


### PR DESCRIPTION
Cygwin converts unix-style paths to windows-style paths so `s:shortpath` shouldn't use `pathshorten` if `has('win32unix')`. `Files` has the same issue.

To reproduce
```sh
cd /usr/bin
fzf --prompt '/u/bin'
```