### PR TITLE
Support for XDG Base Directory Specification

### DIFF
--- a/install
+++ b/install
@@ -11,9 +11,9 @@ allow_legacy=
 shells="bash zsh fish"
 config_prefix="~/."
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]] \
+if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z "$XDG_CONFIG_HOME" ]] && [[ -d "$XDG_CONFIG_HOME" ]] \
     && [[ ! -e ~/.fzf.bash ]]; then
-  config_prefix="\${XDG_CONFIG_HOME:-${XDG_CONFIG_HOME}}/fzf/"
+  config_prefix='"$XDG_CONFIG_HOME"/fzf/'
   fish_dir=$XDG_CONFIG_HOME/fish
   mkdir -p "$XDG_CONFIG_HOME/fzf/"
 elif [[ -d ~/.config/fzf ]]; then

--- a/install
+++ b/install
@@ -51,7 +51,6 @@ for opt in "$@"; do
       eval 'config_dir="$config_prefix"'
       eval "config_dir=$config_dir"
       eval "config_dir=$config_dir"
-      echo $config_dir
       mkdir -p "$config_dir"
       ;;
     --key-bindings)    key_bindings=1    ;;

--- a/install
+++ b/install
@@ -9,13 +9,15 @@ update_config=2
 binary_arch=
 allow_legacy=
 shells="bash zsh fish"
-config_dir=~/.config/fzf
+config_base=~/.
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
-    config_dir=$XDG_CONFIG_HOME/fzf
-    fish_dir=$XDG_CONFIG_HOME/fish
+if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]]; then
+  config_base=$XDG_CONFIG_HOME/fzf/
+  fish_dir=$XDG_CONFIG_HOME/fish/
+  mkdir -p $config_base
+elif [[ -d ~/.config/fzf ]]; then
+  config_base=~/.config/fzf/
 fi
-mkdir -p $config_dir
 
 help() {
   cat << EOF
@@ -247,8 +249,8 @@ fi
 echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
-  echo -n "Generate ${config_dir}/fzf.$shell ... "
-  src=${config_dir}/fzf.${shell}
+  echo -n "Generate ${config_base}fzf.$shell ... "
+  src=${config_base}fzf.${shell}
 
   fzf_completion="[[ \$- == *i* ]] && source \"$fzf_base/shell/completion.${shell}\" 2> /dev/null"
   if [ $auto_completion -eq 0 ]; then
@@ -288,13 +290,13 @@ if [[ "$shells" =~ fish ]]; then
 EOF
   [ $? -eq 0 ] && echo "OK" || echo "Failed"
 
-  mkdir -p $fish_dir/functions
-  if [ -e $fish_dir/functions/fzf.fish ]; then
-    echo -n "Remove unnecessary $fish_dir/functions/fzf.fish ... "
-    rm -f $fish_dir/functions/fzf.fish && echo "OK" || echo "Failed"
+  mkdir -p ${fish_dir}functions
+  if [ -e ${fish_dir}functions/fzf.fish ]; then
+    echo -n "Remove unnecessary ${fish_dir}functions/fzf.fish ... "
+    rm -f ${fish_dir}functions/fzf.fish && echo "OK" || echo "Failed"
   fi
 
-  fish_binding=$fish_dir/functions/fzf_key_bindings.fish
+  fish_binding=${fish_dir}functions/fzf_key_bindings.fish
   if [ $key_bindings -ne 0 ]; then
     echo -n "Symlink $fish_binding ... "
     ln -sf "$fzf_base/shell/key-bindings.fish" \
@@ -360,11 +362,11 @@ echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
   [ $shell = zsh ] && dest=${ZDOTDIR:-~}/.zshrc || dest=~/.bashrc
-  append_line $update_config "[ -f ${config_dir}/fzf.${shell} ] && source ${config_dir}/fzf.${shell}" "$dest" "${config_dir}/fzf.${shell}"
+  append_line $update_config "[ -f ${config_base}fzf.${shell} ] && source ${config_base}fzf.${shell}" "$dest" "${config_base}fzf.${shell}"
 done
 
 if [ $key_bindings -eq 1 ] && [[ "$shells" =~ fish ]]; then
-  bind_file=$fish_dir/functions/fish_user_key_bindings.fish
+  bind_file=${fish_dir}functions/fish_user_key_bindings.fish
   if [ ! -e "$bind_file" ]; then
     create_file "$bind_file" \
       'function fish_user_key_bindings' \

--- a/install
+++ b/install
@@ -11,8 +11,7 @@ allow_legacy=
 shells="bash zsh fish"
 config_dir=~/.config/fzf
 fish_dir=~/.config/fish
-if [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
-    echo hi
+if [[ -v XDG_CONFIG_HOME ]] && [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
     config_dir=$XDG_CONFIG_HOME/fzf
     fish_dir=$XDG_CONFIG_HOME/fish
 fi

--- a/install
+++ b/install
@@ -262,8 +262,8 @@ for shell in $shells; do
     fzf_key_bindings="# $fzf_key_bindings"
   fi
 
-  eval "src=\"$src\""
-  cat > "$src" << EOF
+  eval "src=$src"
+  cat > $src << EOF
 # Setup fzf
 # ---------
 if [[ ! "\$PATH" == *$fzf_base/bin* ]]; then

--- a/install
+++ b/install
@@ -21,7 +21,7 @@ usage: $0 [OPTIONS]
     --bin                Download fzf binary only; Do not generate ~/.fzf.{bash,zsh}
     --all                Download fzf binary and update configuration files
                          to enable key bindings and fuzzy completion
-    --xdg                Use xdg config directories
+    --xdg                Use XDG config directory
     --[no-]key-bindings  Enable/disable key bindings (CTRL-T, CTRL-R, ALT-C)
     --[no-]completion    Enable/disable fuzzy completion (bash & zsh)
     --[no-]update-rc     Whether or not to update shell configuration files

--- a/install
+++ b/install
@@ -264,7 +264,7 @@ for shell in $shells; do
   fi
 
   eval "src=$src"
-  cat > $src << EOF
+  cat > "$src" << EOF
 # Setup fzf
 # ---------
 if [[ ! "\$PATH" == *$fzf_base/bin* ]]; then
@@ -292,13 +292,13 @@ if [[ "$shells" =~ fish ]]; then
 EOF
   [ $? -eq 0 ] && echo "OK" || echo "Failed"
 
-  mkdir -p ${fish_dir}/functions
-  if [ -e ${fish_dir}/functions/fzf.fish ]; then
+  mkdir -p "${fish_dir}/functions"
+  if [ -e "${fish_dir}/functions/fzf.fish" ]; then
     echo -n "Remove unnecessary ${fish_dir}/functions/fzf.fish ... "
-    rm -f ${fish_dir}/functions/fzf.fish && echo "OK" || echo "Failed"
+    rm -f "${fish_dir}/functions/fzf.fish" && echo "OK" || echo "Failed"
   fi
 
-  fish_binding=${fish_dir}/functions/fzf_key_bindings.fish
+  fish_binding="${fish_dir}/functions/fzf_key_bindings.fish"
   if [ $key_bindings -ne 0 ]; then
     echo -n "Symlink $fish_binding ... "
     ln -sf "$fzf_base/shell/key-bindings.fish" \
@@ -368,7 +368,7 @@ for shell in $shells; do
 done
 
 if [ $key_bindings -eq 1 ] && [[ "$shells" =~ fish ]]; then
-  bind_file=${fish_dir}/functions/fish_user_key_bindings.fish
+  bind_file="${fish_dir}/functions/fish_user_key_bindings.fish"
   if [ ! -e "$bind_file" ]; then
     create_file "$bind_file" \
       'function fish_user_key_bindings' \

--- a/install
+++ b/install
@@ -11,7 +11,7 @@ allow_legacy=
 shells="bash zsh fish"
 config_prefix="~/."
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]]; then
+if [[ -v XDG_CONFIG_HOME ]] && [[ $(echo $XDG_CONFIG_HOME | wc -w) -eq 1 ]] && [[ -d $XDG_CONFIG_HOME ]]; then
   config_prefix='$XDG_CONFIG_HOME/fzf/'
   fish_dir=$XDG_CONFIG_HOME/fish
   mkdir -p $XDG_CONFIG_HOME/fzf/

--- a/install
+++ b/install
@@ -9,14 +9,14 @@ update_config=2
 binary_arch=
 allow_legacy=
 shells="bash zsh fish"
-config_prefix=~/.
+config_prefix="~/."
 fish_dir=~/.config/fish
 if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]]; then
-  config_prefix=$XDG_CONFIG_HOME/fzf/
+  config_prefix='$XDG_CONFIG_HOME/fzf/'
   fish_dir=$XDG_CONFIG_HOME/fish
-  mkdir -p $config_prefix
+  mkdir -p $XDG_CONFIG_HOME/fzf/
 elif [[ -d ~/.config/fzf ]]; then
-  config_prefix=~/.config/fzf/
+  config_prefix="~/.config/fzf/"
 fi
 
 help() {
@@ -262,7 +262,8 @@ for shell in $shells; do
     fzf_key_bindings="# $fzf_key_bindings"
   fi
 
-  cat > $src << EOF
+  eval "src=\"$src\""
+  cat > "$src" << EOF
 # Setup fzf
 # ---------
 if [[ ! "\$PATH" == *$fzf_base/bin* ]]; then
@@ -379,7 +380,7 @@ fi
 
 if [ $update_config -eq 1 ]; then
   echo 'Finished. Restart your shell or reload config file.'
-  [[ "$shells" =~ bash ]] && echo '   source ~/.bashrc  # bash'
+  [[ "$shells" =~ bash ]] && echo "   source ~/.bashrc  # bash"
   [[ "$shells" =~ zsh ]]  && echo "   source ${ZDOTDIR:-~}/.zshrc   # zsh"
   [[ "$shells" =~ fish ]] && [ $key_bindings -eq 1 ] && echo '   fzf_key_bindings  # fish'
   echo

--- a/install
+++ b/install
@@ -9,9 +9,8 @@ update_config=2
 binary_arch=
 allow_legacy=
 shells="bash zsh fish"
-config_dir=~
-config_filename=.fzf
-config_prefix='~/.fzf'
+prefix='~/.fzf'
+prefix_expand=~/.fzf
 fish_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fish
 
 help() {
@@ -49,10 +48,9 @@ for opt in "$@"; do
       allow_legacy=1
       ;;
     --xdg)
-      config_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fzf
-      config_filename=fzf
-      config_prefix='"${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf'
-      mkdir -p "$config_dir"
+      prefix='"${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf'
+      prefix_expand=${XDG_CONFIG_HOME:-$HOME/.config}/fzf/fzf
+      mkdir -p "${XDG_CONFIG_HOME:-$HOME/.config}/fzf"
       ;;
     --key-bindings)    key_bindings=1    ;;
     --no-key-bindings) key_bindings=0    ;;
@@ -251,7 +249,7 @@ fi
 echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
-  src=${config_dir}/${config_filename}.${shell}
+  src=${prefix_expand}.${shell}
   echo -n "Generate $src ... "
 
   fzf_completion="[[ \$- == *i* ]] && source \"$fzf_base/shell/completion.${shell}\" 2> /dev/null"
@@ -364,7 +362,7 @@ echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
   [ $shell = zsh ] && dest=${ZDOTDIR:-~}/.zshrc || dest=~/.bashrc
-  append_line $update_config "[ -f ${config_prefix}.${shell} ] && source ${config_prefix}.${shell}" "$dest" "${config_prefix}.${shell}"
+  append_line $update_config "[ -f ${prefix}.${shell} ] && source ${prefix}.${shell}" "$dest" "${prefix}.${shell}"
 done
 
 if [ $key_bindings -eq 1 ] && [[ "$shells" =~ fish ]]; then
@@ -381,7 +379,7 @@ fi
 
 if [ $update_config -eq 1 ]; then
   echo 'Finished. Restart your shell or reload config file.'
-  [[ "$shells" =~ bash ]] && echo "   source ~/.bashrc  # bash"
+  [[ "$shells" =~ bash ]] && echo '   source ~/.bashrc  # bash'
   [[ "$shells" =~ zsh ]]  && echo "   source ${ZDOTDIR:-~}/.zshrc   # zsh"
   [[ "$shells" =~ fish ]] && [ $key_bindings -eq 1 ] && echo '   fzf_key_bindings  # fish'
   echo

--- a/install
+++ b/install
@@ -11,14 +11,6 @@ allow_legacy=
 shells="bash zsh fish"
 config_prefix='~/.'
 fish_dir=${XDG_CONFIG_HOME:-~/.config}/fish
-if [[ ! -e ~/.fzf.bash ]]; then
-  config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
-  eval 'config_dir="$config_prefix"'
-  eval "config_dir=$config_dir"
-  eval "config_dir=$config_dir"
-  echo $config_dir
-  mkdir -p "$config_dir"
-fi
 
 help() {
   cat << EOF
@@ -28,6 +20,7 @@ usage: $0 [OPTIONS]
     --bin                Download fzf binary only; Do not generate ~/.fzf.{bash,zsh}
     --all                Download fzf binary and update configuration files
                          to enable key bindings and fuzzy completion
+    --xdg                Use xdg config directories
     --[no-]key-bindings  Enable/disable key bindings (CTRL-T, CTRL-R, ALT-C)
     --[no-]completion    Enable/disable fuzzy completion (bash & zsh)
     --[no-]update-rc     Whether or not to update shell configuration files
@@ -52,6 +45,14 @@ for opt in "$@"; do
       key_bindings=1
       update_config=1
       allow_legacy=1
+      ;;
+    --xdg)
+      config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
+      eval 'config_dir="$config_prefix"'
+      eval "config_dir=$config_dir"
+      eval "config_dir=$config_dir"
+      echo $config_dir
+      mkdir -p "$config_dir"
       ;;
     --key-bindings)    key_bindings=1    ;;
     --no-key-bindings) key_bindings=0    ;;

--- a/install
+++ b/install
@@ -9,8 +9,10 @@ update_config=2
 binary_arch=
 allow_legacy=
 shells="bash zsh fish"
-config_prefix='~/.'
-fish_dir=${XDG_CONFIG_HOME:-~/.config}/fish
+config_dir=~
+config_filename=.fzf
+config_prefix='~/.fzf'
+fish_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fish
 
 help() {
   cat << EOF
@@ -47,10 +49,9 @@ for opt in "$@"; do
       allow_legacy=1
       ;;
     --xdg)
-      config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
-      eval 'config_dir="$config_prefix"'
-      eval "config_dir=$config_dir"
-      eval "config_dir=$config_dir"
+      config_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fzf
+      config_filename=fzf
+      config_prefix='"${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf'
       mkdir -p "$config_dir"
       ;;
     --key-bindings)    key_bindings=1    ;;
@@ -250,8 +251,8 @@ fi
 echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
-  echo -n "Generate ${config_prefix}fzf.$shell ... "
-  src=${config_prefix}fzf.${shell}
+  src=${config_dir}/${config_filename}.${shell}
+  echo -n "Generate $src ... "
 
   fzf_completion="[[ \$- == *i* ]] && source \"$fzf_base/shell/completion.${shell}\" 2> /dev/null"
   if [ $auto_completion -eq 0 ]; then
@@ -263,8 +264,6 @@ for shell in $shells; do
     fzf_key_bindings="# $fzf_key_bindings"
   fi
 
-  eval "src=$src"
-  eval "src=$src"
   cat > "$src" << EOF
 # Setup fzf
 # ---------
@@ -365,7 +364,7 @@ echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
   [ $shell = zsh ] && dest=${ZDOTDIR:-~}/.zshrc || dest=~/.bashrc
-  append_line $update_config "[ -f ${config_prefix}fzf.${shell} ] && source ${config_prefix}fzf.${shell}" "$dest" "${config_prefix}fzf.${shell}"
+  append_line $update_config "[ -f ${config_prefix}.${shell} ] && source ${config_prefix}.${shell}" "$dest" "${config_prefix}.${shell}"
 done
 
 if [ $key_bindings -eq 1 ] && [[ "$shells" =~ fish ]]; then

--- a/install
+++ b/install
@@ -9,14 +9,14 @@ update_config=2
 binary_arch=
 allow_legacy=
 shells="bash zsh fish"
-config_base=~/.
+config_prefix=~/.
 fish_dir=~/.config/fish
 if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]]; then
-  config_base=$XDG_CONFIG_HOME/fzf/
-  fish_dir=$XDG_CONFIG_HOME/fish/
-  mkdir -p $config_base
+  config_prefix=$XDG_CONFIG_HOME/fzf/
+  fish_dir=$XDG_CONFIG_HOME/fish
+  mkdir -p $config_prefix
 elif [[ -d ~/.config/fzf ]]; then
-  config_base=~/.config/fzf/
+  config_prefix=~/.config/fzf/
 fi
 
 help() {
@@ -249,8 +249,8 @@ fi
 echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
-  echo -n "Generate ${config_base}fzf.$shell ... "
-  src=${config_base}fzf.${shell}
+  echo -n "Generate ${config_prefix}fzf.$shell ... "
+  src=${config_prefix}fzf.${shell}
 
   fzf_completion="[[ \$- == *i* ]] && source \"$fzf_base/shell/completion.${shell}\" 2> /dev/null"
   if [ $auto_completion -eq 0 ]; then
@@ -290,13 +290,13 @@ if [[ "$shells" =~ fish ]]; then
 EOF
   [ $? -eq 0 ] && echo "OK" || echo "Failed"
 
-  mkdir -p ${fish_dir}functions
-  if [ -e ${fish_dir}functions/fzf.fish ]; then
-    echo -n "Remove unnecessary ${fish_dir}functions/fzf.fish ... "
-    rm -f ${fish_dir}functions/fzf.fish && echo "OK" || echo "Failed"
+  mkdir -p ${fish_dir}/functions
+  if [ -e ${fish_dir}/functions/fzf.fish ]; then
+    echo -n "Remove unnecessary ${fish_dir}/functions/fzf.fish ... "
+    rm -f ${fish_dir}/functions/fzf.fish && echo "OK" || echo "Failed"
   fi
 
-  fish_binding=${fish_dir}functions/fzf_key_bindings.fish
+  fish_binding=${fish_dir}/functions/fzf_key_bindings.fish
   if [ $key_bindings -ne 0 ]; then
     echo -n "Symlink $fish_binding ... "
     ln -sf "$fzf_base/shell/key-bindings.fish" \
@@ -362,11 +362,11 @@ echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
   [ $shell = zsh ] && dest=${ZDOTDIR:-~}/.zshrc || dest=~/.bashrc
-  append_line $update_config "[ -f ${config_base}fzf.${shell} ] && source ${config_base}fzf.${shell}" "$dest" "${config_base}fzf.${shell}"
+  append_line $update_config "[ -f ${config_prefix}fzf.${shell} ] && source ${config_prefix}fzf.${shell}" "$dest" "${config_prefix}fzf.${shell}"
 done
 
 if [ $key_bindings -eq 1 ] && [[ "$shells" =~ fish ]]; then
-  bind_file=${fish_dir}functions/fish_user_key_bindings.fish
+  bind_file=${fish_dir}/functions/fish_user_key_bindings.fish
   if [ ! -e "$bind_file" ]; then
     create_file "$bind_file" \
       'function fish_user_key_bindings' \

--- a/install
+++ b/install
@@ -9,6 +9,14 @@ update_config=2
 binary_arch=
 allow_legacy=
 shells="bash zsh fish"
+config_dir=~/.config/fzf
+fish_dir=~/.config/fish
+if [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
+    echo hi
+    config_dir=$XDG_CONFIG_HOME/fzf
+    fish_dir=$XDG_CONFIG_HOME/fish
+fi
+mkdir -p $config_dir
 
 help() {
   cat << EOF
@@ -240,8 +248,8 @@ fi
 echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
-  echo -n "Generate ~/.fzf.$shell ... "
-  src=~/.fzf.${shell}
+  echo -n "Generate ${config_dir}/fzf.$shell ... "
+  src=${config_dir}/fzf.${shell}
 
   fzf_completion="[[ \$- == *i* ]] && source \"$fzf_base/shell/completion.${shell}\" 2> /dev/null"
   if [ $auto_completion -eq 0 ]; then
@@ -281,13 +289,13 @@ if [[ "$shells" =~ fish ]]; then
 EOF
   [ $? -eq 0 ] && echo "OK" || echo "Failed"
 
-  mkdir -p ~/.config/fish/functions
-  if [ -e ~/.config/fish/functions/fzf.fish ]; then
-    echo -n "Remove unnecessary ~/.config/fish/functions/fzf.fish ... "
-    rm -f ~/.config/fish/functions/fzf.fish && echo "OK" || echo "Failed"
+  mkdir -p $fish_dir/functions
+  if [ -e $fish_dir/functions/fzf.fish ]; then
+    echo -n "Remove unnecessary $fish_dir/functions/fzf.fish ... "
+    rm -f $fish_dir/functions/fzf.fish && echo "OK" || echo "Failed"
   fi
 
-  fish_binding=~/.config/fish/functions/fzf_key_bindings.fish
+  fish_binding=$fish_dir/functions/fzf_key_bindings.fish
   if [ $key_bindings -ne 0 ]; then
     echo -n "Symlink $fish_binding ... "
     ln -sf "$fzf_base/shell/key-bindings.fish" \
@@ -353,11 +361,11 @@ echo
 for shell in $shells; do
   [[ "$shell" = fish ]] && continue
   [ $shell = zsh ] && dest=${ZDOTDIR:-~}/.zshrc || dest=~/.bashrc
-  append_line $update_config "[ -f ~/.fzf.${shell} ] && source ~/.fzf.${shell}" "$dest" "~/.fzf.${shell}"
+  append_line $update_config "[ -f ${config_dir}/fzf.${shell} ] && source ${config_dir}/fzf.${shell}" "$dest" "${config_dir}/fzf.${shell}"
 done
 
 if [ $key_bindings -eq 1 ] && [[ "$shells" =~ fish ]]; then
-  bind_file=~/.config/fish/functions/fish_user_key_bindings.fish
+  bind_file=$fish_dir/functions/fish_user_key_bindings.fish
   if [ ! -e "$bind_file" ]; then
     create_file "$bind_file" \
       'function fish_user_key_bindings' \

--- a/install
+++ b/install
@@ -10,14 +10,14 @@ binary_arch=
 allow_legacy=
 shells="bash zsh fish"
 config_prefix='~/.'
-fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z "$XDG_CONFIG_HOME" ]] && [[ -d "$XDG_CONFIG_HOME" ]] \
-    && [[ ! -e ~/.fzf.bash ]]; then
-  config_prefix='"$XDG_CONFIG_HOME"/fzf/'
-  fish_dir=$XDG_CONFIG_HOME/fish
-  mkdir -p "$XDG_CONFIG_HOME/fzf/"
-elif [[ -d ~/.config/fzf ]]; then
-  config_prefix="~/.config/fzf/"
+fish_dir=${XDG_CONFIG_HOME:-~/.config}/fish
+if [[ ! -e ~/.fzf.bash ]]; then
+  config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
+  eval 'config_dir="$config_prefix"'
+  eval "config_dir=$config_dir"
+  eval "config_dir=$config_dir"
+  echo $config_dir
+  mkdir -p "$config_dir"
 fi
 
 help() {
@@ -263,6 +263,7 @@ for shell in $shells; do
     fzf_key_bindings="# $fzf_key_bindings"
   fi
 
+  eval "src=$src"
   eval "src=$src"
   cat > "$src" << EOF
 # Setup fzf

--- a/install
+++ b/install
@@ -21,7 +21,7 @@ usage: $0 [OPTIONS]
     --bin                Download fzf binary only; Do not generate ~/.fzf.{bash,zsh}
     --all                Download fzf binary and update configuration files
                          to enable key bindings and fuzzy completion
-    --xdg                Use XDG config directory
+    --xdg                Generate files under \$XDG_CONFIG_HOME/fzf
     --[no-]key-bindings  Enable/disable key bindings (CTRL-T, CTRL-R, ALT-C)
     --[no-]completion    Enable/disable fuzzy completion (bash & zsh)
     --[no-]update-rc     Whether or not to update shell configuration files

--- a/install
+++ b/install
@@ -9,7 +9,7 @@ update_config=2
 binary_arch=
 allow_legacy=
 shells="bash zsh fish"
-config_prefix="~/."
+config_prefix='~/.'
 fish_dir=~/.config/fish
 if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z "$XDG_CONFIG_HOME" ]] && [[ -d "$XDG_CONFIG_HOME" ]] \
     && [[ ! -e ~/.fzf.bash ]]; then

--- a/install
+++ b/install
@@ -11,10 +11,11 @@ allow_legacy=
 shells="bash zsh fish"
 config_prefix="~/."
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ $(echo $XDG_CONFIG_HOME | wc -w) -eq 1 ]] && [[ -d $XDG_CONFIG_HOME ]]; then
-  config_prefix='$XDG_CONFIG_HOME/fzf/'
+if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]] \
+    && [[ ! -e ~/.fzf.bash ]]; then
+  config_prefix="\${XDG_CONFIG_HOME:-${XDG_CONFIG_HOME}}/fzf/"
   fish_dir=$XDG_CONFIG_HOME/fish
-  mkdir -p $XDG_CONFIG_HOME/fzf/
+  mkdir -p "$XDG_CONFIG_HOME/fzf/"
 elif [[ -d ~/.config/fzf ]]; then
   config_prefix="~/.config/fzf/"
 fi

--- a/uninstall
+++ b/uninstall
@@ -10,7 +10,7 @@ help() {
 usage: $0 [OPTIONS]
 
     --help               Show this message
-    --xdg                Use XDG config directories
+    --xdg                Remove files generated under \$XDG_CONFIG_HOME/fzf
 EOF
 }
 

--- a/uninstall
+++ b/uninstall
@@ -23,7 +23,6 @@ for opt in "$@"; do
       eval 'config_dir="$config_prefix"'
       eval "config_dir=$config_dir"
       eval "config_dir=$config_dir"
-      echo $config_dir
       mkdir -p "$config_dir"
       ;;
     *)

--- a/uninstall
+++ b/uninstall
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-config_base=~/.
+config_prefix=~/.
 fish_dir=~/.config/fish
 if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]]; then
-  config_base=$XDG_CONFIG_HOME/fzf/
-  fish_dir=$XDG_CONFIG_HOME/fish/
-  mkdir -p $config_base
+  config_prefix=$XDG_CONFIG_HOME/fzf/
+  fish_dir=$XDG_CONFIG_HOME/fish
+  mkdir -p $config_prefix
 elif [[ -d ~/.config/fzf ]]; then
-  config_base=~/.config/fzf/
+  config_prefix=~/.config/fzf/
 fi
 
 confirm() {
@@ -64,25 +64,25 @@ remove_line() {
 }
 
 for shell in bash zsh; do
-  remove ${config_base}fzf.${shell}
+  remove ${config_prefix}fzf.${shell}
   remove_line ~/.${shell}rc \
-    "[ -f ${config_base}fzf.${shell} ] && source ${config_base}fzf.${shell}" \
-    "source ${config_base}fzf.${shell}"
+    "[ -f ${config_prefix}fzf.${shell} ] && source ${config_prefix}fzf.${shell}" \
+    "source ${config_prefix}fzf.${shell}"
 done
 
-bind_file=${fish_dir}functions/fish_user_key_bindings.fish
+bind_file=${fish_dir}/functions/fish_user_key_bindings.fish
 if [ -f "$bind_file" ]; then
   remove_line "$bind_file" "fzf_key_bindings"
 fi
 
-if [ -d ${fish_dir}functions ]; then
-  remove ${fish_dir}functions/fzf.fish
-  remove ${fish_dir}functions/fzf_key_bindings.fish
+if [ -d ${fish_dir}/functions ]; then
+  remove ${fish_dir}/functions/fzf.fish
+  remove ${fish_dir}/functions/fzf_key_bindings.fish
 
-  if [ "$(ls -A ${fish_dir}functions)" ]; then
-    echo "Can't delete non-empty directory: \"${fish_dir}functions\""
+  if [ "$(ls -A ${fish_dir}/functions)" ]; then
+    echo "Can't delete non-empty directory: \"${fish_dir}/functions\""
   else
-    rmdir ${fish_dir}functions
+    rmdir ${fish_dir}/functions
   fi
 fi
 

--- a/uninstall
+++ b/uninstall
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 config_prefix=~/.
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]]; then
+if [[ -v XDG_CONFIG_HOME ]] && [[ $(echo $XDG_CONFIG_HOME | wc -w) -eq 1 ]] && [[ -d $XDG_CONFIG_HOME ]]; then
   config_prefix=$XDG_CONFIG_HOME/fzf/
   fish_dir=$XDG_CONFIG_HOME/fish
   mkdir -p $config_prefix

--- a/uninstall
+++ b/uninstall
@@ -6,7 +6,7 @@ if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_
   config_prefix='$XDG_CONFIG_HOME/fzf/'
   fish_dir=$XDG_CONFIG_HOME/fish
 elif [[ -d ~/.config/fzf ]]; then
-  config_prefix=~/.config/fzf/
+  config_prefix="~/.config/fzf/"
 fi
 
 confirm() {
@@ -64,25 +64,30 @@ remove_line() {
 }
 
 for shell in bash zsh; do
-  remove ${config_prefix}fzf.${shell}
+  eval "shell_config=${config_prefix}fzf.${shell}"
+  remove "${shell_config}"
   remove_line ~/.${shell}rc \
     "[ -f ${config_prefix}fzf.${shell} ] && source ${config_prefix}fzf.${shell}" \
     "source ${config_prefix}fzf.${shell}"
 done
 
-bind_file=${fish_dir}/functions/fish_user_key_bindings.fish
+bind_file="${fish_dir}/functions/fish_user_key_bindings.fish"
 if [ -f "$bind_file" ]; then
   remove_line "$bind_file" "fzf_key_bindings"
 fi
 
-if [ -d ${fish_dir}/functions ]; then
-  remove ${fish_dir}/functions/fzf.fish
-  remove ${fish_dir}/functions/fzf_key_bindings.fish
+if [ -d "${fish_dir}/functions" ]; then
+  remove "${fish_dir}/functions/fzf.fish"
+  remove "${fish_dir}/functions/fzf_key_bindings.fish"
 
-  if [ "$(ls -A ${fish_dir}/functions)" ]; then
+  if [ "$(ls -A "${fish_dir}/functions")" ]; then
     echo "Can't delete non-empty directory: \"${fish_dir}/functions\""
   else
-    rmdir ${fish_dir}/functions
+    rmdir "${fish_dir}/functions"
   fi
 fi
 
+eval "src=$config_prefix"
+if [ "$(basename "$src")" == "fzf" ] && [ -d "$src" ]; then
+  rmdir "$src"
+fi

--- a/uninstall
+++ b/uninstall
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-config_prefix=~/.
+config_prefix='~/.'
 fish_dir=~/.config/fish
 if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z "$XDG_CONFIG_HOME" ]] && [[ -d "$XDG_CONFIG_HOME" ]] \
     && [[ ! -e ~/.fzf.bash ]]; then

--- a/uninstall
+++ b/uninstall
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-config_prefix='~/.'
-fish_dir=${XDG_CONFIG_HOME:-~/.config}/fish
+config_dir=~
+config_filename=.fzf
+config_prefix='~/.fzf'
+fish_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fish
 
 help() {
   cat << EOF
@@ -19,11 +21,9 @@ for opt in "$@"; do
       exit 0
       ;;
     --xdg)
-      config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
-      eval 'config_dir="$config_prefix"'
-      eval "config_dir=$config_dir"
-      eval "config_dir=$config_dir"
-      mkdir -p "$config_dir"
+      config_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fzf
+      config_filename=fzf
+      config_prefix='"${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf'
       ;;
     *)
       echo "unknown option: $opt"
@@ -88,12 +88,11 @@ remove_line() {
 }
 
 for shell in bash zsh; do
-  eval "shell_config=${config_prefix}fzf.${shell}"
-  eval "shell_config=${shell_config}"
+  shell_config=${config_dir}/${config_filename}.${shell}
   remove "${shell_config}"
   remove_line ~/.${shell}rc \
-    "[ -f ${config_prefix}fzf.${shell} ] && source ${config_prefix}fzf.${shell}" \
-    "source ${config_prefix}fzf.${shell}"
+    "[ -f ${config_prefix}.${shell} ] && source ${config_prefix}.${shell}" \
+    "source ${config_prefix}.${shell}"
 done
 
 bind_file="${fish_dir}/functions/fish_user_key_bindings.fish"
@@ -112,8 +111,6 @@ if [ -d "${fish_dir}/functions" ]; then
   fi
 fi
 
-eval "src=$config_prefix"
-eval "src=$src"
-if [ "$(basename "$src")" == "fzf" ] && [ -d "$src" ]; then
-  rmdir "$src"
+if [[ "$config_dir" = */fzf ]] && [[ -d "$config_dir" ]]; then
+  rmdir "$config_dir"
 fi

--- a/uninstall
+++ b/uninstall
@@ -2,9 +2,37 @@
 
 config_prefix='~/.'
 fish_dir=${XDG_CONFIG_HOME:-~/.config}/fish
-if [[ ! -e ~/.fzf.bash ]]; then
-  config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
-fi
+
+help() {
+  cat << EOF
+usage: $0 [OPTIONS]
+
+    --help               Show this message
+    --xdg                Use xdg config directories
+EOF
+}
+
+for opt in "$@"; do
+  case $opt in
+    --help)
+      help
+      exit 0
+      ;;
+    --xdg)
+      config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
+      eval 'config_dir="$config_prefix"'
+      eval "config_dir=$config_dir"
+      eval "config_dir=$config_dir"
+      echo $config_dir
+      mkdir -p "$config_dir"
+      ;;
+    *)
+      echo "unknown option: $opt"
+      help
+      exit 1
+      ;;
+  esac
+done
 
 ask() {
   while true; do

--- a/uninstall
+++ b/uninstall
@@ -10,7 +10,7 @@ help() {
 usage: $0 [OPTIONS]
 
     --help               Show this message
-    --xdg                Use xdg config directories
+    --xdg                Use XDG config directories
 EOF
 }
 

--- a/uninstall
+++ b/uninstall
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 config_dir=~/.config/fzf
 fish_dir=~/.config/fish
-if [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
+if [[ -v XDG_CONFIG_HOME ]] && [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
     config_dir=$XDG_CONFIG_HOME/fzf
     fish_dir=$XDG_CONFIG_HOME/fish
 fi

--- a/uninstall
+++ b/uninstall
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 config_prefix=~/.
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ $(echo $XDG_CONFIG_HOME | wc -w) -eq 1 ]] && [[ -d $XDG_CONFIG_HOME ]]; then
-  config_prefix=$XDG_CONFIG_HOME/fzf/
+if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]] \
+    && [[ ! -e ~/.fzf.bash ]]; then
+  config_prefix='$XDG_CONFIG_HOME/fzf/'
   fish_dir=$XDG_CONFIG_HOME/fish
-  mkdir -p $config_prefix
 elif [[ -d ~/.config/fzf ]]; then
   config_prefix=~/.config/fzf/
 fi

--- a/uninstall
+++ b/uninstall
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+config_dir=~/.config/fzf
+fish_dir=~/.config/fish
+if [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
+    config_dir=$XDG_CONFIG_HOME/fzf
+    fish_dir=$XDG_CONFIG_HOME/fish
+fi
 
 confirm() {
   while [ 1 ]; do
@@ -55,25 +61,25 @@ remove_line() {
 }
 
 for shell in bash zsh; do
-  remove ~/.fzf.${shell}
+  remove ${config_dir}/fzf.${shell}
   remove_line ~/.${shell}rc \
-    "[ -f ~/.fzf.${shell} ] && source ~/.fzf.${shell}" \
-    "source ~/.fzf.${shell}"
+    "[ -f ${config_dir}/fzf.${shell} ] && source ${config_dir}/fzf.${shell}" \
+    "source ${config_dir}/fzf.${shell}"
 done
 
-bind_file=~/.config/fish/functions/fish_user_key_bindings.fish
+bind_file=$fish_dir/functions/fish_user_key_bindings.fish
 if [ -f "$bind_file" ]; then
   remove_line "$bind_file" "fzf_key_bindings"
 fi
 
-if [ -d ~/.config/fish/functions ]; then
-  remove ~/.config/fish/functions/fzf.fish
-  remove ~/.config/fish/functions/fzf_key_bindings.fish
+if [ -d $fish_dir/functions ]; then
+  remove $fish_dir/functions/fzf.fish
+  remove $fish_dir/functions/fzf_key_bindings.fish
 
-  if [ "$(ls -A ~/.config/fish/functions)" ]; then
-    echo "Can't delete non-empty directory: \"~/.config/fish/functions\""
+  if [ "$(ls -A $fish_dir/functions)" ]; then
+    echo "Can't delete non-empty directory: \"$fish_dir/functions\""
   else
-    rmdir ~/.config/fish/functions
+    rmdir $fish_dir/functions
   fi
 fi
 

--- a/uninstall
+++ b/uninstall
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
 
 config_prefix='~/.'
-fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z "$XDG_CONFIG_HOME" ]] && [[ -d "$XDG_CONFIG_HOME" ]] \
-    && [[ ! -e ~/.fzf.bash ]]; then
-  config_prefix='"$XDG_CONFIG_HOME"/fzf/'
-  fish_dir=$XDG_CONFIG_HOME/fish
-elif [[ -d ~/.config/fzf ]]; then
-  config_prefix="~/.config/fzf/"
+fish_dir=${XDG_CONFIG_HOME:-~/.config}/fish
+if [[ ! -e ~/.fzf.bash ]]; then
+  config_prefix='"${XDG_CONFIG_HOME:-~/.config}"/fzf/'
 fi
 
 ask() {
@@ -66,6 +62,7 @@ remove_line() {
 
 for shell in bash zsh; do
   eval "shell_config=${config_prefix}fzf.${shell}"
+  eval "shell_config=${shell_config}"
   remove "${shell_config}"
   remove_line ~/.${shell}rc \
     "[ -f ${config_prefix}fzf.${shell} ] && source ${config_prefix}fzf.${shell}" \
@@ -89,6 +86,7 @@ if [ -d "${fish_dir}/functions" ]; then
 fi
 
 eval "src=$config_prefix"
+eval "src=$src"
 if [ "$(basename "$src")" == "fzf" ] && [ -d "$src" ]; then
   rmdir "$src"
 fi

--- a/uninstall
+++ b/uninstall
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+
 config_prefix=~/.
 fish_dir=~/.config/fish
 if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]] \
@@ -9,13 +10,13 @@ elif [[ -d ~/.config/fzf ]]; then
   config_prefix="~/.config/fzf/"
 fi
 
-confirm() {
-  while [ 1 ]; do
-    read -p "$1" -n 1 -r
-    echo
-    if [[ "$REPLY" =~ ^[Yy] ]]; then
+ask() {
+  while true; do
+    read -p "$1 ([y]/n) " -r
+    REPLY=${REPLY:-"y"}
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
       return 0
-    elif [[ "$REPLY" =~ ^[Nn] ]]; then
+    elif [[ $REPLY =~ ^[Nn]$ ]]; then
       return 1
     fi
   done
@@ -49,7 +50,7 @@ remove_line() {
     content=$(sed 's/^[0-9]*://' <<< "$line")
     match=1
     echo    "  - Line #$line_no: $content"
-    [ "$content" = "$1" ] || confirm "    - Remove (y/n) ? "
+    [ "$content" = "$1" ] || ask "    - Remove?"
     if [ $? -eq 0 ]; then
       awk -v n=$line_no 'NR == n {next} {print}' "$src" > "$src.bak" &&
         mv "$src.bak" "$src" || break

--- a/uninstall
+++ b/uninstall
@@ -1,9 +1,12 @@
 #!/usr/bin/env bash
-config_dir=~/.config/fzf
+config_base=~/.
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [ ! -z $XDG_CONFIG_HOME ] && [ -d $XDG_CONFIG_HOME ]; then
-    config_dir=$XDG_CONFIG_HOME/fzf
-    fish_dir=$XDG_CONFIG_HOME/fish
+if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]]; then
+  config_base=$XDG_CONFIG_HOME/fzf/
+  fish_dir=$XDG_CONFIG_HOME/fish/
+  mkdir -p $config_base
+elif [[ -d ~/.config/fzf ]]; then
+  config_base=~/.config/fzf/
 fi
 
 confirm() {
@@ -61,25 +64,25 @@ remove_line() {
 }
 
 for shell in bash zsh; do
-  remove ${config_dir}/fzf.${shell}
+  remove ${config_base}fzf.${shell}
   remove_line ~/.${shell}rc \
-    "[ -f ${config_dir}/fzf.${shell} ] && source ${config_dir}/fzf.${shell}" \
-    "source ${config_dir}/fzf.${shell}"
+    "[ -f ${config_base}fzf.${shell} ] && source ${config_base}fzf.${shell}" \
+    "source ${config_base}fzf.${shell}"
 done
 
-bind_file=$fish_dir/functions/fish_user_key_bindings.fish
+bind_file=${fish_dir}functions/fish_user_key_bindings.fish
 if [ -f "$bind_file" ]; then
   remove_line "$bind_file" "fzf_key_bindings"
 fi
 
-if [ -d $fish_dir/functions ]; then
-  remove $fish_dir/functions/fzf.fish
-  remove $fish_dir/functions/fzf_key_bindings.fish
+if [ -d ${fish_dir}functions ]; then
+  remove ${fish_dir}functions/fzf.fish
+  remove ${fish_dir}functions/fzf_key_bindings.fish
 
-  if [ "$(ls -A $fish_dir/functions)" ]; then
-    echo "Can't delete non-empty directory: \"$fish_dir/functions\""
+  if [ "$(ls -A ${fish_dir}functions)" ]; then
+    echo "Can't delete non-empty directory: \"${fish_dir}functions\""
   else
-    rmdir $fish_dir/functions
+    rmdir ${fish_dir}functions
   fi
 fi
 

--- a/uninstall
+++ b/uninstall
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
-config_dir=~
-config_filename=.fzf
-config_prefix='~/.fzf'
+xdg=0
+prefix='~/.fzf'
+prefix_expand=~/.fzf
 fish_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fish
 
 help() {
@@ -21,9 +21,9 @@ for opt in "$@"; do
       exit 0
       ;;
     --xdg)
-      config_dir=${XDG_CONFIG_HOME:-$HOME/.config}/fzf
-      config_filename=fzf
-      config_prefix='"${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf'
+      xdg=1
+      prefix='"${XDG_CONFIG_HOME:-$HOME/.config}"/fzf/fzf'
+      prefix_expand=${XDG_CONFIG_HOME:-$HOME/.config}/fzf/fzf
       ;;
     *)
       echo "unknown option: $opt"
@@ -88,11 +88,11 @@ remove_line() {
 }
 
 for shell in bash zsh; do
-  shell_config=${config_dir}/${config_filename}.${shell}
+  shell_config=${prefix_expand}.${shell}
   remove "${shell_config}"
   remove_line ~/.${shell}rc \
-    "[ -f ${config_prefix}.${shell} ] && source ${config_prefix}.${shell}" \
-    "source ${config_prefix}.${shell}"
+    "[ -f ${prefix}.${shell} ] && source ${prefix}.${shell}" \
+    "source ${prefix}.${shell}"
 done
 
 bind_file="${fish_dir}/functions/fish_user_key_bindings.fish"
@@ -111,6 +111,7 @@ if [ -d "${fish_dir}/functions" ]; then
   fi
 fi
 
-if [[ "$config_dir" = */fzf ]] && [[ -d "$config_dir" ]]; then
+config_dir=$(dirname "$prefix_expand")
+if [[ "$xdg" = 1 ]] && [[ "$config_dir" = */fzf ]] && [[ -d "$config_dir" ]]; then
   rmdir "$config_dir"
 fi

--- a/uninstall
+++ b/uninstall
@@ -2,9 +2,9 @@
 
 config_prefix=~/.
 fish_dir=~/.config/fish
-if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z $XDG_CONFIG_HOME ]] && [[ -d $XDG_CONFIG_HOME ]] \
+if [[ -v XDG_CONFIG_HOME ]] && [[ ! -z "$XDG_CONFIG_HOME" ]] && [[ -d "$XDG_CONFIG_HOME" ]] \
     && [[ ! -e ~/.fzf.bash ]]; then
-  config_prefix='$XDG_CONFIG_HOME/fzf/'
+  config_prefix='"$XDG_CONFIG_HOME"/fzf/'
   fish_dir=$XDG_CONFIG_HOME/fish
 elif [[ -d ~/.config/fzf ]]; then
   config_prefix="~/.config/fzf/"


### PR DESCRIPTION
This makes it possible to keep your home directory free from fzf dotfiles. One thing to note is that this does not handle the case where a ~/.fzf.bash file already exists. I can include that if desired.