### PR TITLE
[vim] Use string type so term_start does not escape command

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -699,7 +699,8 @@ function! s:execute_term(dict, command, temps) abort
     if has('nvim')
       call termopen(command, fzf)
     else
-      call term_start([&shell, &shellcmdflag, command], {'curwin': fzf.buf, 'exit_cb': function(fzf.on_exit)})
+      let cmds = [&shell, &shellcmdflag, command]
+      call term_start(s:is_win ? join(cmds) : cmds, {'curwin': fzf.buf, 'exit_cb': function(fzf.on_exit)})
     endif
   finally
     if s:present(a:dict, 'dir')


### PR DESCRIPTION
Workaround for Vim 8 terminal. Neovim does not have this issue.

Don't merge this yet.
I'm checking if this is actually required since the Vim plugin uses a temporary batchfile in Windows.
It's definitely required if there are no batchfiles.