### PR TITLE
Executes fzf from fzf-tmux with a process name

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -178,14 +178,14 @@ if [[ -n "$term" ]] || [[ -t 0 ]]; then
   cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf
   TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
-    split-window $opt "cd $(printf %q "$PWD");$envs bash $argsf" $swap \
+    split-window $opt "$envs bash -c 'cd $(printf %q "$PWD"); exec -a fzf bash $argsf'" $swap \
     > /dev/null 2>&1
 else
   mkfifo $fifo1
   cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" >> $argsf
   TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
-    split-window $opt "$envs bash $argsf" $swap \
+    split-window $opt "$envs bash -c 'exec -a fzf bash $argsf'" $swap \
     > /dev/null 2>&1
   cat <&0 > $fifo1 &
 fi


### PR DESCRIPTION
This is a little improvement useful for my use case, but feel free declining it.
I'm a [tmux](https://github.com/tmux/tmux/wiki) user and I uses a key binding which depending on the current execution process does several things.

```tmux
is_fzf='echo "#{pane_current_command}" | grep -iqE "(^|\/)fzf$"'

bind -n C-h run-shell "($is_vim && tmux send-keys C-h) || \
                 ($is_fzf && tmux send-keys C-h) || \
                 ($is_zsh_prompt && tmux send-keys C-h) || \
                 tmux select-pane -L"

```

Currently if fzf is the current execution process, the process name is ``bash``. With these changes the process name is ``fzf`` and I'm able to capture it in tmux.