### PR TITLE
[vim](fix): revert changes that break  fzf#call

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -389,8 +389,7 @@ try
   let use_height = has_key(dict, 'down') && !has('gui_running') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right', 'window')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let has_term = has('nvim-0.2.1') || has('nvim') && !s:is_win || has('terminal') && has('patch-8.0.995')
-  let use_term = has_term && (has('gui_running') || s:is_win || !use_height && s:present(dict, 'down', 'up', 'left', 'right', 'window'))
+  let use_term = has('nvim-0.2.1') || (has('nvim') && !s:is_win) || (has('terminal') && has('patch-8.0.995') && (has('gui_running') || s:is_win))
   let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0


### PR DESCRIPTION
fzf#call stopped working with the latest commit. this fixes it again.

fixes #1066