### PR TITLE
Don't touch dotfiles if not requested

### DIFF
--- a/install
+++ b/install
@@ -305,20 +305,22 @@ append_line() {
   line="$2"
   file="$3"
   pat="${4:-}"
+  lno=""
 
   echo "Update $file:"
   echo "  - $line"
-  [ -f "$file" ] || touch "$file"
-  if [ $# -lt 4 ]; then
-    lno=$(\grep -nF "$line" "$file" | sed 's/:.*//' | tr '\n' ' ')
-  else
-    lno=$(\grep -nF "$pat" "$file" | sed 's/:.*//' | tr '\n' ' ')
+  if [ -f "$file" ]; then
+    if [ $# -lt 4 ]; then
+      lno=$(\grep -nF "$line" "$file" | sed 's/:.*//' | tr '\n' ' ')
+    else
+      lno=$(\grep -nF "$pat" "$file" | sed 's/:.*//' | tr '\n' ' ')
+    fi
   fi
   if [ -n "$lno" ]; then
     echo "    - Already exists: line #$lno"
   else
     if [ $update -eq 1 ]; then
-      echo >> "$file"
+      [ -f "$file" ] && echo >> "$file"
       echo "$line" >> "$file"
       echo "    + Added"
     else


### PR DESCRIPTION
If `.bashrc`/`.zshrc` doesn't exist, the install script will create an empty `.bashrc`/`.zshrc` even if `n` is answered to `Do you want to update your shell configuration files?`. This is a bit of unexpected behavior, e.g. a script which installs `fzf` and then symlinks `.zshrc` from somewhere else will fail.

Ex:
```
[ -f ~/.zshrc] && mv ~/.zshrc ~/.zshrc.bak
printf 'y\ny\nn\n' | ~/fzf/install
ln -s ~/dotfiles/.zshrc ~/.zshrc
```