### PR TITLE
Allow differentiation between ESC and CTRL-C

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -505,6 +505,7 @@ triggered whenever the query string is changed.
     \fBforward-char\fR          \fIctrl-f  right\fR
     \fBforward-word\fR          \fIalt-f   shift-right\fR
     \fBignore\fR
+    \fBinterrupt\fR
     \fBjump\fR                  (EasyMotion-like 2-keystroke movement)
     \fBjump-accept\fR           (jump and accept)
     \fBkill-line\fR

--- a/src/constants.go
+++ b/src/constants.go
@@ -78,5 +78,6 @@ const (
 	exitOk        = 0
 	exitNoMatch   = 1
 	exitError     = 2
-	exitInterrupt = 130
+	exitQuit      = 130
+	exitInterrupt = 131
 )

--- a/src/options.go
+++ b/src/options.go
@@ -680,6 +680,8 @@ func parseKeymap(keymap map[int][]action, str string) {
 				appendAction(actForwardChar)
 			case "forward-word":
 				appendAction(actForwardWord)
+			case "interrupt":
+				appendAction(actInterrupt)
 			case "jump":
 				appendAction(actJump)
 			case "jump-accept":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -141,6 +141,7 @@ var _spinner = []string{`-`, `\`, `|`, `/`, `-`, `\`, `|`, `/`}
 const (
 	reqPrompt util.EventType = iota
 	reqInfo
+	reqInterrupt
 	reqHeader
 	reqList
 	reqJump
@@ -180,6 +181,7 @@ const (
 	actEndOfLine
 	actForwardChar
 	actForwardWord
+	actInterrupt
 	actKillLine
 	actKillWord
 	actUnixLineDiscard
@@ -1445,6 +1447,8 @@ func (t *Terminal) Loop() {
 							return exitOk
 						})
 					case reqQuit:
+						exit(func() int { return exitQuit })
+					case reqInterrupt:
 						exit(func() int { return exitInterrupt })
 					}
 				}
@@ -1574,6 +1578,8 @@ func (t *Terminal) Loop() {
 					t.input = []rune{}
 					t.cx = 0
 				}
+			case actInterrupt:
+				req(reqInterrupt)
 			case actForwardChar:
 				if t.cx < len(t.input) {
 					t.cx++


### PR DESCRIPTION
Added an action `interrupt` which exits with exit code 131 instead of 130. By default, this action is not bound to any key; but if it is bound to a key (e.g. `fzf --bind=ctrl-c:interrupt`), then it can be used to differentiate between the user pressing ESC and the user typing CTRL-C.

The action name `interrupt` seemed like a reasonable name given its similarity to `SIGINT`.

Note: I did not add a test for this, because it wasn't clear to me how to test the exit code. Also I did not update `CHANGELOG.md`. In the man page, all I did was add a line for the `interrupt` action, with no explanation of what it does.

Fixes junegunn/fzf/issues/1105