### PR TITLE
[zsh] Update fzf-history-widget for multi-select

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -68,15 +68,15 @@ bindkey '\ec' fzf-cd-widget
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected num
-  setopt localoptions noglobsubst noposixbuiltins pipefail 2> /dev/null
-  selected=( $(fc -rl 1 |
-    FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
+  setopt localoptions noglobsubst noposixbuiltins pipefail extendedglob 2> /dev/null
+  selected=( "${(@f)$(fc -rl 1 |
+    FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} -m" $(__fzfcmd))}" )
   local ret=$?
-  if [ -n "$selected" ]; then
-    num=$selected[1]
-    if [ -n "$num" ]; then
-      zle vi-fetch-history -n $num
-    fi
+  [[ -n $selected ]] && if [[ ${#selected} -eq 1 ]]; then
+    num=${${selected[1]## #}%%[^0-9]*}
+    [[ -n $num ]] && zle vi-fetch-history -n $num
+  else
+    LBUFFER=${(j: && :)${selected## #[^ ]# #}}
   fi
   zle redisplay
   typeset -f zle-line-init >/dev/null && zle zle-line-init


### PR DESCRIPTION
Allow fzf-history-widget in zsh to accept multi-select. If one entry is selected, then vi-fetch-history is invoked, as in previous code. If multiple entries are selected, then they're joined with ` && `.