### PR TITLE
Improve kill completion.

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -215,7 +215,8 @@ _fzf_complete_kill() {
 
   local selected fzf
   fzf="$(__fzfcmd_complete)"
-  selected=$(command ps -ef | sed 1d | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-50%} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS" $fzf -m | awk '{print $2}' | tr '\n' ' ')
+  selected=$(command ps axo user,pid,ppid,etime,pcpu,pmem,time,args | sed 1d | grep "^$(whoami)" | awk '$4 > "00:01"' \
+      | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-50%} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS" $fzf -m | awk '{print $2}' | tr '\n' ' ')
   printf '\e[5n'
 
   if [ -n "$selected" ]; then

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -163,7 +163,8 @@ fzf-completion() {
   # Kill completion (do not require trigger sequence)
   if [ $cmd = kill -a ${LBUFFER[-1]} = ' ' ]; then
     fzf="$(__fzfcmd_complete)"
-    matches=$(command ps -ef | sed 1d | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-50%} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS" ${=fzf} -m | awk '{print $2}' | tr '\n' ' ')
+    matches=$(command ps axo user,pid,ppid,etime,pcpu,pmem,time,args | sed 1d | grep "^$(whoami)" | awk '$4 > "00:01"' \
+        | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-50%} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS" ${=fzf} -m | awk '{print $2}' | tr '\n' ' ')
     if [ -n "$matches" ]; then
       LBUFFER="$LBUFFER$matches"
     fi


### PR DESCRIPTION
kill <tab> shows commands used in `completion.bash` for process filtering.
This clutters the list with already terminated processes.
The new commands reduces the list to only processes with an elapsed time
of > 1 second.

kill <tab> shows processes belonging to other users.
This has has no value unless fzf is run as root, so that should IMO not
be the default behavior.
The new commands filters on `whoami`

Tested on:
macOS High Sierra 10.13.1
CentOS Linux release 7.4.1708 (Core)
Fedora release 26