### PR TITLE
remove final trailing delimiters under `--with-nth`

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -100,7 +100,7 @@ func Run(opts *Options, revision string) {
 	} else {
 		chunkList = NewChunkList(func(item *Item, data []byte) bool {
 			tokens := Tokenize(string(data), opts.Delimiter)
-			trans := Transform(tokens, opts.WithNth)
+			trans := Transform(tokens, opts.WithNth, opts.Delimiter)
 			transformed := joinTokens(trans)
 			if len(header) < opts.HeaderLines {
 				header = append(header, transformed)

--- a/src/pattern.go
+++ b/src/pattern.go
@@ -386,7 +386,7 @@ func (p *Pattern) transformInput(item *Item) []Token {
 	}
 
 	tokens := Tokenize(item.text.ToString(), p.delimiter)
-	ret := Transform(tokens, p.nth)
+	ret := Transform(tokens, p.nth, p.delimiter)
 	item.transformed = &ret
 	return ret
 }

--- a/src/pattern_test.go
+++ b/src/pattern_test.go
@@ -128,7 +128,7 @@ func TestCaseSensitivity(t *testing.T) {
 func TestOrigTextAndTransformed(t *testing.T) {
 	pattern := BuildPattern(true, algo.FuzzyMatchV2, true, CaseSmart, false, true, true, []Range{}, Delimiter{}, []rune("jg"))
 	tokens := Tokenize("junegunn", Delimiter{})
-	trans := Transform(tokens, []Range{Range{1, 1}})
+	trans := Transform(tokens, []Range{Range{1, 1}}, Delimiter{})
 
 	origBytes := []byte("junegunn.choi")
 	for _, extended := range []bool{false, true} {

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1220,7 +1220,7 @@ func replacePlaceholder(template string, stripAnsi bool, delimiter Delimiter, fo
 
 		for idx, item := range items {
 			tokens := Tokenize(item.AsString(stripAnsi), delimiter)
-			trans := Transform(tokens, ranges)
+			trans := Transform(tokens, ranges, delimiter)
 			str := string(joinTokens(trans))
 			if delimiter.str != nil {
 				str = strings.TrimSuffix(str, *delimiter.str)

--- a/src/tokenizer.go
+++ b/src/tokenizer.go
@@ -178,7 +178,7 @@ func joinTokens(tokens []Token) string {
 }
 
 // Transform is used to transform the input when --with-nth option is given
-func Transform(tokens []Token, withNth []Range) []Token {
+func Transform(tokens []Token, withNth []Range, delimiter Delimiter) []Token {
 	transTokens := make([]Token, len(withNth))
 	numTokens := len(tokens)
 	for idx, r := range withNth {
@@ -249,5 +249,21 @@ func Transform(tokens []Token, withNth []Range) []Token {
 		}
 		transTokens[idx] = Token{&merged, prefixLength}
 	}
+
+	// remove trailing delimiters
+	// a third condition is possible but that delimiter must be invisible whitespace
+	if delimiter.str != nil {
+		rightmostText := transTokens[len(transTokens)-1].text.ToString()
+		rightmostText = strings.TrimSuffix(rightmostText, *delimiter.str)
+		asChars := util.ToChars([]byte(rightmostText))
+		transTokens[len(transTokens)-1].text = &asChars
+	} else if delimiter.regex != nil {
+		reg := regexp.MustCompile(delimiter.regex.String() + "$")
+		rightmostText := transTokens[len(transTokens)-1].text.ToString()
+		rightmostText = reg.ReplaceAllString(rightmostText, "")
+		asChars := util.ToChars([]byte(rightmostText))
+		transTokens[len(transTokens)-1].text = &asChars
+	}
+
 	return transTokens
 }

--- a/src/tokenizer_test.go
+++ b/src/tokenizer_test.go
@@ -72,14 +72,14 @@ func TestTransform(t *testing.T) {
 		tokens := Tokenize(input, Delimiter{})
 		{
 			ranges := splitNth("1,2,3")
-			tx := Transform(tokens, ranges)
+			tx := Transform(tokens, ranges, Delimiter{})
 			if string(joinTokens(tx)) != "abc:  def:  ghi:  " {
 				t.Errorf("%s", tx)
 			}
 		}
 		{
 			ranges := splitNth("1..2,3,2..,1")
-			tx := Transform(tokens, ranges)
+			tx := Transform(tokens, ranges, Delimiter{})
 			if string(joinTokens(tx)) != "abc:  def:  ghi:  def:  ghi:  jklabc:  " ||
 				len(tx) != 4 ||
 				tx[0].text.ToString() != "abc:  def:  " || tx[0].prefixLength != 2 ||
@@ -94,13 +94,13 @@ func TestTransform(t *testing.T) {
 		tokens := Tokenize(input, delimiterRegexp(":"))
 		{
 			ranges := splitNth("1..2,3,2..,1")
-			tx := Transform(tokens, ranges)
-			if string(joinTokens(tx)) != "  abc:  def:  ghi:  def:  ghi:  jkl  abc:" ||
+			tx := Transform(tokens, ranges, delimiterRegexp(":"))
+			if string(joinTokens(tx)) != "  abc:  def:  ghi:  def:  ghi:  jkl  abc" ||
 				len(tx) != 4 ||
 				tx[0].text.ToString() != "  abc:  def:" || tx[0].prefixLength != 0 ||
 				tx[1].text.ToString() != "  ghi:" || tx[1].prefixLength != 12 ||
 				tx[2].text.ToString() != "  def:  ghi:  jkl" || tx[2].prefixLength != 6 ||
-				tx[3].text.ToString() != "  abc:" || tx[3].prefixLength != 0 {
+				tx[3].text.ToString() != "  abc" || tx[3].prefixLength != 0 {
 				t.Errorf("%s", tx)
 			}
 		}
@@ -108,5 +108,5 @@ func TestTransform(t *testing.T) {
 }
 
 func TestTransformIndexOutOfBounds(t *testing.T) {
-	Transform([]Token{}, splitNth("1"))
+	Transform([]Token{}, splitNth("1"), Delimiter{})
 }


### PR DESCRIPTION
fzf retains the trailing delimiter on each field as divided for `--nth` or `--with-nth`.  This is useful for later joining fields, as the delimiters may be defined by regular expressions and thus may vary arbitrarily.

However, it is confusing/distracting for the final trailing delimiter to appear, particularly when control-character delimiters are displayed as `?` (which is true for me after e3e7b3360).

This PR continues to retain trailing delimiters internally, but right-trims the final delimiter just prior to display.  This also affects the `replace-query` action in a consistent way.  When `--nth` is used, it remains possible to query against the delimiter text, which is arguably a bug, but a separate one.

Example of bug, using visible delimiters:
```bash
$ printf '%s' $'one_1_I\ntwo_2_II\nthree_3_III\nfour_4_IV\n' | FZF_DEFAULT_OPTS='' fzf --height=6 --with-nth=1,2 --delimiter='_'
  four_4_
  three_3_
  two_2_
> one_1_    <--- final trailing delimiter
  4/4
> _
```

With the patch:

```bash
$ printf '%s' $'one_1_I\ntwo_2_II\nthree_3_III\nfour_4_IV\n' | FZF_DEFAULT_OPTS='' fzf --height=6 --with-nth=1,2 --delimiter='_'
  four_4
  three_3
  two_2
> one_1
  4/4
> _
```

This first draft of the patch likely has some problems.  I am unfamiliar with Go, and did not look into what `prefixLength` does.