### PR TITLE
Fix multiline ps1 on zsh

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -29,7 +29,7 @@ __fzfcmd() {
 fzf-file-widget() {
   LBUFFER="${LBUFFER}$(__fsel)"
   local ret=$?
-  zle redisplay
+  zle -R
   typeset -f zle-line-init >/dev/null && zle zle-line-init
   return $ret
 }
@@ -43,6 +43,7 @@ fzf-redraw-prompt() {
     $precmd
   done
   zle reset-prompt
+  zle -R
 }
 zle -N fzf-redraw-prompt
 
@@ -78,7 +79,7 @@ fzf-history-widget() {
       zle vi-fetch-history -n $num
     fi
   fi
-  zle redisplay
+  zle -R
   typeset -f zle-line-init >/dev/null && zle zle-line-init
   return $ret
 }


### PR DESCRIPTION
These changes make fzf work perfect on a multiline ps1 prompt.
Without these changes you got lines "eaten" after canceling (and on some cases accepting) the fzf action triggered by one of these helper actions.

This fixes the behavior observed on #490, only for zsh.