### PR TITLE
Fix ExecCommandWith for cmd.exe in Windows

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1105,7 +1105,10 @@ func keyMatch(key int, event tui.Event) bool {
 
 func quoteEntry(entry string) string {
 	if util.IsWindows() {
-		return strconv.Quote(strings.Replace(entry, "\"", "\\\"", -1))
+		r, _ := regexp.Compile("[&|<>()@^%\"]")
+		return r.ReplaceAllStringFunc(strconv.Quote(entry), func (match string) string {
+		    return "^" + match
+		})
 	}
 	return "'" + strings.Replace(entry, "'", "'\\''", -1) + "'"
 }

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1105,8 +1105,10 @@ func keyMatch(key int, event tui.Event) bool {
 
 func quoteEntry(entry string) string {
 	if util.IsWindows() {
+		escaped := strings.Replace(entry, "\\", "\\\\", -1)
+		escaped = "\"" + strings.Replace(escaped, "\"", "\\\"", -1) + "\""
 		r, _ := regexp.Compile("[&|<>()@^%\"]")
-		return r.ReplaceAllStringFunc(strconv.Quote(entry), func (match string) string {
+		return r.ReplaceAllStringFunc(escaped, func (match string) string {
 		    return "^" + match
 		})
 	}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1105,9 +1105,9 @@ func keyMatch(key int, event tui.Event) bool {
 
 func quoteEntry(entry string) string {
 	if util.IsWindows() {
-		escaped := strings.Replace(entry, "\\", "\\\\", -1)
-		escaped = "\"" + strings.Replace(escaped, "\"", "\\\"", -1) + "\""
-		r, _ := regexp.Compile("[&|<>()@^%\"]")
+		escaped := strings.Replace(entry, `\`, `\\`, -1)
+		escaped = `"` + strings.Replace(escaped, `"`, `\"`, -1) + `"`
+		r, _ := regexp.Compile(`[&|<>()@^%"]`)
 		return r.ReplaceAllStringFunc(escaped, func (match string) string {
 		    return "^" + match
 		})

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1107,7 +1107,7 @@ func quoteEntry(entry string) string {
 	if util.IsWindows() {
 		escaped := strings.Replace(entry, `\`, `\\`, -1)
 		escaped = `"` + strings.Replace(escaped, `"`, `\"`, -1) + `"`
-		r, _ := regexp.Compile(`[&|<>()@^%"]`)
+		r, _ := regexp.Compile(`[&|<>()@^%!"]`)
 		return r.ReplaceAllStringFunc(escaped, func (match string) string {
 		    return "^" + match
 		})

--- a/src/util/util_windows.go
+++ b/src/util/util_windows.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
-
-	"github.com/mattn/go-shellwords"
 )
 
 // ExecCommand executes the given command with cmd
@@ -18,11 +16,13 @@ func ExecCommand(command string) *exec.Cmd {
 // ExecCommandWith executes the given command with cmd. _shell parameter is
 // ignored on Windows.
 func ExecCommandWith(_shell string, command string) *exec.Cmd {
-	args, _ := shellwords.Parse(command)
-	allArgs := make([]string, len(args)+1)
-	allArgs[0] = "/c"
-	copy(allArgs[1:], args)
-	return exec.Command("cmd", allArgs...)
+	cmd := exec.Command("cmd")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+	    HideWindow: false,
+	    CmdLine: fmt.Sprintf(` /s /c "%s"`, command),
+	    CreationFlags: 0,
+	}
+	return cmd
 }
 
 // IsWindows returns true on Windows


### PR DESCRIPTION
Close #1018 

Run the command as is in cmd.exe with no parsing and escaping.
Explicity set cmd.SysProcAttr so execCommand does not escape the command.
Technically, the command should be escaped with ^ for special characters, including ".
This allows cmd.exe commands to be chained together.

See https://github.com/neovim/neovim/pull/7343#issuecomment-333350201

However, this requires a new shellescape function that is specific to one of the following:
- interactive prompt
- batchfile
- command name

fzf#shellescape in the Vim plugin can handle only the batchfile.