### PR TITLE
Remove fallback to bash default completion

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -310,15 +310,15 @@ done
 unset _fzf_defc
 
 # Kill completion
-complete -F _fzf_complete_kill -o nospace -o default kill
+complete -F _fzf_complete_kill -o nospace kill
 
 # Host completion
-complete -F _fzf_complete_ssh -o default ssh
-complete -F _fzf_complete_telnet -o default telnet
+complete -F _fzf_complete_ssh ssh
+complete -F _fzf_complete_telnet telnet
 
 # Environment variables / Aliases
-complete -F _fzf_complete_unset -o default unset
-complete -F _fzf_complete_export -o default export
-complete -F _fzf_complete_unalias -o default unalias
+complete -F _fzf_complete_unset unset
+complete -F _fzf_complete_export export
+complete -F _fzf_complete_unalias unalias
 
 unset cmd d_cmds a_cmds x_cmds

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -310,15 +310,15 @@ done
 unset _fzf_defc
 
 # Kill completion
-complete -F _fzf_complete_kill -o nospace -o default -o bashdefault kill
+complete -F _fzf_complete_kill -o nospace -o default kill
 
 # Host completion
-complete -F _fzf_complete_ssh -o default -o bashdefault ssh
-complete -F _fzf_complete_telnet -o default -o bashdefault telnet
+complete -F _fzf_complete_ssh -o default ssh
+complete -F _fzf_complete_telnet -o default telnet
 
 # Environment variables / Aliases
-complete -F _fzf_complete_unset -o default -o bashdefault unset
-complete -F _fzf_complete_export -o default -o bashdefault export
-complete -F _fzf_complete_unalias -o default -o bashdefault unalias
+complete -F _fzf_complete_unset -o default unset
+complete -F _fzf_complete_export -o default export
+complete -F _fzf_complete_unalias -o default unalias
 
 unset cmd d_cmds a_cmds x_cmds


### PR DESCRIPTION
This doesn't work correctly when there's 'globstar' option set
in bash. Running the completion with '**' and then cancelling it stills
triggers bash globstar search, which might be very expensive.