### PR TITLE
Restore tmux window options

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -136,6 +136,11 @@ fifo3="${TMPDIR:-/tmp}/fzf-fifo3-$id"
 cleanup() {
   \rm -f $argsf $fifo1 $fifo2 $fifo3
 
+  # Reset remain-on-exit window option
+  if [[ -n "$tmux_remain_on_exit" ]]; then
+    tmux set-window-option $tmux_remain_on_exit
+  fi
+
   # Remove temp window if we were zoomed
   if [[ -n "$zoomed" ]]; then
     tmux display-message -p "#{window_id}" > /dev/null
@@ -173,6 +178,8 @@ done
 pppid=$$
 echo -n "trap 'kill -SIGUSR1 -$pppid' EXIT SIGINT SIGTERM;" > $argsf
 close="; trap - EXIT SIGINT SIGTERM $close"
+
+tmux_remain_on_exit=$(tmux show-window-options remain-on-exit)
 
 if [[ -n "$term" ]] || [[ -t 0 ]]; then
   cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -136,14 +136,9 @@ fifo3="${TMPDIR:-/tmp}/fzf-fifo3-$id"
 cleanup() {
   \rm -f $argsf $fifo1 $fifo2 $fifo3
 
-  # Reset remain-on-exit window option
-  if [[ -n "$tmux_remain_on_exit" ]]; then
-    tmux set-window-option $tmux_remain_on_exit
-  fi
-
-  # Reset synchronize-panes window option
-  if [[ -n "$tmux_synchronize_panes" ]]; then
-    tmux set-window-option $tmux_synchronize_panes
+  # Restore tmux window options
+  if [[ "${#tmux_win_opts[@]}" -gt 0 ]]; then
+    eval "tmux ${tmux_win_opts[@]}"
   fi
 
   # Remove temp window if we were zoomed
@@ -184,8 +179,7 @@ pppid=$$
 echo -n "trap 'kill -SIGUSR1 -$pppid' EXIT SIGINT SIGTERM;" > $argsf
 close="; trap - EXIT SIGINT SIGTERM $close"
 
-tmux_remain_on_exit=$(tmux show-window-options remain-on-exit)
-tmux_synchronize_panes=$(tmux show-window-options synchronize-panes)
+tmux_win_opts=( $(tmux show-window-options remain-on-exit \; show-window-options synchronize-panes | sed 's/^/set-window-option /; s/$/ \\;/') )
 
 if [[ -n "$term" ]] || [[ -t 0 ]]; then
   cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -141,6 +141,11 @@ cleanup() {
     tmux set-window-option $tmux_remain_on_exit
   fi
 
+  # Reset synchronize-panes window option
+  if [[ -n "$tmux_synchronize_panes" ]]; then
+    tmux set-window-option $tmux_synchronize_panes
+  fi
+
   # Remove temp window if we were zoomed
   if [[ -n "$zoomed" ]]; then
     tmux display-message -p "#{window_id}" > /dev/null
@@ -180,6 +185,7 @@ echo -n "trap 'kill -SIGUSR1 -$pppid' EXIT SIGINT SIGTERM;" > $argsf
 close="; trap - EXIT SIGINT SIGTERM $close"
 
 tmux_remain_on_exit=$(tmux show-window-options remain-on-exit)
+tmux_synchronize_panes=$(tmux show-window-options synchronize-panes)
 
 if [[ -n "$term" ]] || [[ -t 0 ]]; then
   cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf


### PR DESCRIPTION
The `fzf-tmux` script disables the tmux `synchronize-panes` and `remain-on-exit` window options without restoring the original values. This PR fixes that by saving the original values of these options and restoring them on exit.

Note: This fix suffers from a race condition which can result in incorrect and unexpected behaviour if `fzf-tmux` is run concurrently in more than one pane of the same tmux window. I don't think it's possible to avoid that without maintaining some global state for each tmux window, which I think is undesirable and unnecessarily complicated given that this is quite unlikely to occur anyway.