### PR TITLE
Add vi command mode like mode for move up/down

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -146,6 +146,19 @@ actions are affected:
 .TP
 .BI "--jump-labels=" "CHARS"
 Label characters for \fBjump\fR and \fBjump-accept\fR
+.TP
+.BI "--vi-mode"
+Enable vi command line like mode by default (otherwise can be entered this mode by ctrl-O).
+In this mode, key bindings will be changed as follows:
+    i       ... back to default mode
+    j       ... move down
+    k       ... move up
+    g       ... move top
+    G       ... move bottom
+    o       ... return
+    q       ... quit
+    f,space ... move half pave
+    b       ... move back half pave
 .SS Layout
 .TP
 .BI "--height=" "HEIGHT[%]"
@@ -528,6 +541,7 @@ triggered whenever the query string is changed.
     \fBprint-query\fR           (print query and exit)
     \fBreplace-query\fR         (replace query string with the current selection)
     \fBselect-all\fR
+    \fBtoDefaultMode\fR         (back to default mode from vi mode)
     \fBtoggle\fR                (\fIright-click\fR)
     \fBtoggle-all\fR
     \fBtoggle+down\fR           \fIctrl-i  (tab)\fR
@@ -538,6 +552,7 @@ triggered whenever the query string is changed.
     \fBtoggle-sort\fR
     \fBtoggle+up\fR             \fIbtab    (shift-tab)\fR
     \fBtop\fR                   (move to the top result)
+    \fBtoViMode\fR              \fIctrl-o\fR
     \fBunix-line-discard\fR     \fIctrl-u\fR
     \fBunix-word-rubout\fR      \fIctrl-w\fR
     \fBup\fR                    \fIctrl-k  ctrl-p  up\fR

--- a/src/options.go
+++ b/src/options.go
@@ -47,6 +47,8 @@ const usage = `usage: fzf [options]
                           highlighted substring (default: 10)
     --filepath-word       Make word-wise movements respect path separators
     --jump-labels=CHARS   Label characters for jump and jump-accept
+    --vi-mode             Enable vi command line like mode by default
+                          (otherwise can be entered this mode by ctrl-o)
 
   Layout
     --height=HEIGHT[%]    Display fzf window below the cursor with the given
@@ -176,6 +178,8 @@ type Options struct {
 	ToggleSort  bool
 	Expect      map[int]string
 	Keymap      map[int][]action
+	viMode      bool
+	viKeymap    map[int][]action
 	Preview     previewOpts
 	PrintQuery  bool
 	ReadZero    bool
@@ -1050,6 +1054,8 @@ func parseOptions(opts *Options, allArgs []string) {
 		case "--jump-labels":
 			opts.JumpLabels = nextString(allArgs, &i, "label characters required")
 			validateJumpLabels = true
+		case "--vi-mode":
+			opts.viMode = true
 		case "-1", "--select-1":
 			opts.Select1 = true
 		case "+1", "--no-select-1":
@@ -1232,6 +1238,7 @@ func postProcessOptions(opts *Options) {
 		keymap[key] = actions
 	}
 	opts.Keymap = keymap
+	opts.viKeymap = viKeymap()
 
 	// If we're not using extended search mode, --nth option becomes irrelevant
 	// if it contains the whole range


### PR DESCRIPTION
Hello, 

Sometimes i'd like to move up/down without ctrl key and this commit will do that (just switching a keymap). Apparent problem of current implementation is keymap for vi-mode cannot be changed.

If you don't think this is good, please ignore this.
Thanks.

----
This commit adds vi command line like mode which can be enabled by ctrl-o or specifying --vi-mode at start time.

In this mode, key bindings will be changed as follows:
   i       ... back to default mode
   j       ... move down
   k       ... move up
   g       ... move top
   G       ... move bottom
   o       ... return
   q       ... quit
   f,space ... move half page
   b       ... move back half page

Also, action 'toDefaultMode' and 'toViMode' are added.