### PR TITLE
Make default answer "y" in install script

### DIFF
--- a/install
+++ b/install
@@ -69,6 +69,7 @@ fzf_base="$(pwd)"
 ask() {
   while true; do
     read -p "$1 ([y]/n) " -r
+    REPLY=${REPLY:-"y"}
     if [[ $REPLY =~ ^[Yy]$ ]]; then
       return 1
     elif [[ $REPLY =~ ^[Nn]$ ]]; then


### PR DESCRIPTION
The current install script hints that `y` will be the default answer to the various prompts, but if the user presses `Enter` without entering an answer, nothing happens.

This PR sets the default answer to `y` as hinted in the prompt `[y]/n` so that the user can keep pressing `Enter` to accept the default answer.