### PR TITLE
Fix broken link in readme TOC

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Table of Contents
       * [Executing external programs](#executing-external-programs)
       * [Preview window](#preview-window)
    * [Tips](#tips)
-      * [Respecting .gitignore, <code>.hgignore</code>, and <code>svn:ignore</code>](#respecting-gitignore-hgignore-and-svnignore)
+      * [Respecting .gitignore](#respecting-gitignore)
       * [git ls-tree for fast traversal](#git-ls-tree-for-fast-traversal)
       * [Fish shell](#fish-shell)
    * [<a href="LICENSE">License</a>](#license)


### PR DESCRIPTION
The `Respecting .gitignore` link pointed to a section of the readme which no longer exists.