### PR TITLE
fish: Use $version instead of $FISH_VERSION

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -40,8 +40,8 @@ function fzf_key_bindings
     begin
       set -lx FZF_DEFAULT_OPTS "--height $FZF_TMUX_HEIGHT $FZF_DEFAULT_OPTS --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m"
 
-      set -l FISH_MAJOR (echo $FISH_VERSION | cut -f1 -d.)
-      set -l FISH_MINOR (echo $FISH_VERSION | cut -f2 -d.)
+      set -l FISH_MAJOR (echo $version | cut -f1 -d.)
+      set -l FISH_MINOR (echo $version | cut -f2 -d.)
 
       # history's -z flag is needed for multi-line support.
       # history's -z flag was added in fish 2.4.0, so don't use it for versions


### PR DESCRIPTION
This is the most simple fix I could think of for #1099 

If this is not robust enough for you or pre-mature (we can wait for fish 2.7 to be out), let me know.

Starting with fish 2.7 uppercase var are lowercases, see

  https://github.com/fish-shell/fish-shell/issues/4414

or in case of $FISH_VERSION renamed, see also

  https://github.com/fish-shell/fish-shell/commit/fb8ae04f80c3a129f789e7b718464d014508315f