### PR TITLE
Default command outputs relative filepath on Windows (take #2)

### DIFF
--- a/src/constants.go
+++ b/src/constants.go
@@ -59,7 +59,7 @@ func init() {
 	} else if os.Getenv("TERM") == "cygwin" {
 		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	} else {
-		defaultCommand = `for /r %P in (*) do @(set _relpath=%P & echo !_relpath:%cd%\=!)`
+		defaultCommand = `for /r %P in (*) do @(set _relpath=%P & echo !_relpath:%__CD__%=!)`
 	}
 }
 

--- a/src/constants.go
+++ b/src/constants.go
@@ -59,7 +59,7 @@ func init() {
 	} else if os.Getenv("TERM") == "cygwin" {
 		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	} else {
-		defaultCommand = `dir /s/b`
+		defaultCommand = `for /r %P in (*) do @(set _relpath=%P & echo !_relpath:%cd%\=!)`
 	}
 }
 

--- a/src/constants.go
+++ b/src/constants.go
@@ -59,7 +59,7 @@ func init() {
 	} else if os.Getenv("TERM") == "cygwin" {
 		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	} else {
-		defaultCommand = `for /r %P in (*) do @(set _curfile=%P & echo !_curfile:%__CD__%=!)`
+		defaultCommand = `for /r %P in (*) do @(set "_curfile=%P" & set "_curfile=!_curfile:%__CD__%=!" & echo !_curfile!)`
 	}
 }
 

--- a/src/constants.go
+++ b/src/constants.go
@@ -59,7 +59,7 @@ func init() {
 	} else if os.Getenv("TERM") == "cygwin" {
 		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	} else {
-		defaultCommand = `for /r %P in (*) do @(set _relpath=%P & echo !_relpath:%__CD__%=!)`
+		defaultCommand = `for /r %P in (*) do @(set _curfile=%P & echo !_curfile:%__CD__%=!)`
 	}
 }
 

--- a/src/util/util_windows.go
+++ b/src/util/util_windows.go
@@ -20,7 +20,7 @@ func ExecCommandWith(_shell string, command string) *exec.Cmd {
 	cmd := exec.Command("cmd")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow:    false,
-		CmdLine:       fmt.Sprintf(` /s /c "%s"`, command),
+		CmdLine:       fmt.Sprintf(` /v:on/s/c "%s"`, command),
 		CreationFlags: 0,
 	}
 	return cmd


### PR DESCRIPTION
Retry #971 but don't use `dir`. Instead, use `for /r`. It outputs the same files as `dir /a:-d/s/b`.
Problem is ending the for loop when fzf exits. I don't know what's causing cmd.exe to not terminate.

I added `v:on` flag for now so fzf doesn't run a subshell.