### PR TITLE
Clear grep options

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -124,7 +124,7 @@ _fzf_handle_dynamic_completion() {
   elif [ -n "$_fzf_completion_loader" ]; then
     _completion_loader "$@"
     ret=$?
-    eval "$(complete | command grep "\-F.* $orig_cmd$" | _fzf_orig_completion_filter)"
+    eval "$(complete | GREP_OPTIONS='' command grep "\-F.* $orig_cmd$" | _fzf_orig_completion_filter)"
     source "${BASH_SOURCE[0]}"
     return $ret
   fi
@@ -226,16 +226,16 @@ _fzf_complete_kill() {
 
 _fzf_complete_telnet() {
   _fzf_complete '+m' "$@" < <(
-    command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0' |
+    GREP_OPTIONS='' command grep -v '^\s*\(#\|$\)' /etc/hosts | GREP_OPTIONS='' command grep -Fv '0.0.0.0' |
         awk '{if (length($2) > 0) {print $2}}' | sort -u
   )
 }
 
 _fzf_complete_ssh() {
   _fzf_complete '+m' "$@" < <(
-    cat <(cat ~/.ssh/config /etc/ssh/ssh_config 2> /dev/null | command grep -i '^host' | command grep -v '*' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}') \
-        <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
-        <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
+    cat <(cat ~/.ssh/config /etc/ssh/ssh_config 2> /dev/null | GREP_OPTIONS='' command grep -i '^host' | GREP_OPTIONS='' command grep -v '*' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}') \
+        <(GREP_OPTIONS='' command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
+        <(GREP_OPTIONS='' command grep -v '^\s*\(#\|$\)' /etc/hosts | GREP_OPTIONS='' command grep -Fv '0.0.0.0') |
         awk '{if (length($2) > 0) {print $2}}' | sort -u
   )
 }

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -109,16 +109,16 @@ _fzf_complete() {
 
 _fzf_complete_telnet() {
   _fzf_complete '+m' "$@" < <(
-    command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0' |
+    GREP_OPTIONS='' command grep -v '^\s*\(#\|$\)' /etc/hosts | GREP_OPTIONS='' command grep -Fv '0.0.0.0' |
         awk '{if (length($2) > 0) {print $2}}' | sort -u
   )
 }
 
 _fzf_complete_ssh() {
   _fzf_complete '+m' "$@" < <(
-    command cat <(cat ~/.ssh/config /etc/ssh/ssh_config 2> /dev/null | command grep -i '^host' | command grep -v '*' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}') \
-        <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
-        <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
+    command cat <(cat ~/.ssh/config /etc/ssh/ssh_config 2> /dev/null | GREP_OPTIONS='' command grep -i '^host' | GREP_OPTIONS='' command grep -v '*' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}') \
+        <(GREP_OPTIONS='' command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
+        <(GREP_OPTIONS='' command grep -v '^\s*\(#\|$\)' /etc/hosts | GREP_OPTIONS='' command grep -Fv '0.0.0.0') |
         awk '{if (length($2) > 0) {print $2}}' | sort -u
   )
 }

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -57,7 +57,7 @@ __fzf_history__() (
   line=$(
     HISTTIMEFORMAT= history |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS --tac -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m" $(__fzfcmd) |
-    command grep '^ *[0-9]') &&
+    GREP_OPTIONS='' command grep '^ *[0-9]') &&
     if [[ $- =~ H ]]; then
       sed 's/^ *\([0-9]*\)\** .*/!\1/' <<< "$line"
     else


### PR DESCRIPTION
Clear the environment variable `GREP_OPTIONS` to avoid incorrect results with grep and to potentially increase performance.