### PR TITLE
Allow custom sink*

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -320,11 +320,12 @@ function! fzf#wrap(...)
   endif
 
   " Action: g:fzf_action
-  if !s:has_any(opts, ['sink', 'sink*'])
-    let opts._action = get(g:, 'fzf_action', s:default_action)
-    let opts.options .= ' --expect='.join(keys(opts._action), ',')
+  if !has_key(opts, 'sink') && opts.options !~# '--expect'
+    let opts._action   = get(g:, 'fzf_action', s:default_action)
+    let opts.options  .= ' --expect='.join(keys(opts._action), ',')
+    let opts._sink_ref = has_key(opts, 'sink*') ? opts['sink*'] : function('s:common_sink')
     function! opts.sink(lines) abort
-      return s:common_sink(self._action, a:lines)
+      return self._sink_ref(self._action, a:lines)
     endfunction
     let opts['sink*'] = remove(opts, 'sink')
   endif

--- a/test/fzf.vader
+++ b/test/fzf.vader
@@ -137,6 +137,19 @@ Execute (fzf#wrap):
   AssertEqual 'e', opts.sink
   Assert !has_key(opts, 'sink*')
 
+  let opts = fzf#wrap('foobar', {'sink*': 'test', 'options': '--expect'})
+  Log opts
+  Assert opts['sink*'] == 'test'
+
+  function! TestCustomSinkAst(actions, lines)
+    return [a:actions, a:lines]
+  endfunction
+  let opts = fzf#wrap('foobar', {'sink*': function('TestCustomSinkAst')})
+  Log opts
+  Assert opts.options =~ '--expect='
+  Assert opts['sink*'](['', ['lines']]) == [opts._action, ['', ['lines']]]
+  delfunction TestCustomSinkAst
+
   let g:fzf_history_dir = '/tmp'
   let opts = fzf#wrap('foobar', {'options': '--color light'})
   Log opts


### PR DESCRIPTION
As a wrapper, I think it should support `g:fzf_action` when `--expect` is not given, avoiding [this](https://github.com/junegunn/fzf.vim/blob/master/autoload/fzf/vim.vim#L122) when using fzf#wrap.


Notes:
- `sink*` could receive `(actions, action, lines)` instead of `(actions, [action, lines])`.
- Perhaps there is no need for `actions` if [this](https://github.com/lfmet/fzf/blob/55cea7d2c02bafbce7aa6e129f4580d568936c6e/plugin/fzf.vim#L324) is defined in the script source scope.