### PR TITLE
Exclude fzf binary from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/fzf
+bin/fzf*_*
 target
 pkg
 Gemfile.lock


### PR DESCRIPTION
Not necessary but a bit convenient for me because `bin/fzf-0.13.5-darwin_amd64` is dirtying my index.