### PR TITLE
[vim] Require tmap for :terminal on Windows

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -389,7 +389,7 @@ try
   let use_height = has_key(dict, 'down') && !has('gui_running') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right', 'window')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let has_vim8_term = has('terminal') && has('patch-8.0.995')
+  let has_vim8_term = has('terminal') && has('patch-8.0.995') && (!s:is_win || has('patch-8.0.1108'))
   let has_nvim_term = has('nvim-0.2.1') || has('nvim') && !s:is_win
   let use_term = has_nvim_term ||
     \ has_vim8_term && (has('gui_running') || s:is_win || !use_height && s:present(dict, 'down', 'up', 'left', 'right', 'window'))

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -389,10 +389,10 @@ try
   let use_height = has_key(dict, 'down') && !has('gui_running') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right', 'window')) &&
         \ executable('tput') && filereadable('/dev/tty')
-  let has_vim8_term = has('terminal') && has('patch-8.0.995') && (!s:is_win || has('patch-8.0.1108'))
+  let has_vim8_term = has('terminal') && has('patch-8.0.995')
   let has_nvim_term = has('nvim-0.2.1') || has('nvim') && !s:is_win
   let use_term = has_nvim_term ||
-    \ has_vim8_term && (has('gui_running') || s:is_win || !use_height && s:present(dict, 'down', 'up', 'left', 'right', 'window'))
+    \ has_vim8_term && (has('gui_running') || (s:is_win ? has('patch-8.0.1108') : !use_height && s:present(dict, 'down', 'up', 'left', 'right', 'window')))
   let use_tmux = (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:tmux_enabled() && s:splittable(dict)
   if prefer_tmux && use_tmux
     let use_height = 0


### PR DESCRIPTION
Vim's backspace doesn't work in ConEmu by default so `tnoremap` is required to fix it for winpty.
Alternative is to not use `:terminal` on ConEmu because https://conemu.github.io/en/VimXterm.html doesn't mention `tnoremap`.

It's a big jump from `8.0995` to `8.0.1108` but I can't use fzf without backspace.