### PR TITLE
[zsh] Make default ignore pattern to be configurable

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -2,9 +2,17 @@
 # ------------
 if [[ $- == *i* ]]; then
 
+local default_ignore="${FZF_DEFAULT_IGNORE:-\
+    -path '*/\\.*' \
+    -o -fstype 'sysfs' \
+    -o -fstype 'devfs' \
+    -o -fstype 'devtmpfs' \
+    -o -fstype 'proc' \
+}"
+
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
-  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( ${default_ignore} \\) -prune \
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null | cut -b3-"}"
@@ -48,7 +56,7 @@ zle -N fzf-redraw-prompt
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( ${default_ignore} \\) -prune \
     -o -type d -print 2> /dev/null | cut -b3-"}"
   setopt localoptions pipefail 2> /dev/null
   local dir="$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m)"


### PR DESCRIPTION
Since both `FZF_CTRL_T_COMMAND` and `FZF_ALT_C_COMMAND` share the same
ignore pattern for the `file` command, it makes sense to move the
pattern to a distinct variable and let the user to optionally provide it
via a global variable.

It is useful to let the user to *conceal* some commonly ignore directories (a `build` directory for example).

What do you think?