### PR TITLE
Add bin/fzf.exe to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/fzf
+bin/fzf.exe
 target
 pkg
 Gemfile.lock


### PR DESCRIPTION
On Cygwin and MinGW, the fzf binary will have a .exe extension, so
ignore that binary if it exists as well as the bare binary.