### PR TITLE
Make fzf embedable

### DIFF
--- a/src/chunklist_test.go
+++ b/src/chunklist_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestChunkList(t *testing.T) {
 	// FIXME global
-	sortCriteria = []criterion{byScore, byLength}
+	sortCriteria = []Criterion{CriterionByScore, CriterionByLength}
 
 	cl := NewChunkList(func(item *Item, s []byte) bool {
 		item.text = util.ToChars(s)

--- a/src/command.go
+++ b/src/command.go
@@ -1,0 +1,125 @@
+package fzf
+
+import (
+	"os"
+	"strings"
+
+	"github.com/junegunn/fzf/src/util"
+)
+
+type Command interface {
+	GetPreview(stripAnsi bool, delimiter Delimiter, query string, allItems []*Item) string
+	HasPlusFlag() bool
+	Execute(withStdio bool, stripAnsi bool, delimiter Delimiter, forcePlus bool, query string, allItems []*Item)
+}
+
+type DefaultCommand struct {
+	command string
+}
+
+func NewDefaultCommand(command string) Command {
+	if len(command) == 0 {
+		return nil
+	}
+	return &DefaultCommand{command}
+}
+
+func (p *DefaultCommand) GetPreview(stripAnsi bool, delimiter Delimiter, query string, allItems []*Item) string {
+	command := replacePlaceholder(p.command,
+		stripAnsi, delimiter, false, query, allItems)
+	cmd := util.ExecCommand(command)
+	out, _ := cmd.CombinedOutput()
+	return string(out)
+}
+
+func (p *DefaultCommand) HasPlusFlag() bool {
+	for _, match := range placeholder.FindAllString(p.command, -1) {
+		if match[0] == '\\' {
+			continue
+		}
+		if match[1] == '+' {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *DefaultCommand) Execute(withStdio bool, stripAnsi bool, delimiter Delimiter, forcePlus bool, query string, allItems []*Item) {
+	command := replacePlaceholder(p.command, stripAnsi, delimiter, forcePlus, query, allItems)
+	cmd := util.ExecCommand(command)
+	if withStdio {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	cmd.Run()
+}
+
+func replacePlaceholder(template string, stripAnsi bool, delimiter Delimiter, forcePlus bool, query string, allItems []*Item) string {
+	current := allItems[:1]
+	selected := allItems[1:]
+	if current[0] == nil {
+		current = []*Item{}
+	}
+	if selected[0] == nil {
+		selected = []*Item{}
+	}
+	return placeholder.ReplaceAllStringFunc(template, func(match string) string {
+		// Escaped pattern
+		if match[0] == '\\' {
+			return match[1:]
+		}
+
+		// Current query
+		if match == "{q}" {
+			return quoteEntry(query)
+		}
+
+		plusFlag := forcePlus
+		if match[1] == '+' {
+			match = "{" + match[2:]
+			plusFlag = true
+		}
+		items := current
+		if plusFlag {
+			items = selected
+		}
+
+		replacements := make([]string, len(items))
+
+		if match == "{}" {
+			for idx, item := range items {
+				replacements[idx] = quoteEntry(item.AsString(stripAnsi))
+			}
+			return strings.Join(replacements, " ")
+		}
+
+		tokens := strings.Split(match[1:len(match)-1], ",")
+		ranges := make([]Range, len(tokens))
+		for idx, s := range tokens {
+			r, ok := ParseRange(&s)
+			if !ok {
+				// Invalid expression, just return the original string in the template
+				return match
+			}
+			ranges[idx] = r
+		}
+
+		for idx, item := range items {
+			tokens := Tokenize(item.AsString(stripAnsi), delimiter)
+			trans := Transform(tokens, ranges)
+			str := string(joinTokens(trans))
+			if delimiter.str != nil {
+				str = strings.TrimSuffix(str, *delimiter.str)
+			} else if delimiter.regex != nil {
+				delims := delimiter.regex.FindAllStringIndex(str, -1)
+				if len(delims) > 0 && delims[len(delims)-1][1] == len(str) {
+					str = str[:delims[len(delims)-1][0]]
+				}
+			}
+			str = strings.TrimSpace(str)
+			replacements[idx] = quoteEntry(str)
+		}
+		return strings.Join(replacements, " ")
+	})
+}

--- a/src/command.go
+++ b/src/command.go
@@ -109,10 +109,10 @@ func replacePlaceholder(template string, stripAnsi bool, delimiter Delimiter, fo
 			tokens := Tokenize(item.AsString(stripAnsi), delimiter)
 			trans := Transform(tokens, ranges)
 			str := string(joinTokens(trans))
-			if delimiter.str != nil {
-				str = strings.TrimSuffix(str, *delimiter.str)
-			} else if delimiter.regex != nil {
-				delims := delimiter.regex.FindAllStringIndex(str, -1)
+			if delimiter.Str != nil {
+				str = strings.TrimSuffix(str, *delimiter.Str)
+			} else if delimiter.Regex != nil {
+				delims := delimiter.Regex.FindAllStringIndex(str, -1)
 				if len(delims) > 0 && delims[len(delims)-1][1] == len(str) {
 					str = str[:delims[len(delims)-1][0]]
 				}

--- a/src/core.go
+++ b/src/core.go
@@ -118,7 +118,7 @@ func Run(opts *Options, revision string) {
 	// Reader
 	streamingFilter := opts.Filter != nil && !sort && !opts.Tac && !opts.Sync
 	if !streamingFilter {
-		reader := NewReader(func(data []byte) bool {
+		reader := opts.ReaderFactory(func(data []byte) bool {
 			return chunkList.Push(data)
 		}, eventBox, opts.ReadZero)
 		go reader.ReadSource()
@@ -153,7 +153,7 @@ func Run(opts *Options, revision string) {
 		found := false
 		if streamingFilter {
 			slab := util.MakeSlab(slab16Size, slab32Size)
-			reader := NewReader(
+			reader := opts.ReaderFactory(
 				func(runes []byte) bool {
 					item := Item{}
 					if chunkList.trans(&item, runes) {

--- a/src/core.go
+++ b/src/core.go
@@ -44,6 +44,8 @@ Matcher  -> EvtHeader         -> Terminal (update header)
 
 // Run starts fzf
 func Run(opts *Options, revision string) {
+	postProcessOptions(opts)
+
 	sort := opts.Sort > 0
 	sortCriteria = opts.Criteria
 

--- a/src/core.go
+++ b/src/core.go
@@ -127,11 +127,11 @@ func Run(opts *Options, revision string) {
 	// Matcher
 	forward := true
 	for _, cri := range opts.Criteria[1:] {
-		if cri == byEnd {
+		if cri == CriterionByEnd {
 			forward = false
 			break
 		}
-		if cri == byBegin {
+		if cri == CriterionByBegin {
 			break
 		}
 	}

--- a/src/options.go
+++ b/src/options.go
@@ -142,102 +142,105 @@ type PreviewOpts struct {
 
 // Options stores the values of command-line options
 type Options struct {
-	Fuzzy       bool
-	FuzzyAlgo   algo.Algo
-	Extended    bool
-	Case        Case
-	Normalize   bool
-	Nth         []Range
-	WithNth     []Range
-	Delimiter   Delimiter
-	Sort        int
-	Tac         bool
-	Criteria    []Criterion
-	Multi       bool
-	Ansi        bool
-	Mouse       bool
-	Theme       *tui.ColorTheme
-	Black       bool
-	Bold        bool
-	Height      SizeSpec
-	MinHeight   int
-	Reverse     bool
-	Cycle       bool
-	Hscroll     bool
-	HscrollOff  int
-	FileWord    bool
-	InlineInfo  bool
-	JumpLabels  string
-	Prompt      string
-	Query       string
-	Select1     bool
-	Exit0       bool
-	Filter      *string
-	ToggleSort  bool
-	Expect      map[int]string
-	Keymap      map[int][]Action
-	Preview     PreviewOpts
-	PrintQuery  bool
-	ReadZero    bool
-	Printer     func(string)
-	Sync        bool
-	History     *History
-	Header      []string
-	HeaderLines int
-	Margin      [4]SizeSpec
-	Bordered    bool
-	Tabstop     int
-	ClearOnExit bool
-	Version     bool
+	Fuzzy         bool
+	FuzzyAlgo     algo.Algo
+	Extended      bool
+	Case          Case
+	Normalize     bool
+	Nth           []Range
+	WithNth       []Range
+	Delimiter     Delimiter
+	Sort          int
+	Tac           bool
+	Criteria      []Criterion
+	Multi         bool
+	Ansi          bool
+	Mouse         bool
+	Theme         *tui.ColorTheme
+	Black         bool
+	Bold          bool
+	Height        SizeSpec
+	MinHeight     int
+	Reverse       bool
+	Cycle         bool
+	Hscroll       bool
+	HscrollOff    int
+	FileWord      bool
+	InlineInfo    bool
+	JumpLabels    string
+	Prompt        string
+	Query         string
+	Select1       bool
+	Exit0         bool
+	Filter        *string
+	ToggleSort    bool
+	Expect        map[int]string
+	Keymap        map[int][]Action
+	Preview       PreviewOpts
+	PrintQuery    bool
+	ReadZero      bool
+	Printer       func(string)
+	Sync          bool
+	History       *History
+	Header        []string
+	HeaderLines   int
+	Margin        [4]SizeSpec
+	Bordered      bool
+	Tabstop       int
+	ClearOnExit   bool
+	Version       bool
+	ReaderFactory ReaderFactory
 }
 
 func DefaultOptions() *Options {
 	return &Options{
-		Fuzzy:       true,
-		FuzzyAlgo:   algo.FuzzyMatchV2,
-		Extended:    true,
-		Case:        CaseSmart,
-		Normalize:   true,
-		Nth:         make([]Range, 0),
-		WithNth:     make([]Range, 0),
-		Delimiter:   Delimiter{},
-		Sort:        1000,
-		Tac:         false,
-		Criteria:    []Criterion{CriterionByScore, CriterionByLength},
-		Multi:       false,
-		Ansi:        false,
-		Mouse:       true,
-		Theme:       tui.EmptyTheme(),
-		Black:       false,
-		Bold:        true,
-		MinHeight:   10,
-		Reverse:     false,
-		Cycle:       false,
-		Hscroll:     true,
-		HscrollOff:  10,
-		FileWord:    false,
-		InlineInfo:  false,
-		JumpLabels:  defaultJumpLabels,
-		Prompt:      "> ",
-		Query:       "",
-		Select1:     false,
-		Exit0:       false,
-		Filter:      nil,
-		ToggleSort:  false,
-		Expect:      make(map[int]string),
-		Keymap:      make(map[int][]Action),
-		Preview:     PreviewOpts{"", posRight, SizeSpec{50, true}, false, false},
-		PrintQuery:  false,
-		ReadZero:    false,
-		Printer:     func(str string) { fmt.Println(str) },
-		Sync:        false,
-		History:     nil,
-		Header:      make([]string, 0),
-		HeaderLines: 0,
-		Margin:      defaultMargin(),
-		Tabstop:     8,
-		ClearOnExit: true,
-		Version:     false}
+		Fuzzy:         true,
+		FuzzyAlgo:     algo.FuzzyMatchV2,
+		Extended:      true,
+		Case:          CaseSmart,
+		Normalize:     true,
+		Nth:           make([]Range, 0),
+		WithNth:       make([]Range, 0),
+		Delimiter:     Delimiter{},
+		Sort:          1000,
+		Tac:           false,
+		Criteria:      []Criterion{CriterionByScore, CriterionByLength},
+		Multi:         false,
+		Ansi:          false,
+		Mouse:         true,
+		Theme:         tui.EmptyTheme(),
+		Black:         false,
+		Bold:          true,
+		MinHeight:     10,
+		Reverse:       false,
+		Cycle:         false,
+		Hscroll:       true,
+		HscrollOff:    10,
+		FileWord:      false,
+		InlineInfo:    false,
+		JumpLabels:    defaultJumpLabels,
+		Prompt:        "> ",
+		Query:         "",
+		Select1:       false,
+		Exit0:         false,
+		Filter:        nil,
+		ToggleSort:    false,
+		Expect:        make(map[int]string),
+		Keymap:        make(map[int][]Action),
+		Preview:       PreviewOpts{"", posRight, SizeSpec{50, true}, false, false},
+		PrintQuery:    false,
+		ReadZero:      false,
+		Printer:       func(str string) { fmt.Println(str) },
+		Sync:          false,
+		History:       nil,
+		Header:        make([]string, 0),
+		HeaderLines:   0,
+		Margin:        defaultMargin(),
+		Tabstop:       8,
+		ClearOnExit:   true,
+		Version:       false,
+		ReaderFactory: NewDefaultReader,
+	}
 }
 
 func help(code int) {

--- a/src/options.go
+++ b/src/options.go
@@ -1253,6 +1253,5 @@ func ParseOptions() *Options {
 	// Options from command-line arguments
 	parseOptions(opts, os.Args[1:])
 
-	postProcessOptions(opts)
 	return opts
 }

--- a/src/options.go
+++ b/src/options.go
@@ -336,17 +336,17 @@ func delimiterRegexp(str string) Delimiter {
 
 	// 1. Pattern does not contain any special character
 	if regexp.QuoteMeta(str) == str {
-		return Delimiter{str: &str}
+		return Delimiter{Str: &str}
 	}
 
 	rx, e := regexp.Compile(str)
 	// 2. Pattern is not a valid regular expression
 	if e != nil {
-		return Delimiter{str: &str}
+		return Delimiter{Str: &str}
 	}
 
 	// 3. Pattern as regular expression. Slow.
-	return Delimiter{regex: rx}
+	return Delimiter{Regex: rx}
 }
 
 func isAlphabet(char uint8) bool {
@@ -1232,7 +1232,7 @@ func postProcessOptions(opts *Options) {
 	// if it contains the whole range
 	if !opts.Extended || len(opts.Nth) == 1 {
 		for _, r := range opts.Nth {
-			if r.begin == rangeEllipsis && r.end == rangeEllipsis {
+			if r.Begin == rangeEllipsis && r.End == rangeEllipsis {
 				opts.Nth = make([]Range, 0)
 				return
 			}

--- a/src/options.go
+++ b/src/options.go
@@ -133,7 +133,7 @@ const (
 )
 
 type PreviewOpts struct {
-	Command  string
+	Command  Command
 	Position WindowPosition
 	Size     SizeSpec
 	Hidden   bool
@@ -227,7 +227,7 @@ func DefaultOptions() *Options {
 		ToggleSort:    false,
 		Expect:        make(map[int]string),
 		Keymap:        make(map[int][]Action),
-		Preview:       PreviewOpts{"", WindowPositionRight, SizeSpec{50, true}, false, false},
+		Preview:       PreviewOpts{nil, WindowPositionRight, SizeSpec{50, true}, false, false},
 		PrintQuery:    false,
 		ReadZero:      false,
 		Printer:       func(str string) { fmt.Println(str) },
@@ -763,13 +763,13 @@ func parseKeymap(keymap map[int][]Action, str string) {
 					}
 					if spec[offset] == ':' {
 						if specIndex == len(specs)-1 {
-							actions = append(actions, Action{t: t, a: spec[offset+1:]})
+							actions = append(actions, Action{t: t, a: NewDefaultCommand(spec[offset+1:])})
 						} else {
 							prevSpec = spec + "+"
 							continue
 						}
 					} else {
-						actions = append(actions, Action{t: t, a: spec[offset+1 : len(spec)-1]})
+						actions = append(actions, Action{t: t, a: NewDefaultCommand(spec[offset+1 : len(spec)-1])})
 					}
 				}
 			}
@@ -1092,9 +1092,9 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.HeaderLines = atoi(
 				nextString(allArgs, &i, "number of header lines required"))
 		case "--preview":
-			opts.Preview.Command = nextString(allArgs, &i, "preview command required")
+			opts.Preview.Command = NewDefaultCommand(nextString(allArgs, &i, "preview command required"))
 		case "--no-preview":
-			opts.Preview.Command = ""
+			opts.Preview.Command = nil
 		case "--preview-window":
 			parsePreviewWindow(&opts.Preview,
 				nextString(allArgs, &i, "preview window layout required: [up|down|left|right][:SIZE[%]][:wrap][:hidden]"))
@@ -1163,7 +1163,7 @@ func parseOptions(opts *Options, allArgs []string) {
 			} else if match, value := optString(arg, "--header-lines="); match {
 				opts.HeaderLines = atoi(value)
 			} else if match, value := optString(arg, "--preview="); match {
-				opts.Preview.Command = value
+				opts.Preview.Command = NewDefaultCommand(value)
 			} else if match, value := optString(arg, "--preview-window="); match {
 				parsePreviewWindow(&opts.Preview, value)
 			} else if match, value := optString(arg, "--margin="); match {

--- a/src/options.go
+++ b/src/options.go
@@ -123,21 +123,21 @@ func defaultMargin() [4]SizeSpec {
 	return [4]SizeSpec{}
 }
 
-type windowPosition int
+type WindowPosition int
 
 const (
-	posUp windowPosition = iota
-	posDown
-	posLeft
-	posRight
+	WindowPositionUp WindowPosition = iota
+	WindowPositionDown
+	WindowPositionLeft
+	WindowPositionRight
 )
 
 type PreviewOpts struct {
-	command  string
-	position windowPosition
-	size     SizeSpec
-	hidden   bool
-	wrap     bool
+	Command  string
+	Position WindowPosition
+	Size     SizeSpec
+	Hidden   bool
+	Wrap     bool
 }
 
 // Options stores the values of command-line options
@@ -227,7 +227,7 @@ func DefaultOptions() *Options {
 		ToggleSort:    false,
 		Expect:        make(map[int]string),
 		Keymap:        make(map[int][]Action),
-		Preview:       PreviewOpts{"", posRight, SizeSpec{50, true}, false, false},
+		Preview:       PreviewOpts{"", WindowPositionRight, SizeSpec{50, true}, false, false},
 		PrintQuery:    false,
 		ReadZero:      false,
 		Printer:       func(str string) { fmt.Println(str) },
@@ -845,41 +845,41 @@ func parseHeight(str string) SizeSpec {
 
 func parsePreviewWindow(opts *PreviewOpts, input string) {
 	// Default
-	opts.position = posRight
-	opts.size = SizeSpec{50, true}
-	opts.hidden = false
-	opts.wrap = false
+	opts.Position = WindowPositionRight
+	opts.Size = SizeSpec{50, true}
+	opts.Hidden = false
+	opts.Wrap = false
 
 	tokens := strings.Split(input, ":")
 	sizeRegex := regexp.MustCompile("^[0-9]+%?$")
 	for _, token := range tokens {
 		switch token {
 		case "hidden":
-			opts.hidden = true
+			opts.Hidden = true
 		case "wrap":
-			opts.wrap = true
+			opts.Wrap = true
 		case "up", "top":
-			opts.position = posUp
+			opts.Position = WindowPositionUp
 		case "down", "bottom":
-			opts.position = posDown
+			opts.Position = WindowPositionDown
 		case "left":
-			opts.position = posLeft
+			opts.Position = WindowPositionLeft
 		case "right":
-			opts.position = posRight
+			opts.Position = WindowPositionRight
 		default:
 			if sizeRegex.MatchString(token) {
-				opts.size = parseSize(token, 99, "window size")
+				opts.Size = parseSize(token, 99, "window size")
 			} else {
 				errorExit("invalid preview window layout: " + input)
 			}
 		}
 	}
-	if !opts.size.percent && opts.size.size > 0 {
+	if !opts.Size.percent && opts.Size.size > 0 {
 		// Adjust size for border
-		opts.size.size += 2
+		opts.Size.size += 2
 		// And padding
-		if opts.position == posLeft || opts.position == posRight {
-			opts.size.size += 2
+		if opts.Position == WindowPositionLeft || opts.Position == WindowPositionRight {
+			opts.Size.size += 2
 		}
 	}
 }
@@ -1092,9 +1092,9 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.HeaderLines = atoi(
 				nextString(allArgs, &i, "number of header lines required"))
 		case "--preview":
-			opts.Preview.command = nextString(allArgs, &i, "preview command required")
+			opts.Preview.Command = nextString(allArgs, &i, "preview command required")
 		case "--no-preview":
-			opts.Preview.command = ""
+			opts.Preview.Command = ""
 		case "--preview-window":
 			parsePreviewWindow(&opts.Preview,
 				nextString(allArgs, &i, "preview window layout required: [up|down|left|right][:SIZE[%]][:wrap][:hidden]"))
@@ -1163,7 +1163,7 @@ func parseOptions(opts *Options, allArgs []string) {
 			} else if match, value := optString(arg, "--header-lines="); match {
 				opts.HeaderLines = atoi(value)
 			} else if match, value := optString(arg, "--preview="); match {
-				opts.Preview.command = value
+				opts.Preview.Command = value
 			} else if match, value := optString(arg, "--preview-window="); match {
 				parsePreviewWindow(&opts.Preview, value)
 			} else if match, value := optString(arg, "--margin="); match {

--- a/src/options.go
+++ b/src/options.go
@@ -643,7 +643,7 @@ func parseKeymap(keymap map[int][]Action, str string) {
 		idx2 := len(pair[0]) + 1
 		specs := strings.Split(pair[1], "+")
 		actions := make([]Action, 0, len(specs))
-		appendAction := func(types ...actionType) {
+		appendAction := func(types ...ActionType) {
 			actions = append(actions, toActions(types...)...)
 		}
 		prevSpec := ""
@@ -654,122 +654,122 @@ func parseKeymap(keymap map[int][]Action, str string) {
 			specLower := strings.ToLower(spec)
 			switch specLower {
 			case "ignore":
-				appendAction(actIgnore)
+				appendAction(ActionTypeIgnore)
 			case "beginning-of-line":
-				appendAction(actBeginningOfLine)
+				appendAction(ActionTypeBeginningOfLine)
 			case "abort":
-				appendAction(actAbort)
+				appendAction(ActionTypeAbort)
 			case "accept":
-				appendAction(actAccept)
+				appendAction(ActionTypeAccept)
 			case "print-query":
-				appendAction(actPrintQuery)
+				appendAction(ActionTypePrintQuery)
 			case "backward-char":
-				appendAction(actBackwardChar)
+				appendAction(ActionTypeBackwardChar)
 			case "backward-delete-char":
-				appendAction(actBackwardDeleteChar)
+				appendAction(ActionTypeBackwardDeleteChar)
 			case "backward-word":
-				appendAction(actBackwardWord)
+				appendAction(ActionTypeBackwardWord)
 			case "clear-screen":
-				appendAction(actClearScreen)
+				appendAction(ActionTypeClearScreen)
 			case "delete-char":
-				appendAction(actDeleteChar)
+				appendAction(ActionTypeDeleteChar)
 			case "delete-char/eof":
-				appendAction(actDeleteCharEOF)
+				appendAction(ActionTypeDeleteCharEOF)
 			case "end-of-line":
-				appendAction(actEndOfLine)
+				appendAction(ActionTypeEndOfLine)
 			case "cancel":
-				appendAction(actCancel)
+				appendAction(ActionTypeCancel)
 			case "forward-char":
-				appendAction(actForwardChar)
+				appendAction(ActionTypeForwardChar)
 			case "forward-word":
-				appendAction(actForwardWord)
+				appendAction(ActionTypeForwardWord)
 			case "jump":
-				appendAction(actJump)
+				appendAction(ActionTypeJump)
 			case "jump-accept":
-				appendAction(actJumpAccept)
+				appendAction(ActionTypeJumpAccept)
 			case "kill-line":
-				appendAction(actKillLine)
+				appendAction(ActionTypeKillLine)
 			case "kill-word":
-				appendAction(actKillWord)
+				appendAction(ActionTypeKillWord)
 			case "unix-line-discard", "line-discard":
-				appendAction(actUnixLineDiscard)
+				appendAction(ActionTypeUnixLineDiscard)
 			case "unix-word-rubout", "word-rubout":
-				appendAction(actUnixWordRubout)
+				appendAction(ActionTypeUnixWordRubout)
 			case "yank":
-				appendAction(actYank)
+				appendAction(ActionTypeYank)
 			case "backward-kill-word":
-				appendAction(actBackwardKillWord)
+				appendAction(ActionTypeBackwardKillWord)
 			case "toggle-down":
-				appendAction(actToggle, actDown)
+				appendAction(ActionTypeToggle, ActionTypeDown)
 			case "toggle-up":
-				appendAction(actToggle, actUp)
+				appendAction(ActionTypeToggle, ActionTypeUp)
 			case "toggle-in":
-				appendAction(actToggleIn)
+				appendAction(ActionTypeToggleIn)
 			case "toggle-out":
-				appendAction(actToggleOut)
+				appendAction(ActionTypeToggleOut)
 			case "toggle-all":
-				appendAction(actToggleAll)
+				appendAction(ActionTypeToggleAll)
 			case "select-all":
-				appendAction(actSelectAll)
+				appendAction(ActionTypeSelectAll)
 			case "deselect-all":
-				appendAction(actDeselectAll)
+				appendAction(ActionTypeDeselectAll)
 			case "toggle":
-				appendAction(actToggle)
+				appendAction(ActionTypeToggle)
 			case "down":
-				appendAction(actDown)
+				appendAction(ActionTypeDown)
 			case "up":
-				appendAction(actUp)
+				appendAction(ActionTypeUp)
 			case "top":
-				appendAction(actTop)
+				appendAction(ActionTypeTop)
 			case "page-up":
-				appendAction(actPageUp)
+				appendAction(ActionTypePageUp)
 			case "page-down":
-				appendAction(actPageDown)
+				appendAction(ActionTypePageDown)
 			case "half-page-up":
-				appendAction(actHalfPageUp)
+				appendAction(ActionTypeHalfPageUp)
 			case "half-page-down":
-				appendAction(actHalfPageDown)
+				appendAction(ActionTypeHalfPageDown)
 			case "previous-history":
-				appendAction(actPreviousHistory)
+				appendAction(ActionTypePreviousHistory)
 			case "next-history":
-				appendAction(actNextHistory)
+				appendAction(ActionTypeNextHistory)
 			case "toggle-preview":
-				appendAction(actTogglePreview)
+				appendAction(ActionTypeTogglePreview)
 			case "toggle-preview-wrap":
-				appendAction(actTogglePreviewWrap)
+				appendAction(ActionTypeTogglePreviewWrap)
 			case "toggle-sort":
-				appendAction(actToggleSort)
+				appendAction(ActionTypeToggleSort)
 			case "preview-up":
-				appendAction(actPreviewUp)
+				appendAction(ActionTypePreviewUp)
 			case "preview-down":
-				appendAction(actPreviewDown)
+				appendAction(ActionTypePreviewDown)
 			case "preview-page-up":
-				appendAction(actPreviewPageUp)
+				appendAction(ActionTypePreviewPageUp)
 			case "preview-page-down":
-				appendAction(actPreviewPageDown)
+				appendAction(ActionTypePreviewPageDown)
 			default:
 				t := isExecuteAction(specLower)
-				if t == actIgnore {
+				if t == ActionTypeIgnore {
 					errorExit("unknown action: " + spec)
 				} else {
 					var offset int
 					switch t {
-					case actExecuteSilent:
+					case ActionTypeExecuteSilent:
 						offset = len("execute-silent")
-					case actExecuteMulti:
+					case ActionTypeExecuteMulti:
 						offset = len("execute-multi")
 					default:
 						offset = len("execute")
 					}
 					if spec[offset] == ':' {
 						if specIndex == len(specs)-1 {
-							actions = append(actions, Action{t: t, a: NewDefaultCommand(spec[offset+1:])})
+							actions = append(actions, Action{Type: t, Command: NewDefaultCommand(spec[offset+1:])})
 						} else {
 							prevSpec = spec + "+"
 							continue
 						}
 					} else {
-						actions = append(actions, Action{t: t, a: NewDefaultCommand(spec[offset+1 : len(spec)-1])})
+						actions = append(actions, Action{Type: t, Command: NewDefaultCommand(spec[offset+1 : len(spec)-1])})
 					}
 				}
 			}
@@ -779,10 +779,10 @@ func parseKeymap(keymap map[int][]Action, str string) {
 	}
 }
 
-func isExecuteAction(str string) actionType {
+func isExecuteAction(str string) ActionType {
 	matches := executeRegexp.FindAllStringSubmatch(":"+str, -1)
 	if matches == nil || len(matches) != 1 {
-		return actIgnore
+		return ActionTypeIgnore
 	}
 	prefix := matches[0][1]
 	if len(prefix) == 0 {
@@ -790,13 +790,13 @@ func isExecuteAction(str string) actionType {
 	}
 	switch prefix {
 	case "execute":
-		return actExecute
+		return ActionTypeExecute
 	case "execute-silent":
-		return actExecuteSilent
+		return ActionTypeExecuteSilent
 	case "execute-multi":
-		return actExecuteMulti
+		return ActionTypeExecuteMulti
 	}
-	return actIgnore
+	return ActionTypeIgnore
 }
 
 func parseToggleSort(keymap map[int][]Action, str string) {
@@ -804,7 +804,7 @@ func parseToggleSort(keymap map[int][]Action, str string) {
 	if len(keys) != 1 {
 		errorExit("multiple keys specified")
 	}
-	keymap[firstKey(keys)] = toActions(actToggleSort)
+	keymap[firstKey(keys)] = toActions(ActionTypeToggleSort)
 }
 
 func strLines(str string) []string {
@@ -1209,10 +1209,10 @@ func postProcessOptions(opts *Options) {
 	// Default actions for CTRL-N / CTRL-P when --history is set
 	if opts.History != nil {
 		if _, prs := opts.Keymap[tui.CtrlP]; !prs {
-			opts.Keymap[tui.CtrlP] = toActions(actPreviousHistory)
+			opts.Keymap[tui.CtrlP] = toActions(ActionTypePreviousHistory)
 		}
 		if _, prs := opts.Keymap[tui.CtrlN]; !prs {
-			opts.Keymap[tui.CtrlN] = toActions(actNextHistory)
+			opts.Keymap[tui.CtrlN] = toActions(ActionTypeNextHistory)
 		}
 	}
 
@@ -1220,7 +1220,7 @@ func postProcessOptions(opts *Options) {
 	keymap := defaultKeymap()
 	for key, actions := range opts.Keymap {
 		for _, act := range actions {
-			if act.t == actToggleSort {
+			if act.Type == ActionTypeToggleSort {
 				opts.ToggleSort = true
 			}
 		}

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -94,7 +94,7 @@ func TestSplitNth(t *testing.T) {
 
 func TestIrrelevantNth(t *testing.T) {
 	{
-		opts := defaultOptions()
+		opts := DefaultOptions()
 		words := []string{"--nth", "..", "-x"}
 		parseOptions(opts, words)
 		postProcessOptions(opts)
@@ -104,7 +104,7 @@ func TestIrrelevantNth(t *testing.T) {
 	}
 	for _, words := range [][]string{[]string{"--nth", "..,3", "+x"}, []string{"--nth", "3,1..", "+x"}, []string{"--nth", "..-1,1", "+x"}} {
 		{
-			opts := defaultOptions()
+			opts := DefaultOptions()
 			parseOptions(opts, words)
 			postProcessOptions(opts)
 			if len(opts.Nth) != 0 {
@@ -112,7 +112,7 @@ func TestIrrelevantNth(t *testing.T) {
 			}
 		}
 		{
-			opts := defaultOptions()
+			opts := DefaultOptions()
 			words = append(words, "-x")
 			parseOptions(opts, words)
 			postProcessOptions(opts)
@@ -326,7 +326,7 @@ func TestParseNilTheme(t *testing.T) {
 
 func TestDefaultCtrlNP(t *testing.T) {
 	check := func(words []string, key int, expected actionType) {
-		opts := defaultOptions()
+		opts := DefaultOptions()
 		parseOptions(opts, words)
 		postProcessOptions(opts)
 		if opts.Keymap[key][0].t != expected {
@@ -353,7 +353,7 @@ func TestDefaultCtrlNP(t *testing.T) {
 }
 
 func optsFor(words ...string) *Options {
-	opts := defaultOptions()
+	opts := DefaultOptions()
 	parseOptions(opts, words)
 	postProcessOptions(opts)
 	return opts

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -226,50 +226,50 @@ func TestParseKeysWithComma(t *testing.T) {
 
 func TestBind(t *testing.T) {
 	keymap := defaultKeymap()
-	check := func(keyName int, arg1 string, types ...actionType) {
+	check := func(keyName int, arg1 string, types ...ActionType) {
 		if len(keymap[keyName]) != len(types) {
 			t.Errorf("invalid number of actions (%d != %d)", len(types), len(keymap[keyName]))
 			return
 		}
 		for idx, action := range keymap[keyName] {
-			if types[idx] != action.t {
-				t.Errorf("invalid action type (%d != %d)", types[idx], action.t)
+			if types[idx] != action.Type {
+				t.Errorf("invalid action type (%d != %d)", types[idx], action.Type)
 			}
 		}
-		if len(arg1) > 0 && (keymap[keyName][0].a == nil || keymap[keyName][0].a.(*DefaultCommand).command != arg1) {
-			t.Errorf("invalid action argument: (%s != %s)", arg1, keymap[keyName][0].a)
+		if len(arg1) > 0 && (keymap[keyName][0].Command == nil || keymap[keyName][0].Command.(*DefaultCommand).command != arg1) {
+			t.Errorf("invalid action argument: (%s != %s)", arg1, keymap[keyName][0].Command)
 		}
 	}
-	check(tui.CtrlA, "", actBeginningOfLine)
+	check(tui.CtrlA, "", ActionTypeBeginningOfLine)
 	parseKeymap(keymap,
 		"ctrl-a:kill-line,ctrl-b:toggle-sort+up+down,c:page-up,alt-z:page-down,"+
 			"f1:execute(ls {})+abort,f2:execute/echo {}, {}, {}/,f3:execute[echo '({})'],f4:execute;less {};,"+
 			"alt-a:execute-Multi@echo (,),[,],/,:,;,%,{}@,alt-b:execute;echo (,),[,],/,:,@,%,{};,"+
 			"x:Execute(foo+bar),X:execute/bar+baz/"+
 			",,:abort,::accept,+:execute:++\nfoobar,Y:execute(baz)+up")
-	check(tui.CtrlA, "", actKillLine)
-	check(tui.CtrlB, "", actToggleSort, actUp, actDown)
-	check(tui.AltZ+'c', "", actPageUp)
-	check(tui.AltZ+',', "", actAbort)
-	check(tui.AltZ+':', "", actAccept)
-	check(tui.AltZ, "", actPageDown)
-	check(tui.F1, "ls {}", actExecute, actAbort)
-	check(tui.F2, "echo {}, {}, {}", actExecute)
-	check(tui.F3, "echo '({})'", actExecute)
-	check(tui.F4, "less {}", actExecute)
-	check(tui.AltZ+'x', "foo+bar", actExecute)
-	check(tui.AltZ+'X', "bar+baz", actExecute)
-	check(tui.AltA, "echo (,),[,],/,:,;,%,{}", actExecuteMulti)
-	check(tui.AltB, "echo (,),[,],/,:,@,%,{}", actExecute)
-	check(tui.AltZ+'+', "++\nfoobar,Y:execute(baz)+up", actExecute)
+	check(tui.CtrlA, "", ActionTypeKillLine)
+	check(tui.CtrlB, "", ActionTypeToggleSort, ActionTypeUp, ActionTypeDown)
+	check(tui.AltZ+'c', "", ActionTypePageUp)
+	check(tui.AltZ+',', "", ActionTypeAbort)
+	check(tui.AltZ+':', "", ActionTypeAccept)
+	check(tui.AltZ, "", ActionTypePageDown)
+	check(tui.F1, "ls {}", ActionTypeExecute, ActionTypeAbort)
+	check(tui.F2, "echo {}, {}, {}", ActionTypeExecute)
+	check(tui.F3, "echo '({})'", ActionTypeExecute)
+	check(tui.F4, "less {}", ActionTypeExecute)
+	check(tui.AltZ+'x', "foo+bar", ActionTypeExecute)
+	check(tui.AltZ+'X', "bar+baz", ActionTypeExecute)
+	check(tui.AltA, "echo (,),[,],/,:,;,%,{}", ActionTypeExecuteMulti)
+	check(tui.AltB, "echo (,),[,],/,:,@,%,{}", ActionTypeExecute)
+	check(tui.AltZ+'+', "++\nfoobar,Y:execute(baz)+up", ActionTypeExecute)
 
 	for idx, char := range []rune{'~', '!', '@', '#', '$', '%', '^', '&', '*', '|', ';', '/'} {
 		parseKeymap(keymap, fmt.Sprintf("%d:execute%cfoobar%c", idx%10, char, char))
-		check(tui.AltZ+int([]rune(fmt.Sprintf("%d", idx%10))[0]), "foobar", actExecute)
+		check(tui.AltZ+int([]rune(fmt.Sprintf("%d", idx%10))[0]), "foobar", ActionTypeExecute)
 	}
 
 	parseKeymap(keymap, "f1:abort")
-	check(tui.F1, "", actAbort)
+	check(tui.F1, "", ActionTypeAbort)
 }
 
 func TestColorSpec(t *testing.T) {
@@ -325,31 +325,31 @@ func TestParseNilTheme(t *testing.T) {
 }
 
 func TestDefaultCtrlNP(t *testing.T) {
-	check := func(words []string, key int, expected actionType) {
+	check := func(words []string, key int, expected ActionType) {
 		opts := DefaultOptions()
 		parseOptions(opts, words)
 		postProcessOptions(opts)
-		if opts.Keymap[key][0].t != expected {
+		if opts.Keymap[key][0].Type != expected {
 			t.Error()
 		}
 	}
-	check([]string{}, tui.CtrlN, actDown)
-	check([]string{}, tui.CtrlP, actUp)
+	check([]string{}, tui.CtrlN, ActionTypeDown)
+	check([]string{}, tui.CtrlP, ActionTypeUp)
 
-	check([]string{"--bind=ctrl-n:accept"}, tui.CtrlN, actAccept)
-	check([]string{"--bind=ctrl-p:accept"}, tui.CtrlP, actAccept)
+	check([]string{"--bind=ctrl-n:accept"}, tui.CtrlN, ActionTypeAccept)
+	check([]string{"--bind=ctrl-p:accept"}, tui.CtrlP, ActionTypeAccept)
 
 	f, _ := ioutil.TempFile("", "fzf-history")
 	f.Close()
 	hist := "--history=" + f.Name()
-	check([]string{hist}, tui.CtrlN, actNextHistory)
-	check([]string{hist}, tui.CtrlP, actPreviousHistory)
+	check([]string{hist}, tui.CtrlN, ActionTypeNextHistory)
+	check([]string{hist}, tui.CtrlP, ActionTypePreviousHistory)
 
-	check([]string{hist, "--bind=ctrl-n:accept"}, tui.CtrlN, actAccept)
-	check([]string{hist, "--bind=ctrl-n:accept"}, tui.CtrlP, actPreviousHistory)
+	check([]string{hist, "--bind=ctrl-n:accept"}, tui.CtrlN, ActionTypeAccept)
+	check([]string{hist, "--bind=ctrl-n:accept"}, tui.CtrlP, ActionTypePreviousHistory)
 
-	check([]string{hist, "--bind=ctrl-p:accept"}, tui.CtrlN, actNextHistory)
-	check([]string{hist, "--bind=ctrl-p:accept"}, tui.CtrlP, actAccept)
+	check([]string{hist, "--bind=ctrl-p:accept"}, tui.CtrlN, ActionTypeNextHistory)
+	check([]string{hist, "--bind=ctrl-p:accept"}, tui.CtrlP, ActionTypeAccept)
 }
 
 func optsFor(words ...string) *Options {

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -236,7 +236,7 @@ func TestBind(t *testing.T) {
 				t.Errorf("invalid action type (%d != %d)", types[idx], action.t)
 			}
 		}
-		if len(arg1) > 0 && keymap[keyName][0].a != arg1 {
+		if len(arg1) > 0 && (keymap[keyName][0].a == nil || keymap[keyName][0].a.(*DefaultCommand).command != arg1) {
 			t.Errorf("invalid action argument: (%s != %s)", arg1, keymap[keyName][0].a)
 		}
 	}
@@ -378,7 +378,7 @@ func TestToggle(t *testing.T) {
 
 func TestPreviewOpts(t *testing.T) {
 	opts := optsFor()
-	if !(opts.Preview.Command == "" &&
+	if !(opts.Preview.Command == nil &&
 		opts.Preview.Hidden == false &&
 		opts.Preview.Wrap == false &&
 		opts.Preview.Position == WindowPositionRight &&
@@ -387,7 +387,8 @@ func TestPreviewOpts(t *testing.T) {
 		t.Error()
 	}
 	opts = optsFor("--preview", "cat {}", "--preview-window=left:15:hidden:wrap")
-	if !(opts.Preview.Command == "cat {}" &&
+	if !(opts.Preview.Command != nil &&
+		opts.Preview.Command.(*DefaultCommand).command == "cat {}" &&
 		opts.Preview.Hidden == true &&
 		opts.Preview.Wrap == true &&
 		opts.Preview.Position == WindowPositionLeft &&
@@ -396,7 +397,7 @@ func TestPreviewOpts(t *testing.T) {
 		t.Error(opts.Preview)
 	}
 	opts = optsFor("--preview-window=up:15:wrap:hidden", "--preview-window=down")
-	if !(opts.Preview.Command == "" &&
+	if !(opts.Preview.Command == nil &&
 		opts.Preview.Hidden == false &&
 		opts.Preview.Wrap == false &&
 		opts.Preview.Position == WindowPositionDown &&
@@ -405,7 +406,7 @@ func TestPreviewOpts(t *testing.T) {
 		t.Error(opts.Preview)
 	}
 	opts = optsFor("--preview-window=up:15:wrap:hidden")
-	if !(opts.Preview.Command == "" &&
+	if !(opts.Preview.Command == nil &&
 		opts.Preview.Hidden == true &&
 		opts.Preview.Wrap == true &&
 		opts.Preview.Position == WindowPositionUp &&

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -11,32 +11,32 @@ import (
 func TestDelimiterRegex(t *testing.T) {
 	// Valid regex
 	delim := delimiterRegexp(".")
-	if delim.regex == nil || delim.str != nil {
+	if delim.Regex == nil || delim.Str != nil {
 		t.Error(delim)
 	}
 	// Broken regex -> string
 	delim = delimiterRegexp("[0-9")
-	if delim.regex != nil || *delim.str != "[0-9" {
+	if delim.Regex != nil || *delim.Str != "[0-9" {
 		t.Error(delim)
 	}
 	// Valid regex
 	delim = delimiterRegexp("[0-9]")
-	if delim.regex.String() != "[0-9]" || delim.str != nil {
+	if delim.Regex.String() != "[0-9]" || delim.Str != nil {
 		t.Error(delim)
 	}
 	// Tab character
 	delim = delimiterRegexp("\t")
-	if delim.regex != nil || *delim.str != "\t" {
+	if delim.Regex != nil || *delim.Str != "\t" {
 		t.Error(delim)
 	}
 	// Tab expression
 	delim = delimiterRegexp("\\t")
-	if delim.regex != nil || *delim.str != "\t" {
+	if delim.Regex != nil || *delim.Str != "\t" {
 		t.Error(delim)
 	}
 	// Tabs -> regex
 	delim = delimiterRegexp("\t+")
-	if delim.regex == nil || delim.str != nil {
+	if delim.Regex == nil || delim.Str != nil {
 		t.Error(delim)
 	}
 }
@@ -44,7 +44,7 @@ func TestDelimiterRegex(t *testing.T) {
 func TestDelimiterRegexString(t *testing.T) {
 	delim := delimiterRegexp("*")
 	tokens := Tokenize("-*--*---**---", delim)
-	if delim.regex != nil ||
+	if delim.Regex != nil ||
 		tokens[0].text.ToString() != "-*" ||
 		tokens[1].text.ToString() != "--*" ||
 		tokens[2].text.ToString() != "---*" ||
@@ -57,7 +57,7 @@ func TestDelimiterRegexString(t *testing.T) {
 func TestDelimiterRegexRegex(t *testing.T) {
 	delim := delimiterRegexp("--\\*")
 	tokens := Tokenize("-*--*---**---", delim)
-	if delim.str != nil ||
+	if delim.Str != nil ||
 		tokens[0].text.ToString() != "-*--*" ||
 		tokens[1].text.ToString() != "---*" ||
 		tokens[2].text.ToString() != "*---" {
@@ -69,24 +69,24 @@ func TestSplitNth(t *testing.T) {
 	{
 		ranges := splitNth("..")
 		if len(ranges) != 1 ||
-			ranges[0].begin != rangeEllipsis ||
-			ranges[0].end != rangeEllipsis {
+			ranges[0].Begin != rangeEllipsis ||
+			ranges[0].End != rangeEllipsis {
 			t.Errorf("%s", ranges)
 		}
 	}
 	{
 		ranges := splitNth("..3,1..,2..3,4..-1,-3..-2,..,2,-2,2..-2,1..-1")
 		if len(ranges) != 10 ||
-			ranges[0].begin != rangeEllipsis || ranges[0].end != 3 ||
-			ranges[1].begin != rangeEllipsis || ranges[1].end != rangeEllipsis ||
-			ranges[2].begin != 2 || ranges[2].end != 3 ||
-			ranges[3].begin != 4 || ranges[3].end != rangeEllipsis ||
-			ranges[4].begin != -3 || ranges[4].end != -2 ||
-			ranges[5].begin != rangeEllipsis || ranges[5].end != rangeEllipsis ||
-			ranges[6].begin != 2 || ranges[6].end != 2 ||
-			ranges[7].begin != -2 || ranges[7].end != -2 ||
-			ranges[8].begin != 2 || ranges[8].end != -2 ||
-			ranges[9].begin != rangeEllipsis || ranges[9].end != rangeEllipsis {
+			ranges[0].Begin != rangeEllipsis || ranges[0].End != 3 ||
+			ranges[1].Begin != rangeEllipsis || ranges[1].End != rangeEllipsis ||
+			ranges[2].Begin != 2 || ranges[2].End != 3 ||
+			ranges[3].Begin != 4 || ranges[3].End != rangeEllipsis ||
+			ranges[4].Begin != -3 || ranges[4].End != -2 ||
+			ranges[5].Begin != rangeEllipsis || ranges[5].End != rangeEllipsis ||
+			ranges[6].Begin != 2 || ranges[6].End != 2 ||
+			ranges[7].Begin != -2 || ranges[7].End != -2 ||
+			ranges[8].Begin != 2 || ranges[8].End != -2 ||
+			ranges[9].Begin != rangeEllipsis || ranges[9].End != rangeEllipsis {
 			t.Errorf("%s", ranges)
 		}
 	}

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -378,39 +378,39 @@ func TestToggle(t *testing.T) {
 
 func TestPreviewOpts(t *testing.T) {
 	opts := optsFor()
-	if !(opts.Preview.command == "" &&
-		opts.Preview.hidden == false &&
-		opts.Preview.wrap == false &&
-		opts.Preview.position == posRight &&
-		opts.Preview.size.percent == true &&
-		opts.Preview.size.size == 50) {
+	if !(opts.Preview.Command == "" &&
+		opts.Preview.Hidden == false &&
+		opts.Preview.Wrap == false &&
+		opts.Preview.Position == WindowPositionRight &&
+		opts.Preview.Size.percent == true &&
+		opts.Preview.Size.size == 50) {
 		t.Error()
 	}
 	opts = optsFor("--preview", "cat {}", "--preview-window=left:15:hidden:wrap")
-	if !(opts.Preview.command == "cat {}" &&
-		opts.Preview.hidden == true &&
-		opts.Preview.wrap == true &&
-		opts.Preview.position == posLeft &&
-		opts.Preview.size.percent == false &&
-		opts.Preview.size.size == 15+2+2) {
+	if !(opts.Preview.Command == "cat {}" &&
+		opts.Preview.Hidden == true &&
+		opts.Preview.Wrap == true &&
+		opts.Preview.Position == WindowPositionLeft &&
+		opts.Preview.Size.percent == false &&
+		opts.Preview.Size.size == 15+2+2) {
 		t.Error(opts.Preview)
 	}
 	opts = optsFor("--preview-window=up:15:wrap:hidden", "--preview-window=down")
-	if !(opts.Preview.command == "" &&
-		opts.Preview.hidden == false &&
-		opts.Preview.wrap == false &&
-		opts.Preview.position == posDown &&
-		opts.Preview.size.percent == true &&
-		opts.Preview.size.size == 50) {
+	if !(opts.Preview.Command == "" &&
+		opts.Preview.Hidden == false &&
+		opts.Preview.Wrap == false &&
+		opts.Preview.Position == WindowPositionDown &&
+		opts.Preview.Size.percent == true &&
+		opts.Preview.Size.size == 50) {
 		t.Error(opts.Preview)
 	}
 	opts = optsFor("--preview-window=up:15:wrap:hidden")
-	if !(opts.Preview.command == "" &&
-		opts.Preview.hidden == true &&
-		opts.Preview.wrap == true &&
-		opts.Preview.position == posUp &&
-		opts.Preview.size.percent == false &&
-		opts.Preview.size.size == 15+2) {
+	if !(opts.Preview.Command == "" &&
+		opts.Preview.Hidden == true &&
+		opts.Preview.Wrap == true &&
+		opts.Preview.Position == WindowPositionUp &&
+		opts.Preview.Size.percent == false &&
+		opts.Preview.Size.size == 15+2) {
 		t.Error(opts.Preview)
 	}
 }

--- a/src/reader.go
+++ b/src/reader.go
@@ -10,8 +10,14 @@ import (
 	"github.com/junegunn/fzf/src/util"
 )
 
+type Reader interface {
+	ReadSource()
+}
+
+type ReaderFactory func(pusher func([]byte) bool, eventBox *util.EventBox, delimNil bool) Reader
+
 // Reader reads from command or standard input
-type Reader struct {
+type DefaultReader struct {
 	pusher   func([]byte) bool
 	eventBox *util.EventBox
 	delimNil bool
@@ -19,11 +25,11 @@ type Reader struct {
 }
 
 // NewReader returns new Reader object
-func NewReader(pusher func([]byte) bool, eventBox *util.EventBox, delimNil bool) *Reader {
-	return &Reader{pusher, eventBox, delimNil, int32(EvtReady)}
+func NewDefaultReader(pusher func([]byte) bool, eventBox *util.EventBox, delimNil bool) Reader {
+	return &DefaultReader{pusher, eventBox, delimNil, int32(EvtReady)}
 }
 
-func (r *Reader) startEventPoller() {
+func (r *DefaultReader) startEventPoller() {
 	go func() {
 		ptr := &r.event
 		pollInterval := readerPollIntervalMin
@@ -44,13 +50,13 @@ func (r *Reader) startEventPoller() {
 	}()
 }
 
-func (r *Reader) fin(success bool) {
+func (r *DefaultReader) fin(success bool) {
 	atomic.StoreInt32(&r.event, int32(EvtReadFin))
 	r.eventBox.Set(EvtReadFin, success)
 }
 
 // ReadSource reads data from the default command or from standard input
-func (r *Reader) ReadSource() {
+func (r *DefaultReader) ReadSource() {
 	r.startEventPoller()
 	var success bool
 	if util.IsTty() {
@@ -65,7 +71,7 @@ func (r *Reader) ReadSource() {
 	r.fin(success)
 }
 
-func (r *Reader) feed(src io.Reader) {
+func (r *DefaultReader) feed(src io.Reader) {
 	delim := byte('\n')
 	if r.delimNil {
 		delim = '\000'
@@ -95,12 +101,12 @@ func (r *Reader) feed(src io.Reader) {
 	}
 }
 
-func (r *Reader) readFromStdin() bool {
+func (r *DefaultReader) readFromStdin() bool {
 	r.feed(os.Stdin)
 	return true
 }
 
-func (r *Reader) readFromCommand(cmd string) bool {
+func (r *DefaultReader) readFromCommand(cmd string) bool {
 	listCommand := util.ExecCommand(cmd)
 	out, err := listCommand.StdoutPipe()
 	if err != nil {

--- a/src/reader_test.go
+++ b/src/reader_test.go
@@ -10,7 +10,7 @@ import (
 func TestReadFromCommand(t *testing.T) {
 	strs := []string{}
 	eb := util.NewEventBox()
-	reader := Reader{
+	reader := DefaultReader{
 		pusher:   func(s []byte) bool { strs = append(strs, string(s)); return true },
 		eventBox: eb,
 		event:    int32(EvtReady)}

--- a/src/result.go
+++ b/src/result.go
@@ -48,12 +48,12 @@ func buildResult(item *Item, offsets []Offset, score int) Result {
 	for idx, criterion := range sortCriteria {
 		val := uint16(math.MaxUint16)
 		switch criterion {
-		case byScore:
+		case CriterionByScore:
 			// Higher is better
 			val = math.MaxUint16 - util.AsUint16(score)
-		case byLength:
+		case CriterionByLength:
 			val = item.TrimLength()
-		case byBegin, byEnd:
+		case CriterionByBegin, CriterionByEnd:
 			if validOffsetFound {
 				whitePrefixLen := 0
 				for idx := 0; idx < numChars; idx++ {
@@ -63,7 +63,7 @@ func buildResult(item *Item, offsets []Offset, score int) Result {
 						break
 					}
 				}
-				if criterion == byBegin {
+				if criterion == CriterionByBegin {
 					val = util.AsUint16(minEnd - whitePrefixLen)
 				} else {
 					val = util.AsUint16(math.MaxUint16 - math.MaxUint16*(maxEnd-whitePrefixLen)/int(item.TrimLength()))
@@ -77,7 +77,7 @@ func buildResult(item *Item, offsets []Offset, score int) Result {
 }
 
 // Sort criteria to use. Never changes once fzf is started.
-var sortCriteria []criterion
+var sortCriteria []Criterion
 
 // Index returns ordinal index of the Item
 func (result *Result) Index() int32 {

--- a/src/result_test.go
+++ b/src/result_test.go
@@ -54,7 +54,7 @@ func TestRankComparison(t *testing.T) {
 // Match length, string length, index
 func TestResultRank(t *testing.T) {
 	// FIXME global
-	sortCriteria = []criterion{byScore, byLength}
+	sortCriteria = []Criterion{CriterionByScore, CriterionByLength}
 
 	strs := [][]rune{[]rune("foo"), []rune("foobar"), []rune("bar"), []rune("baz")}
 	item1 := buildResult(

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -75,7 +75,7 @@ type Terminal struct {
 	toggleSort bool
 	delimiter  Delimiter
 	expect     map[int]string
-	keymap     map[int][]action
+	keymap     map[int][]Action
 	pressed    string
 	printQuery bool
 	history    *History
@@ -84,7 +84,7 @@ type Terminal struct {
 	header0    []string
 	ansi       bool
 	tabstop    int
-	margin     [4]sizeSpec
+	margin     [4]SizeSpec
 	strong     tui.Attr
 	bordered   bool
 	cleanExit  bool
@@ -103,7 +103,7 @@ type Terminal struct {
 	selected   map[int32]selectedItem
 	version    int64
 	reqBox     *util.EventBox
-	preview    previewOpts
+	preview    PreviewOpts
 	previewer  previewer
 	previewBox *util.EventBox
 	eventBox   *util.EventBox
@@ -155,7 +155,7 @@ const (
 	reqQuit
 )
 
-type action struct {
+type Action struct {
 	t actionType
 	a string
 }
@@ -219,16 +219,16 @@ const (
 	actTop
 )
 
-func toActions(types ...actionType) []action {
-	actions := make([]action, len(types))
+func toActions(types ...actionType) []Action {
+	actions := make([]Action, len(types))
 	for idx, t := range types {
-		actions[idx] = action{t: t, a: ""}
+		actions[idx] = Action{t: t, a: ""}
 	}
 	return actions
 }
 
-func defaultKeymap() map[int][]action {
-	keymap := make(map[int][]action)
+func defaultKeymap() map[int][]Action {
+	keymap := make(map[int][]Action)
 	keymap[tui.Invalid] = toActions(actInvalid)
 	keymap[tui.Resize] = toActions(actClearScreen)
 	keymap[tui.CtrlA] = toActions(actBeginningOfLine)
@@ -508,7 +508,7 @@ const (
 	maxDisplayWidthCalc = 1024
 )
 
-func calculateSize(base int, size sizeSpec, margin int, minSize int) int {
+func calculateSize(base int, size SizeSpec, margin int, minSize int) int {
 	max := base - margin
 	if size.percent {
 		return util.Constrain(int(float64(base)*0.01*size.size), minSize, max)
@@ -1486,8 +1486,8 @@ func (t *Terminal) Loop() {
 			}
 		}
 
-		var doAction func(action, int) bool
-		doActions := func(actions []action, mapkey int) bool {
+		var doAction func(Action, int) bool
+		doActions := func(actions []Action, mapkey int) bool {
 			for _, action := range actions {
 				if !doAction(action, mapkey) {
 					return false
@@ -1495,7 +1495,7 @@ func (t *Terminal) Loop() {
 			}
 			return true
 		}
-		doAction = func(a action, mapkey int) bool {
+		doAction = func(a Action, mapkey int) bool {
 			switch a.t {
 			case actIgnore:
 			case actExecute, actExecuteSilent:
@@ -1606,14 +1606,14 @@ func (t *Terminal) Loop() {
 				}
 			case actToggleIn:
 				if t.reverse {
-					return doAction(action{t: actToggleUp}, mapkey)
+					return doAction(Action{t: actToggleUp}, mapkey)
 				}
-				return doAction(action{t: actToggleDown}, mapkey)
+				return doAction(Action{t: actToggleDown}, mapkey)
 			case actToggleOut:
 				if t.reverse {
-					return doAction(action{t: actToggleDown}, mapkey)
+					return doAction(Action{t: actToggleDown}, mapkey)
 				}
-				return doAction(action{t: actToggleUp}, mapkey)
+				return doAction(Action{t: actToggleUp}, mapkey)
 			case actToggleDown:
 				if t.multi && t.merger.Length() > 0 {
 					toggle()

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -156,128 +156,128 @@ const (
 )
 
 type Action struct {
-	t actionType
-	a Command
+	Type    ActionType
+	Command Command
 }
 
-type actionType int
+type ActionType int
 
 const (
-	actIgnore actionType = iota
-	actInvalid
-	actRune
-	actMouse
-	actBeginningOfLine
-	actAbort
-	actAccept
-	actBackwardChar
-	actBackwardDeleteChar
-	actBackwardWord
-	actCancel
-	actClearScreen
-	actDeleteChar
-	actDeleteCharEOF
-	actEndOfLine
-	actForwardChar
-	actForwardWord
-	actKillLine
-	actKillWord
-	actUnixLineDiscard
-	actUnixWordRubout
-	actYank
-	actBackwardKillWord
-	actSelectAll
-	actDeselectAll
-	actToggle
-	actToggleAll
-	actToggleDown
-	actToggleUp
-	actToggleIn
-	actToggleOut
-	actDown
-	actUp
-	actPageUp
-	actPageDown
-	actHalfPageUp
-	actHalfPageDown
-	actJump
-	actJumpAccept
-	actPrintQuery
-	actToggleSort
-	actTogglePreview
-	actTogglePreviewWrap
-	actPreviewUp
-	actPreviewDown
-	actPreviewPageUp
-	actPreviewPageDown
-	actPreviousHistory
-	actNextHistory
-	actExecute
-	actExecuteSilent
-	actExecuteMulti // Deprecated
-	actSigStop
-	actTop
+	ActionTypeIgnore ActionType = iota
+	ActionTypeInvalid
+	ActionTypeRune
+	ActionTypeMouse
+	ActionTypeBeginningOfLine
+	ActionTypeAbort
+	ActionTypeAccept
+	ActionTypeBackwardChar
+	ActionTypeBackwardDeleteChar
+	ActionTypeBackwardWord
+	ActionTypeCancel
+	ActionTypeClearScreen
+	ActionTypeDeleteChar
+	ActionTypeDeleteCharEOF
+	ActionTypeEndOfLine
+	ActionTypeForwardChar
+	ActionTypeForwardWord
+	ActionTypeKillLine
+	ActionTypeKillWord
+	ActionTypeUnixLineDiscard
+	ActionTypeUnixWordRubout
+	ActionTypeYank
+	ActionTypeBackwardKillWord
+	ActionTypeSelectAll
+	ActionTypeDeselectAll
+	ActionTypeToggle
+	ActionTypeToggleAll
+	ActionTypeToggleDown
+	ActionTypeToggleUp
+	ActionTypeToggleIn
+	ActionTypeToggleOut
+	ActionTypeDown
+	ActionTypeUp
+	ActionTypePageUp
+	ActionTypePageDown
+	ActionTypeHalfPageUp
+	ActionTypeHalfPageDown
+	ActionTypeJump
+	ActionTypeJumpAccept
+	ActionTypePrintQuery
+	ActionTypeToggleSort
+	ActionTypeTogglePreview
+	ActionTypeTogglePreviewWrap
+	ActionTypePreviewUp
+	ActionTypePreviewDown
+	ActionTypePreviewPageUp
+	ActionTypePreviewPageDown
+	ActionTypePreviousHistory
+	ActionTypeNextHistory
+	ActionTypeExecute
+	ActionTypeExecuteSilent
+	ActionTypeExecuteMulti // Deprecated
+	ActionTypeSigStop
+	ActionTypeTop
 )
 
-func toActions(types ...actionType) []Action {
+func toActions(types ...ActionType) []Action {
 	actions := make([]Action, len(types))
 	for idx, t := range types {
-		actions[idx] = Action{t: t, a: nil}
+		actions[idx] = Action{Type: t, Command: nil}
 	}
 	return actions
 }
 
 func defaultKeymap() map[int][]Action {
 	keymap := make(map[int][]Action)
-	keymap[tui.Invalid] = toActions(actInvalid)
-	keymap[tui.Resize] = toActions(actClearScreen)
-	keymap[tui.CtrlA] = toActions(actBeginningOfLine)
-	keymap[tui.CtrlB] = toActions(actBackwardChar)
-	keymap[tui.CtrlC] = toActions(actAbort)
-	keymap[tui.CtrlG] = toActions(actAbort)
-	keymap[tui.CtrlQ] = toActions(actAbort)
-	keymap[tui.ESC] = toActions(actAbort)
-	keymap[tui.CtrlD] = toActions(actDeleteCharEOF)
-	keymap[tui.CtrlE] = toActions(actEndOfLine)
-	keymap[tui.CtrlF] = toActions(actForwardChar)
-	keymap[tui.CtrlH] = toActions(actBackwardDeleteChar)
-	keymap[tui.BSpace] = toActions(actBackwardDeleteChar)
-	keymap[tui.Tab] = toActions(actToggleDown)
-	keymap[tui.BTab] = toActions(actToggleUp)
-	keymap[tui.CtrlJ] = toActions(actDown)
-	keymap[tui.CtrlK] = toActions(actUp)
-	keymap[tui.CtrlL] = toActions(actClearScreen)
-	keymap[tui.CtrlM] = toActions(actAccept)
-	keymap[tui.CtrlN] = toActions(actDown)
-	keymap[tui.CtrlP] = toActions(actUp)
-	keymap[tui.CtrlU] = toActions(actUnixLineDiscard)
-	keymap[tui.CtrlW] = toActions(actUnixWordRubout)
-	keymap[tui.CtrlY] = toActions(actYank)
+	keymap[tui.Invalid] = toActions(ActionTypeInvalid)
+	keymap[tui.Resize] = toActions(ActionTypeClearScreen)
+	keymap[tui.CtrlA] = toActions(ActionTypeBeginningOfLine)
+	keymap[tui.CtrlB] = toActions(ActionTypeBackwardChar)
+	keymap[tui.CtrlC] = toActions(ActionTypeAbort)
+	keymap[tui.CtrlG] = toActions(ActionTypeAbort)
+	keymap[tui.CtrlQ] = toActions(ActionTypeAbort)
+	keymap[tui.ESC] = toActions(ActionTypeAbort)
+	keymap[tui.CtrlD] = toActions(ActionTypeDeleteCharEOF)
+	keymap[tui.CtrlE] = toActions(ActionTypeEndOfLine)
+	keymap[tui.CtrlF] = toActions(ActionTypeForwardChar)
+	keymap[tui.CtrlH] = toActions(ActionTypeBackwardDeleteChar)
+	keymap[tui.BSpace] = toActions(ActionTypeBackwardDeleteChar)
+	keymap[tui.Tab] = toActions(ActionTypeToggleDown)
+	keymap[tui.BTab] = toActions(ActionTypeToggleUp)
+	keymap[tui.CtrlJ] = toActions(ActionTypeDown)
+	keymap[tui.CtrlK] = toActions(ActionTypeUp)
+	keymap[tui.CtrlL] = toActions(ActionTypeClearScreen)
+	keymap[tui.CtrlM] = toActions(ActionTypeAccept)
+	keymap[tui.CtrlN] = toActions(ActionTypeDown)
+	keymap[tui.CtrlP] = toActions(ActionTypeUp)
+	keymap[tui.CtrlU] = toActions(ActionTypeUnixLineDiscard)
+	keymap[tui.CtrlW] = toActions(ActionTypeUnixWordRubout)
+	keymap[tui.CtrlY] = toActions(ActionTypeYank)
 	if !util.IsWindows() {
-		keymap[tui.CtrlZ] = toActions(actSigStop)
+		keymap[tui.CtrlZ] = toActions(ActionTypeSigStop)
 	}
 
-	keymap[tui.AltB] = toActions(actBackwardWord)
-	keymap[tui.SLeft] = toActions(actBackwardWord)
-	keymap[tui.AltF] = toActions(actForwardWord)
-	keymap[tui.SRight] = toActions(actForwardWord)
-	keymap[tui.AltD] = toActions(actKillWord)
-	keymap[tui.AltBS] = toActions(actBackwardKillWord)
+	keymap[tui.AltB] = toActions(ActionTypeBackwardWord)
+	keymap[tui.SLeft] = toActions(ActionTypeBackwardWord)
+	keymap[tui.AltF] = toActions(ActionTypeForwardWord)
+	keymap[tui.SRight] = toActions(ActionTypeForwardWord)
+	keymap[tui.AltD] = toActions(ActionTypeKillWord)
+	keymap[tui.AltBS] = toActions(ActionTypeBackwardKillWord)
 
-	keymap[tui.Up] = toActions(actUp)
-	keymap[tui.Down] = toActions(actDown)
-	keymap[tui.Left] = toActions(actBackwardChar)
-	keymap[tui.Right] = toActions(actForwardChar)
+	keymap[tui.Up] = toActions(ActionTypeUp)
+	keymap[tui.Down] = toActions(ActionTypeDown)
+	keymap[tui.Left] = toActions(ActionTypeBackwardChar)
+	keymap[tui.Right] = toActions(ActionTypeForwardChar)
 
-	keymap[tui.Home] = toActions(actBeginningOfLine)
-	keymap[tui.End] = toActions(actEndOfLine)
-	keymap[tui.Del] = toActions(actDeleteChar)
-	keymap[tui.PgUp] = toActions(actPageUp)
-	keymap[tui.PgDn] = toActions(actPageDown)
+	keymap[tui.Home] = toActions(ActionTypeBeginningOfLine)
+	keymap[tui.End] = toActions(ActionTypeEndOfLine)
+	keymap[tui.Del] = toActions(ActionTypeDeleteChar)
+	keymap[tui.PgUp] = toActions(ActionTypePageUp)
+	keymap[tui.PgDn] = toActions(ActionTypePageDown)
 
-	keymap[tui.Rune] = toActions(actRune)
-	keymap[tui.Mouse] = toActions(actMouse)
-	keymap[tui.DoubleClick] = toActions(actAccept)
+	keymap[tui.Rune] = toActions(ActionTypeRune)
+	keymap[tui.Mouse] = toActions(ActionTypeMouse)
+	keymap[tui.DoubleClick] = toActions(ActionTypeAccept)
 	return keymap
 }
 
@@ -1407,16 +1407,16 @@ func (t *Terminal) Loop() {
 			return true
 		}
 		doAction = func(a Action, mapkey int) bool {
-			switch a.t {
-			case actIgnore:
-			case actExecute, actExecuteSilent:
-				t.executeCommand(a.a, false, a.t == actExecuteSilent)
-			case actExecuteMulti:
-				t.executeCommand(a.a, true, false)
-			case actInvalid:
+			switch a.Type {
+			case ActionTypeIgnore:
+			case ActionTypeExecute, ActionTypeExecuteSilent:
+				t.executeCommand(a.Command, false, a.Type == ActionTypeExecuteSilent)
+			case ActionTypeExecuteMulti:
+				t.executeCommand(a.Command, true, false)
+			case ActionTypeInvalid:
 				t.mutex.Unlock()
 				return false
-			case actTogglePreview:
+			case ActionTypeTogglePreview:
 				if t.hasPreviewer() {
 					t.previewer.enabled = !t.previewer.enabled
 					t.tui.Clear()
@@ -1429,51 +1429,51 @@ func (t *Terminal) Loop() {
 					}
 					req(reqList, reqInfo, reqHeader)
 				}
-			case actTogglePreviewWrap:
+			case ActionTypeTogglePreviewWrap:
 				if t.hasPreviewWindow() {
 					t.preview.Wrap = !t.preview.Wrap
 					req(reqPreviewRefresh)
 				}
-			case actToggleSort:
+			case ActionTypeToggleSort:
 				t.sort = !t.sort
 				t.eventBox.Set(EvtSearchNew, t.sort)
 				t.mutex.Unlock()
 				return false
-			case actPreviewUp:
+			case ActionTypePreviewUp:
 				if t.hasPreviewWindow() {
 					scrollPreview(-1)
 				}
-			case actPreviewDown:
+			case ActionTypePreviewDown:
 				if t.hasPreviewWindow() {
 					scrollPreview(1)
 				}
-			case actPreviewPageUp:
+			case ActionTypePreviewPageUp:
 				if t.hasPreviewWindow() {
 					scrollPreview(-t.pwindow.Height())
 				}
-			case actPreviewPageDown:
+			case ActionTypePreviewPageDown:
 				if t.hasPreviewWindow() {
 					scrollPreview(t.pwindow.Height())
 				}
-			case actBeginningOfLine:
+			case ActionTypeBeginningOfLine:
 				t.cx = 0
-			case actBackwardChar:
+			case ActionTypeBackwardChar:
 				if t.cx > 0 {
 					t.cx--
 				}
-			case actPrintQuery:
+			case ActionTypePrintQuery:
 				req(reqPrintQuery)
-			case actAbort:
+			case ActionTypeAbort:
 				req(reqQuit)
-			case actDeleteChar:
+			case ActionTypeDeleteChar:
 				t.delChar()
-			case actDeleteCharEOF:
+			case ActionTypeDeleteCharEOF:
 				if !t.delChar() && t.cx == 0 {
 					req(reqQuit)
 				}
-			case actEndOfLine:
+			case ActionTypeEndOfLine:
 				t.cx = len(t.input)
-			case actCancel:
+			case ActionTypeCancel:
 				if len(t.input) == 0 {
 					req(reqQuit)
 				} else {
@@ -1481,144 +1481,144 @@ func (t *Terminal) Loop() {
 					t.input = []rune{}
 					t.cx = 0
 				}
-			case actForwardChar:
+			case ActionTypeForwardChar:
 				if t.cx < len(t.input) {
 					t.cx++
 				}
-			case actBackwardDeleteChar:
+			case ActionTypeBackwardDeleteChar:
 				if t.cx > 0 {
 					t.input = append(t.input[:t.cx-1], t.input[t.cx:]...)
 					t.cx--
 				}
-			case actSelectAll:
+			case ActionTypeSelectAll:
 				if t.multi {
 					for i := 0; i < t.merger.Length(); i++ {
 						t.selectItem(t.merger.Get(i).item)
 					}
 					req(reqList, reqInfo)
 				}
-			case actDeselectAll:
+			case ActionTypeDeselectAll:
 				if t.multi {
 					t.selected = make(map[int32]selectedItem)
 					t.version++
 					req(reqList, reqInfo)
 				}
-			case actToggle:
+			case ActionTypeToggle:
 				if t.multi && t.merger.Length() > 0 {
 					toggle()
 					req(reqList)
 				}
-			case actToggleAll:
+			case ActionTypeToggleAll:
 				if t.multi {
 					for i := 0; i < t.merger.Length(); i++ {
 						t.toggleItem(t.merger.Get(i).item)
 					}
 					req(reqList, reqInfo)
 				}
-			case actToggleIn:
+			case ActionTypeToggleIn:
 				if t.reverse {
-					return doAction(Action{t: actToggleUp}, mapkey)
+					return doAction(Action{Type: ActionTypeToggleUp}, mapkey)
 				}
-				return doAction(Action{t: actToggleDown}, mapkey)
-			case actToggleOut:
+				return doAction(Action{Type: ActionTypeToggleDown}, mapkey)
+			case ActionTypeToggleOut:
 				if t.reverse {
-					return doAction(Action{t: actToggleDown}, mapkey)
+					return doAction(Action{Type: ActionTypeToggleDown}, mapkey)
 				}
-				return doAction(Action{t: actToggleUp}, mapkey)
-			case actToggleDown:
+				return doAction(Action{Type: ActionTypeToggleUp}, mapkey)
+			case ActionTypeToggleDown:
 				if t.multi && t.merger.Length() > 0 {
 					toggle()
 					t.vmove(-1, true)
 					req(reqList)
 				}
-			case actToggleUp:
+			case ActionTypeToggleUp:
 				if t.multi && t.merger.Length() > 0 {
 					toggle()
 					t.vmove(1, true)
 					req(reqList)
 				}
-			case actDown:
+			case ActionTypeDown:
 				t.vmove(-1, true)
 				req(reqList)
-			case actUp:
+			case ActionTypeUp:
 				t.vmove(1, true)
 				req(reqList)
-			case actAccept:
+			case ActionTypeAccept:
 				req(reqClose)
-			case actClearScreen:
+			case ActionTypeClearScreen:
 				req(reqRedraw)
-			case actTop:
+			case ActionTypeTop:
 				t.vset(0)
 				req(reqList)
-			case actUnixLineDiscard:
+			case ActionTypeUnixLineDiscard:
 				if t.cx > 0 {
 					t.yanked = copySlice(t.input[:t.cx])
 					t.input = t.input[t.cx:]
 					t.cx = 0
 				}
-			case actUnixWordRubout:
+			case ActionTypeUnixWordRubout:
 				if t.cx > 0 {
 					t.rubout("\\s\\S")
 				}
-			case actBackwardKillWord:
+			case ActionTypeBackwardKillWord:
 				if t.cx > 0 {
 					t.rubout(t.wordRubout)
 				}
-			case actYank:
+			case ActionTypeYank:
 				suffix := copySlice(t.input[t.cx:])
 				t.input = append(append(t.input[:t.cx], t.yanked...), suffix...)
 				t.cx += len(t.yanked)
-			case actPageUp:
+			case ActionTypePageUp:
 				t.vmove(t.maxItems()-1, false)
 				req(reqList)
-			case actPageDown:
+			case ActionTypePageDown:
 				t.vmove(-(t.maxItems() - 1), false)
 				req(reqList)
-			case actHalfPageUp:
+			case ActionTypeHalfPageUp:
 				t.vmove(t.maxItems()/2, false)
 				req(reqList)
-			case actHalfPageDown:
+			case ActionTypeHalfPageDown:
 				t.vmove(-(t.maxItems() / 2), false)
 				req(reqList)
-			case actJump:
+			case ActionTypeJump:
 				t.jumping = jumpEnabled
 				req(reqJump)
-			case actJumpAccept:
+			case ActionTypeJumpAccept:
 				t.jumping = jumpAcceptEnabled
 				req(reqJump)
-			case actBackwardWord:
+			case ActionTypeBackwardWord:
 				t.cx = findLastMatch(t.wordRubout, string(t.input[:t.cx])) + 1
-			case actForwardWord:
+			case ActionTypeForwardWord:
 				t.cx += findFirstMatch(t.wordNext, string(t.input[t.cx:])) + 1
-			case actKillWord:
+			case ActionTypeKillWord:
 				ncx := t.cx +
 					findFirstMatch(t.wordNext, string(t.input[t.cx:])) + 1
 				if ncx > t.cx {
 					t.yanked = copySlice(t.input[t.cx:ncx])
 					t.input = append(t.input[:t.cx], t.input[ncx:]...)
 				}
-			case actKillLine:
+			case ActionTypeKillLine:
 				if t.cx < len(t.input) {
 					t.yanked = copySlice(t.input[t.cx:])
 					t.input = t.input[:t.cx]
 				}
-			case actRune:
+			case ActionTypeRune:
 				prefix := copySlice(t.input[:t.cx])
 				t.input = append(append(prefix, event.Char), t.input[t.cx:]...)
 				t.cx++
-			case actPreviousHistory:
+			case ActionTypePreviousHistory:
 				if t.history != nil {
 					t.history.override(string(t.input))
 					t.input = trimQuery(t.history.previous())
 					t.cx = len(t.input)
 				}
-			case actNextHistory:
+			case ActionTypeNextHistory:
 				if t.history != nil {
 					t.history.override(string(t.input))
 					t.input = trimQuery(t.history.next())
 					t.cx = len(t.input)
 				}
-			case actSigStop:
+			case ActionTypeSigStop:
 				p, err := os.FindProcess(os.Getpid())
 				if err == nil {
 					t.tui.Clear()
@@ -1627,7 +1627,7 @@ func (t *Terminal) Loop() {
 					t.mutex.Unlock()
 					return false
 				}
-			case actMouse:
+			case ActionTypeMouse:
 				me := event.MouseEvent
 				mx, my := me.X, me.Y
 				if me.S != 0 {

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -301,7 +301,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		delay = initialDelay
 	}
 	var previewBox *util.EventBox
-	if len(opts.Preview.command) > 0 {
+	if len(opts.Preview.Command) > 0 {
 		previewBox = util.NewEventBox()
 	}
 	strongAttr := tui.Bold
@@ -327,7 +327,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 			}
 
 			effectiveMinHeight := minHeight
-			if previewBox != nil && (opts.Preview.position == posUp || opts.Preview.position == posDown) {
+			if previewBox != nil && (opts.Preview.Position == WindowPositionUp || opts.Preview.Position == WindowPositionDown) {
 				effectiveMinHeight *= 2
 			}
 			if opts.InlineInfo {
@@ -388,7 +388,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		selected:   make(map[int32]selectedItem),
 		reqBox:     util.NewEventBox(),
 		preview:    opts.Preview,
-		previewer:  previewer{"", 0, 0, previewBox != nil && !opts.Preview.hidden},
+		previewer:  previewer{"", 0, 0, previewBox != nil && !opts.Preview.Hidden},
 		previewBox: previewBox,
 		eventBox:   eventBox,
 		mutex:      sync.Mutex{},
@@ -548,14 +548,14 @@ func (t *Terminal) resizeWindows() {
 		}
 	}
 
-	previewVisible := t.isPreviewEnabled() && t.preview.size.size > 0
+	previewVisible := t.isPreviewEnabled() && t.preview.Size.size > 0
 	minAreaWidth := minWidth
 	minAreaHeight := minHeight
 	if previewVisible {
-		switch t.preview.position {
-		case posUp, posDown:
+		switch t.preview.Position {
+		case WindowPositionUp, WindowPositionDown:
 			minAreaHeight *= 2
-		case posLeft, posRight:
+		case WindowPositionLeft, WindowPositionRight:
 			minAreaWidth *= 2
 		}
 	}
@@ -588,30 +588,30 @@ func (t *Terminal) resizeWindows() {
 			// ncurses auto-wraps the line when the cursor reaches the right-end of
 			// the window. To prevent unintended line-wraps, we use the width one
 			// column larger than the desired value.
-			if !t.preview.wrap && t.tui.DoesAutoWrap() {
+			if !t.preview.Wrap && t.tui.DoesAutoWrap() {
 				pwidth += 1
 			}
 			t.pwindow = t.tui.NewWindow(y+1, x+2, pwidth, h-2, tui.BorderNone)
 			os.Setenv("FZF_PREVIEW_HEIGHT", strconv.Itoa(h-2))
 		}
-		switch t.preview.position {
-		case posUp:
-			pheight := calculateSize(height, t.preview.size, minHeight, 3)
+		switch t.preview.Position {
+		case WindowPositionUp:
+			pheight := calculateSize(height, t.preview.Size, minHeight, 3)
 			t.window = t.tui.NewWindow(
 				marginInt[0]+pheight, marginInt[3], width, height-pheight, tui.BorderNone)
 			createPreviewWindow(marginInt[0], marginInt[3], width, pheight)
-		case posDown:
-			pheight := calculateSize(height, t.preview.size, minHeight, 3)
+		case WindowPositionDown:
+			pheight := calculateSize(height, t.preview.Size, minHeight, 3)
 			t.window = t.tui.NewWindow(
 				marginInt[0], marginInt[3], width, height-pheight, tui.BorderNone)
 			createPreviewWindow(marginInt[0]+height-pheight, marginInt[3], width, pheight)
-		case posLeft:
-			pwidth := calculateSize(width, t.preview.size, minWidth, 5)
+		case WindowPositionLeft:
+			pwidth := calculateSize(width, t.preview.Size, minWidth, 5)
 			t.window = t.tui.NewWindow(
 				marginInt[0], marginInt[3]+pwidth, width-pwidth, height, tui.BorderNone)
 			createPreviewWindow(marginInt[0], marginInt[3], pwidth, height)
-		case posRight:
-			pwidth := calculateSize(width, t.preview.size, minWidth, 5)
+		case WindowPositionRight:
+			pwidth := calculateSize(width, t.preview.Size, minWidth, 5)
 			t.window = t.tui.NewWindow(
 				marginInt[0], marginInt[3], width-pwidth, height, tui.BorderNone)
 			createPreviewWindow(marginInt[0], marginInt[3]+width-pwidth, pwidth, height)
@@ -983,7 +983,7 @@ func (t *Terminal) printPreview() {
 			var fillRet tui.FillReturn
 			_, _, ansi = extractColor(line, ansi, func(str string, ansi *ansiState) bool {
 				trimmed := []rune(str)
-				if !t.preview.wrap {
+				if !t.preview.Wrap {
 					trimmed, _ = t.trimRight(trimmed, maxWidth-t.pwindow.X())
 				}
 				str, _ = t.processTabs(trimmed, 0)
@@ -1355,7 +1355,7 @@ func (t *Terminal) Loop() {
 				})
 				// We don't display preview window if no match
 				if request[0] != nil {
-					command := replacePlaceholder(t.preview.command,
+					command := replacePlaceholder(t.preview.Command,
 						t.ansi, t.delimiter, false, string(t.input), request)
 					cmd := util.ExecCommand(command)
 					out, _ := cmd.CombinedOutput()
@@ -1403,7 +1403,7 @@ func (t *Terminal) Loop() {
 							version = t.version
 							focused = currentFocus
 							if t.isPreviewEnabled() {
-								_, list := t.buildPlusList(t.preview.command, false)
+								_, list := t.buildPlusList(t.preview.Command, false)
 								t.previewBox.Set(reqPreviewEnqueue, list)
 							}
 						}
@@ -1511,7 +1511,7 @@ func (t *Terminal) Loop() {
 					t.tui.Clear()
 					t.resizeWindows()
 					if t.previewer.enabled {
-						valid, list := t.buildPlusList(t.preview.command, false)
+						valid, list := t.buildPlusList(t.preview.Command, false)
 						if valid {
 							t.previewBox.Set(reqPreviewEnqueue, list)
 						}
@@ -1520,7 +1520,7 @@ func (t *Terminal) Loop() {
 				}
 			case actTogglePreviewWrap:
 				if t.hasPreviewWindow() {
-					t.preview.wrap = !t.preview.wrap
+					t.preview.Wrap = !t.preview.Wrap
 					req(reqPreviewRefresh)
 				}
 			case actToggleSort:

--- a/src/terminal_test.go
+++ b/src/terminal_test.go
@@ -82,12 +82,12 @@ func TestReplacePlaceholder(t *testing.T) {
 
 	// String delimiter
 	delim := "'"
-	result = replacePlaceholder("echo {}/{1}/{2}", true, Delimiter{str: &delim}, false, "query", items1)
+	result = replacePlaceholder("echo {}/{1}/{2}", true, Delimiter{Str: &delim}, false, "query", items1)
 	check("echo '  foo'\\''bar baz'/'foo'/'bar baz'")
 
 	// Regex delimiter
 	regex := regexp.MustCompile("[oa]+")
 	// foo'bar baz
-	result = replacePlaceholder("echo {}/{1}/{3}/{2..3}", true, Delimiter{regex: regex}, false, "query", items1)
+	result = replacePlaceholder("echo {}/{1}/{3}/{2..3}", true, Delimiter{Regex: regex}, false, "query", items1)
 	check("echo '  foo'\\''bar baz'/'f'/'r b'/''\\''bar b'")
 }

--- a/src/tokenizer.go
+++ b/src/tokenizer.go
@@ -13,8 +13,8 @@ const rangeEllipsis = 0
 
 // Range represents nth-expression
 type Range struct {
-	begin int
-	end   int
+	Begin int
+	End   int
 }
 
 // Token contains the tokenized part of the strings and its prefix length
@@ -25,8 +25,8 @@ type Token struct {
 
 // Delimiter for tokenizing the input
 type Delimiter struct {
-	regex *regexp.Regexp
-	str   *string
+	Regex *regexp.Regexp
+	Str   *string
 }
 
 func newRange(begin int, end int) Range {
@@ -132,21 +132,21 @@ func awkTokenizer(input string) ([]string, int) {
 
 // Tokenize tokenizes the given string with the delimiter
 func Tokenize(text string, delimiter Delimiter) []Token {
-	if delimiter.str == nil && delimiter.regex == nil {
+	if delimiter.Str == nil && delimiter.Regex == nil {
 		// AWK-style (\S+\s*)
 		tokens, prefixLength := awkTokenizer(text)
 		return withPrefixLengths(tokens, prefixLength)
 	}
 
-	if delimiter.str != nil {
-		return withPrefixLengths(strings.SplitAfter(text, *delimiter.str), 0)
+	if delimiter.Str != nil {
+		return withPrefixLengths(strings.SplitAfter(text, *delimiter.Str), 0)
 	}
 
 	// FIXME performance
 	var tokens []string
-	if delimiter.regex != nil {
+	if delimiter.Regex != nil {
 		for len(text) > 0 {
-			loc := delimiter.regex.FindStringIndex(text)
+			loc := delimiter.Regex.FindStringIndex(text)
 			if len(loc) < 2 {
 				loc = []int{0, len(text)}
 			}
@@ -173,8 +173,8 @@ func Transform(tokens []Token, withNth []Range) []Token {
 	for idx, r := range withNth {
 		parts := []*util.Chars{}
 		minIdx := 0
-		if r.begin == r.end {
-			idx := r.begin
+		if r.Begin == r.End {
+			idx := r.Begin
 			if idx == rangeEllipsis {
 				chars := util.ToChars([]byte(joinTokens(tokens)))
 				parts = append(parts, &chars)
@@ -189,18 +189,18 @@ func Transform(tokens []Token, withNth []Range) []Token {
 			}
 		} else {
 			var begin, end int
-			if r.begin == rangeEllipsis { // ..N
-				begin, end = 1, r.end
+			if r.Begin == rangeEllipsis { // ..N
+				begin, end = 1, r.End
 				if end < 0 {
 					end += numTokens + 1
 				}
-			} else if r.end == rangeEllipsis { // N..
-				begin, end = r.begin, numTokens
+			} else if r.End == rangeEllipsis { // N..
+				begin, end = r.Begin, numTokens
 				if begin < 0 {
 					begin += numTokens + 1
 				}
 			} else {
-				begin, end = r.begin, r.end
+				begin, end = r.Begin, r.End
 				if begin < 0 {
 					begin += numTokens + 1
 				}

--- a/src/tokenizer_test.go
+++ b/src/tokenizer_test.go
@@ -8,35 +8,35 @@ func TestParseRange(t *testing.T) {
 	{
 		i := ".."
 		r, _ := ParseRange(&i)
-		if r.begin != rangeEllipsis || r.end != rangeEllipsis {
+		if r.Begin != rangeEllipsis || r.End != rangeEllipsis {
 			t.Errorf("%s", r)
 		}
 	}
 	{
 		i := "3.."
 		r, _ := ParseRange(&i)
-		if r.begin != 3 || r.end != rangeEllipsis {
+		if r.Begin != 3 || r.End != rangeEllipsis {
 			t.Errorf("%s", r)
 		}
 	}
 	{
 		i := "3..5"
 		r, _ := ParseRange(&i)
-		if r.begin != 3 || r.end != 5 {
+		if r.Begin != 3 || r.End != 5 {
 			t.Errorf("%s", r)
 		}
 	}
 	{
 		i := "-3..-5"
 		r, _ := ParseRange(&i)
-		if r.begin != -3 || r.end != -5 {
+		if r.Begin != -3 || r.End != -5 {
 			t.Errorf("%s", r)
 		}
 	}
 	{
 		i := "3"
 		r, _ := ParseRange(&i)
-		if r.begin != 3 || r.end != 3 {
+		if r.Begin != 3 || r.End != 3 {
 			t.Errorf("%s", r)
 		}
 	}


### PR DESCRIPTION
Not so much a Pull-Request but rather a request for comment.

I wanted to embed/include the fzf-"ui" in one of my projects and encountered several quirks.

What I wanted:
* Invoke fzf.Run with Options created/set programmatically. (Unluckily plenty of things are not accessible from other packages)
* Feed the searcher programmatically
* Have a preview without spawning a process
* React to some specially keybindings (e.g. Ctrl-Space should invoke a go function rather than execute something)

Changes I made to achieve this:
* Reader is now an interface so that fzf can be feeded by some other means than stdin or the output of an executable. There is now an additional implementation using a go channel (chan []byte)
* There is now a Command interface so that fzf can trigger some go func rather than "just" running an executable. This applies to actions as well as the preview.
* All settings and inner types of Option are now public. Actually that is the bulk of the the changes

I admit that the result is not a very clean API, but nevertheless it is usable.