### PR TITLE
Provide an option to reverse items only

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,8 @@ cursor with `--height` option.
 vim $(fzf --height 40%)
 ```
 
-Also check out `--reverse` option if you prefer "top-down" layout instead of
-the default "bottom-up" layout.
+Also check out `--reverse` and `--layout` options if you prefer
+"top-down" layout instead of the default "bottom-up" layout.
 
 ```sh
 vim $(fzf --height 40% --reverse)
@@ -228,7 +228,7 @@ You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
 default. For example,
 
 ```sh
-export FZF_DEFAULT_OPTS='--height 40% --reverse --border'
+export FZF_DEFAULT_OPTS='--height 40% --layout=reverse-list --border'
 ```
 
 #### Search syntax
@@ -266,7 +266,7 @@ or `py`.
     - e.g. `export FZF_DEFAULT_COMMAND='fd --type f'`
 - `FZF_DEFAULT_OPTS`
     - Default options
-    - e.g. `export FZF_DEFAULT_OPTS="--reverse --inline-info"`
+    - e.g. `export FZF_DEFAULT_OPTS="--layout=reverse-list --inline-info"`
 
 #### Options
 

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
 default. For example,
 
 ```sh
-export FZF_DEFAULT_OPTS='--height 40% --layout=reverse-list --border'
+export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
 ```
 
 #### Search syntax
@@ -266,7 +266,7 @@ or `py`.
     - e.g. `export FZF_DEFAULT_COMMAND='fd --type f'`
 - `FZF_DEFAULT_OPTS`
     - Default options
-    - e.g. `export FZF_DEFAULT_OPTS="--layout=reverse-list --inline-info"`
+    - e.g. `export FZF_DEFAULT_OPTS="--layout=reverse --inline-info"`
 
 #### Options
 

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -157,19 +157,19 @@ Minimum height when \fB--height\fR is given in percent (default: 10).
 Ignored when \fB--height\fR is not specified.
 .TP
 .BI "--layout=" "LAYOUT"
-Choose the layout (default: bottom-up)
+Choose the layout (default: default)
 
 .br
-.BR bottom-up "     Show everything from bottom up"
+.BR default "     Show everything from bottom up"
 .br
-.BR top-down "      Show everything from top down"
+.BR reverse "     Show everything from top down"
 .br
-.BR top-down-below "Show items from top down, prompt and header at the bottom"
+.BR reverse-list "Show items from top down, prompt and header at the bottom"
 .br
 
 .TP
 .B "--reverse"
-Deprecated synonym for \fB--layout=top-down\fB
+A synonym for \fB--layout=reverse\fB
 
 .TP
 .B "--border"
@@ -553,8 +553,8 @@ triggered whenever the query string is changed.
     \fBtoggle\fR                (\fIright-click\fR)
     \fBtoggle-all\fR
     \fBtoggle+down\fR           \fIctrl-i  (tab)\fR
-    \fBtoggle-in\fR             (\fB--layout=top-down*\fR ? \fBtoggle+up\fR : \fBtoggle+down\fR)
-    \fBtoggle-out\fR            (\fB--layout=top-down*\fR ? \fBtoggle+down\fR : \fBtoggle+up\fR)
+    \fBtoggle-in\fR             (\fB--layout=reverse*\fR ? \fBtoggle+up\fR : \fBtoggle+down\fR)
+    \fBtoggle-out\fR            (\fB--layout=reverse*\fR ? \fBtoggle+down\fR : \fBtoggle+up\fR)
     \fBtoggle-preview\fR
     \fBtoggle-preview-wrap\fR
     \fBtoggle-sort\fR

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -160,11 +160,11 @@ Ignored when \fB--height\fR is not specified.
 Choose the layout (default: default)
 
 .br
-.BR default "     Show everything from bottom up"
+.BR default "       Display from the bottom of the screen"
 .br
-.BR reverse "     Show everything from top down"
+.BR reverse "       Display from the top of the screen"
 .br
-.BR reverse-list "Show items from top down, prompt and header at the bottom"
+.BR reverse-list "  Display from the top of the screen, prompt at the bottom"
 .br
 
 .TP

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -156,8 +156,21 @@ the full screen.
 Minimum height when \fB--height\fR is given in percent (default: 10).
 Ignored when \fB--height\fR is not specified.
 .TP
+.BI "--layout=" "LAYOUT"
+Choose the layout (default: bottom-up)
+
+.br
+.BR bottom-up "     Show everything from bottom up"
+.br
+.BR top-down "      Show everything from top down"
+.br
+.BR top-down-below "Show items from top down, prompt and header at the bottom"
+.br
+
+.TP
 .B "--reverse"
-Reverse orientation
+Deprecated synonym for \fB--layout=top-down\fB
+
 .TP
 .B "--border"
 Draw border above and below the finder
@@ -195,7 +208,7 @@ Input prompt (default: '> ')
 .TP
 .BI "--header=" "STR"
 The given string will be printed as the sticky header. The lines are displayed
-in the given order from top to bottom regardless of \fB--reverse\fR option, and
+in the given order from top to bottom regardless of \fB--layout\fR option, and
 are not affected by \fB--with-nth\fR. ANSI color codes are processed even when
 \fB--ansi\fR is not set.
 .TP
@@ -540,8 +553,8 @@ triggered whenever the query string is changed.
     \fBtoggle\fR                (\fIright-click\fR)
     \fBtoggle-all\fR
     \fBtoggle+down\fR           \fIctrl-i  (tab)\fR
-    \fBtoggle-in\fR             (\fB--reverse\fR ? \fBtoggle+up\fR : \fBtoggle+down\fR)
-    \fBtoggle-out\fR            (\fB--reverse\fR ? \fBtoggle+down\fR : \fBtoggle+up\fR)
+    \fBtoggle-in\fR             (\fB--layout=top-down*\fR ? \fBtoggle+up\fR : \fBtoggle+down\fR)
+    \fBtoggle-out\fR            (\fB--layout=top-down*\fR ? \fBtoggle+down\fR : \fBtoggle+up\fR)
     \fBtoggle-preview\fR
     \fBtoggle-preview-wrap\fR
     \fBtoggle-sort\fR

--- a/src/options.go
+++ b/src/options.go
@@ -53,8 +53,8 @@ const usage = `usage: fzf [options]
                           height instead of using fullscreen
     --min-height=HEIGHT   Minimum height when --height is given in percent
                           (default: 10)
-    --layout=LAYOUT       Choose layout: [bottom-up|top-down|top-down-below]
-                          (default: bottom-up)
+    --layout=LAYOUT       Choose layout: [default|reverse|reverse-list]
+                          (default: default)
     --border              Draw border above and below the finder
     --margin=MARGIN       Screen margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
     --inline-info         Display finder info inline with the query
@@ -92,7 +92,7 @@ const usage = `usage: fzf [options]
   Environment variables
     FZF_DEFAULT_COMMAND   Default command to use when input is tty
     FZF_DEFAULT_OPTS      Default options
-                          (e.g. '--layout=top-down --inline-info')
+                          (e.g. '--layout=reverse-list --inline-info')
 
 `
 
@@ -137,9 +137,9 @@ const (
 type layoutType int
 
 const (
-	layoutBottomUp layoutType = iota
-	layoutTopDown
-	layoutTopDownBelow
+	layoutDefault layoutType = iota
+	layoutReverse
+	layoutReverseList
 )
 
 type previewOpts struct {
@@ -221,7 +221,7 @@ func defaultOptions() *Options {
 		Black:       false,
 		Bold:        true,
 		MinHeight:   10,
-		Layout:      layoutBottomUp,
+		Layout:      layoutDefault,
 		Cycle:       false,
 		Hscroll:     true,
 		HscrollOff:  10,
@@ -869,16 +869,16 @@ func parseHeight(str string) sizeSpec {
 
 func parseLayout(str string) layoutType {
 	switch str {
-	case "bottom-up":
-		return layoutBottomUp
-	case "top-down":
-		return layoutTopDown
-	case "top-down-below":
-		return layoutTopDownBelow
+	case "default":
+		return layoutDefault
+	case "reverse":
+		return layoutReverse
+	case "reverse-list":
+		return layoutReverseList
 	default:
-		errorExit("invalid layout (expected: bottom-up / top-down / top-down-below)")
+		errorExit("invalid layout (expected: default / reverse / reverse-list)")
 	}
-	return layoutBottomUp
+	return layoutDefault
 }
 
 func parsePreviewWindow(opts *previewOpts, input string) {
@@ -1063,11 +1063,11 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.Bold = false
 		case "--layout":
 			opts.Layout = parseLayout(
-				nextString(allArgs, &i, "layout required (bottom-up / top-down / top-down-below)"))
+				nextString(allArgs, &i, "layout required (default / reverse / reverse-list)"))
 		case "--reverse":
-			opts.Layout = layoutTopDown
+			opts.Layout = layoutReverse
 		case "--no-reverse":
-			opts.Layout = layoutBottomUp
+			opts.Layout = layoutDefault
 		case "--cycle":
 			opts.Cycle = true
 		case "--no-cycle":

--- a/src/options.go
+++ b/src/options.go
@@ -54,7 +54,6 @@ const usage = `usage: fzf [options]
     --min-height=HEIGHT   Minimum height when --height is given in percent
                           (default: 10)
     --layout=LAYOUT       Choose layout: [default|reverse|reverse-list]
-                          (default: default)
     --border              Draw border above and below the finder
     --margin=MARGIN       Screen margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
     --inline-info         Display finder info inline with the query
@@ -92,7 +91,7 @@ const usage = `usage: fzf [options]
   Environment variables
     FZF_DEFAULT_COMMAND   Default command to use when input is tty
     FZF_DEFAULT_OPTS      Default options
-                          (e.g. '--layout=reverse-list --inline-info')
+                          (e.g. '--layout=reverse --inline-info')
 
 `
 

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -302,7 +302,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 	input := trimQuery(opts.Query)
 	var header []string
 	switch opts.Layout {
-	case layoutBottomUp, layoutTopDownBelow:
+	case layoutDefault, layoutReverseList:
 		header = reverseStringArray(opts.Header)
 	default:
 		header = opts.Header
@@ -646,9 +646,9 @@ func (t *Terminal) move(y int, x int, clear bool) {
 	h := t.window.Height()
 
 	switch t.layout {
-	case layoutBottomUp:
+	case layoutDefault:
 		y = h - y - 1
-	case layoutTopDownBelow:
+	case layoutReverseList:
 		n := 2 + len(t.header)
 		if t.inlineInfo {
 			n--
@@ -761,7 +761,7 @@ func (t *Terminal) printList() {
 	count := t.merger.Length() - t.offset
 	for j := 0; j < maxy; j++ {
 		i := j
-		if t.layout == layoutBottomUp {
+		if t.layout == layoutDefault {
 			i = maxy - 1 - j
 		}
 		line := i + 2 + len(t.header)
@@ -1673,12 +1673,12 @@ func (t *Terminal) Loop() {
 					req(reqList, reqInfo)
 				}
 			case actToggleIn:
-				if t.layout != layoutBottomUp {
+				if t.layout != layoutDefault {
 					return doAction(action{t: actToggleUp}, mapkey)
 				}
 				return doAction(action{t: actToggleDown}, mapkey)
 			case actToggleOut:
-				if t.layout != layoutBottomUp {
+				if t.layout != layoutDefault {
 					return doAction(action{t: actToggleDown}, mapkey)
 				}
 				return doAction(action{t: actToggleUp}, mapkey)
@@ -1812,9 +1812,9 @@ func (t *Terminal) Loop() {
 					}
 					h := t.window.Height()
 					switch t.layout {
-					case layoutBottomUp:
+					case layoutDefault:
 						my = h - my - 1
-					case layoutTopDownBelow:
+					case layoutReverseList:
 						if my < h-min {
 							my += min
 						} else {
@@ -1907,7 +1907,7 @@ func (t *Terminal) constrain() {
 }
 
 func (t *Terminal) vmove(o int, allowCycle bool) {
-	if t.layout != layoutBottomUp {
+	if t.layout != layoutDefault {
 		o *= -1
 	}
 	dest := t.cy + o

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -1045,8 +1045,8 @@ class TestGoFZF < TestBase
     assert_equal '50', readonce.chomp
   end
 
-  def test_header_lines_top_down
-    tmux.send_keys "seq 100 | #{fzf '--header-lines=10 -q 5 --layout=top-down'}", :Enter
+  def test_header_lines_reverse
+    tmux.send_keys "seq 100 | #{fzf '--header-lines=10 -q 5 --reverse'}", :Enter
     2.times do
       tmux.until do |lines|
         lines[1].include?('/90') &&
@@ -1060,8 +1060,8 @@ class TestGoFZF < TestBase
     assert_equal '50', readonce.chomp
   end
 
-  def test_header_lines_top_down_below
-    tmux.send_keys "seq 100 | #{fzf '--header-lines=10 -q 5 --layout=top-down-below'}", :Enter
+  def test_header_lines_reverse_list
+    tmux.send_keys "seq 100 | #{fzf '--header-lines=10 -q 5 --layout=reverse-list'}", :Enter
     2.times do
       tmux.until do |lines|
         lines[0]    == '> 50' &&
@@ -1107,8 +1107,8 @@ class TestGoFZF < TestBase
     end
   end
 
-  def test_header_top_down
-    tmux.send_keys "seq 100 | #{fzf "--header=\\\"\\$(head -5 #{FILE})\\\" --layout=top-down"}", :Enter
+  def test_header_reverse
+    tmux.send_keys "seq 100 | #{fzf "--header=\\\"\\$(head -5 #{FILE})\\\" --reverse"}", :Enter
     header = File.readlines(FILE).take(5).map(&:strip)
     tmux.until do |lines|
       lines[1].include?('100/100') &&
@@ -1117,8 +1117,8 @@ class TestGoFZF < TestBase
     end
   end
 
-  def test_header_top_down_below
-    tmux.send_keys "seq 100 | #{fzf "--header=\\\"\\$(head -5 #{FILE})\\\" --layout=top-down-below"}", :Enter
+  def test_header_reverse_list
+    tmux.send_keys "seq 100 | #{fzf "--header=\\\"\\$(head -5 #{FILE})\\\" --layout=reverse-list"}", :Enter
     header = File.readlines(FILE).take(5).map(&:strip)
     tmux.until do |lines|
       lines[-2].include?('100/100') &&
@@ -1137,8 +1137,8 @@ class TestGoFZF < TestBase
     end
   end
 
-  def test_header_and_header_lines_top_down
-    tmux.send_keys "seq 100 | #{fzf "--layout=top-down --header-lines 10 --header \\\"\\$(head -5 #{FILE})\\\""}", :Enter
+  def test_header_and_header_lines_reverse
+    tmux.send_keys "seq 100 | #{fzf "--reverse --header-lines 10 --header \\\"\\$(head -5 #{FILE})\\\""}", :Enter
     header = File.readlines(FILE).take(5).map(&:strip)
     tmux.until do |lines|
       lines[1].include?('90/90') &&
@@ -1147,8 +1147,8 @@ class TestGoFZF < TestBase
     end
   end
 
-  def test_header_and_header_lines_top_down_below
-    tmux.send_keys "seq 100 | #{fzf "--layout=top-down-below --header-lines 10 --header \\\"\\$(head -5 #{FILE})\\\""}", :Enter
+  def test_header_and_header_lines_reverse_list
+    tmux.send_keys "seq 100 | #{fzf "--layout=reverse-list --header-lines 10 --header \\\"\\$(head -5 #{FILE})\\\""}", :Enter
     header = File.readlines(FILE).take(5).map(&:strip)
     tmux.until do |lines|
       lines[-2].include?('90/90') &&
@@ -1176,14 +1176,14 @@ class TestGoFZF < TestBase
     tmux.send_keys :Enter
   end
 
-  def test_margin_top_down
-    tmux.send_keys "seq 1000 | #{fzf '--margin 7,5 --layout=top-down'}", :Enter
+  def test_margin_reverse
+    tmux.send_keys "seq 1000 | #{fzf '--margin 7,5 --reverse'}", :Enter
     tmux.until { |lines| lines[1 + 7] == '       1000/1000' }
     tmux.send_keys :Enter
   end
 
-  def test_margin_top_down_below
-    tmux.send_keys "yes | head -1000 | #{fzf '--margin 5,3 --layout=top-down-below'}", :Enter
+  def test_margin_reverse_list
+    tmux.send_keys "yes | head -1000 | #{fzf '--margin 5,3 --layout=reverse-list'}", :Enter
     tmux.until { |lines| lines[4] == '' && lines[5] == '   > y' }
     tmux.send_keys :Enter
   end
@@ -1387,7 +1387,7 @@ class TestGoFZF < TestBase
     rescue
       nil
     end
-    tmux.send_keys %(seq 100 | #{FZF} --layout=top-down --preview 'echo {} >> #{tempname}; echo ' --preview-window 0), :Enter
+    tmux.send_keys %(seq 100 | #{FZF} --reverse --preview 'echo {} >> #{tempname}; echo ' --preview-window 0), :Enter
     tmux.until { |lines| lines.item_count == 100 && lines[1] == '  100/100' && lines[2] == '> 1' }
     tmux.until { |_| %w[1] == File.readlines(tempname).map(&:chomp) }
     tmux.send_keys :Down


### PR DESCRIPTION
I'm quite used to have a prompt at the bottom of the screen (not to mention vim & emacs) while I prefer a list of items shown from top down.  I just don't want to be distracted by what I type but just like to concentrate on what to pick.

So, I've extended the `--reverse` option so it optionally takes `all`, `items` or `none` so you can choose which area to reverse.