### PR TITLE
Functionalize zsh completion script.

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#compdef fzf
 #     ____      ____
 #    / __/___  / __/
 #   / /_/_  / / /_
@@ -9,25 +9,7 @@
 # - $FZF_TMUX_HEIGHT        (default: '40%')
 # - $FZF_COMPLETION_TRIGGER (default: '**')
 # - $FZF_COMPLETION_OPTS    (default: empty)
-
 # To use custom commands instead of find, override _fzf_compgen_{path,dir}
-if ! declare -f _fzf_compgen_path > /dev/null; then
-  _fzf_compgen_path() {
-    echo "$1"
-    command find -L "$1" \
-      -name .git -prune -o -name .svn -prune -o \( -type d -o -type f -o -type l \) \
-      -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
-  }
-fi
-
-if ! declare -f _fzf_compgen_dir > /dev/null; then
-  _fzf_compgen_dir() {
-    command find -L "$1" \
-      -name .git -prune -o -name .svn -prune -o -type d \
-      -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
-  }
-fi
-
 ###########################################################
 
 __fzfcmd_complete() {
@@ -189,11 +171,32 @@ fzf-completion() {
   fi
 }
 
-[ -z "$fzf_default_completion" ] && {
-  binding=$(bindkey '^I')
-  [[ $binding =~ 'undefined-key' ]] || fzf_default_completion=$binding[(s: :w)2]
-  unset binding
+_fzf() {
+  if ! declare -f _fzf_compgen_path > /dev/null; then
+    _fzf_compgen_path() {
+      echo "$1"
+      command find -L "$1" \
+        -name .git -prune -o -name .svn -prune -o \( -type d -o -type f -o -type l \) \
+        -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    }
+  fi
+
+  if ! declare -f _fzf_compgen_dir > /dev/null; then
+    _fzf_compgen_dir() {
+      command find -L "$1" \
+        -name .git -prune -o -name .svn -prune -o -type d \
+        -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    }
+  fi
+
+  [ -z "$fzf_default_completion" ] && {
+    binding=$(bindkey '^I')
+    [[ $binding =~ 'undefined-key' ]] || fzf_default_completion=$binding[(s: :w)2]
+    unset binding
+  }
+
+  zle     -N   fzf-completion
+  bindkey '^I' fzf-completion
 }
 
-zle     -N   fzf-completion
-bindkey '^I' fzf-completion
+_fzf "$@"


### PR DESCRIPTION
Let me first preface this by saying I don't use zsh so please let me know if this is a bad idea. On Fedora with bash, I install the `completion.bash` to the global directory and it works automatically once installed. With zsh, I try to install the `completion.zsh` to `site-functions`, but this doesn't work.

What seems to be missing is the `compdef` at the beginning (the shebang seems unnecessary since it's expected to be `source`d) and the top-level code needs to be in a function (and install as `_fzf`.) This allows it to be loaded from the zsh `site-functions` directory automatically. The `fzf` call at the end allows it to be `source`d just like before.

Anyway, like I said, I don't really use zsh, so I've only done minimal testing but this seems to work in both scenarios.