### PR TITLE
Add an option: --tty=DEVICE

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -365,6 +365,9 @@ ncurses finder only after the input stream is complete.
 e.g. \fBfzf --multi | fzf --sync\fR
 .RE
 .TP
+.BI "--tty=" "DEVICE"
+Device name of tty (default: \fB/dev/tty\fR)
+.TP
 .B "--version"
 Display version information and exit
 

--- a/src/options.go
+++ b/src/options.go
@@ -86,6 +86,7 @@ const usage = `usage: fzf [options]
     --read0               Read input delimited by ASCII NUL characters
     --print0              Print output delimited by ASCII NUL characters
     --sync                Synchronous search for multi-staged filtering
+    --tty=DEVICE          Use DEVICE as tty (default: /dev/tty)
     --version             Display version information and exit
 
   Environment variables
@@ -188,6 +189,7 @@ type Options struct {
 	Bordered    bool
 	Tabstop     int
 	ClearOnExit bool
+	TtyDevice   string
 	Version     bool
 }
 
@@ -237,6 +239,7 @@ func defaultOptions() *Options {
 		Margin:      defaultMargin(),
 		Tabstop:     8,
 		ClearOnExit: true,
+		TtyDevice:   "/dev/tty",
 		Version:     false}
 }
 
@@ -1133,6 +1136,8 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.ClearOnExit = true
 		case "--no-clear":
 			opts.ClearOnExit = false
+		case "--tty":
+			opts.TtyDevice = nextString(allArgs, &i, "device name required")
 		case "--version":
 			opts.Version = true
 		default:
@@ -1188,6 +1193,8 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.HscrollOff = atoi(value)
 			} else if match, value := optString(arg, "--jump-labels="); match {
 				opts.JumpLabels = value
+			} else if match, value := optString(arg, "--tty="); match {
+				opts.TtyDevice = value
 			} else {
 				errorExit("unknown option: " + arg)
 			}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -326,7 +326,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		if tui.HasFullscreenRenderer() {
 			renderer = tui.NewFullscreenRenderer(opts.Theme, opts.Black, opts.Mouse)
 		} else {
-			renderer = tui.NewLightRenderer(opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit,
+			renderer = tui.NewLightRenderer(opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit, opts.TtyDevice,
 				true, func(h int) int { return h })
 		}
 	} else {
@@ -350,7 +350,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 			}
 			return util.Min(termHeight, util.Max(maxHeight, effectiveMinHeight))
 		}
-		renderer = tui.NewLightRenderer(opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit, false, maxHeightFunc)
+		renderer = tui.NewLightRenderer(opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit, opts.TtyDevice, false, maxHeightFunc)
 	}
 	wordRubout := "[^[:alnum:]][[:alnum:]]"
 	wordNext := "[[:alnum:]][^[:alnum:]]|(.$)"


### PR DESCRIPTION
I have a similar problem to #447, where tty is somehow inaccessible via /dev/tty but $TTY still points to the working tty.  In this case, you could say `fzf --tty=$TTY` to force attaching to the tty.

In my case, I tried to invoke fzf from within rb-readline on Rails console run under spring, but I got the `Failed to open /dev/tty` error.  I guess there could be something wrong with the handling of tty in any of pry/spring/rb-readline, but I wasn't able to identify which and how.