### PR TITLE
Avoid duplicates when filter history(#49, #88, #492, #600)

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -55,7 +55,7 @@ __fzf_history__() (
   local line
   shopt -u nocaseglob nocasematch
   line=$(
-    HISTTIMEFORMAT= history |
+    HISTTIMEFORMAT= history | sort -uk2,1000 | sort -nr |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS --tac --sync -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m" $(__fzfcmd) |
     command grep '^ *[0-9]') &&
     if [[ $- =~ H ]]; then

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -50,7 +50,7 @@ function fzf_key_bindings
         history -z | eval (__fzfcmd) --read0 -q '(commandline)' | perl -pe 'chomp if eof' | read -lz result
         and commandline -- $result
       else
-        history | eval (__fzfcmd) -q '(commandline)' | read -l result
+        history | sort -uk2,1000 | sort -nr | eval (__fzfcmd) -q '(commandline)' | read -l result
         and commandline -- $result
       end
     end

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -69,7 +69,7 @@ bindkey '\ec' fzf-cd-widget
 fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail 2> /dev/null
-  selected=( $(fc -rl 1 |
+  selected=( $(fc -rl 1 | sort -uk2,1000 | sort -nr |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then


### PR DESCRIPTION
When hit `Ctrl - R`, what we want is to find some commands we can quickly reuse. Duplicates is meaningless and sometimes annoying in this situation.

Config the shell to not record repeated commands is a solution. But history is not only used for `Ctrl - R`. We want to recall what happened by looking up the history when something goes wrong. Information will be lost if we discard the repeated commands. Moreover, this solution doesn't solve the duplicates problem on `Ctrl + R` perfectly. Eg, we enter `ls` many times per day. When we want to filter a history command contains 'ls', there still be many duplicates `ls` appeared. Shell config like `HIST_IGNORE_ALL_DUPS` should not work because they are separated by other commands.

I think this commit solved the problem. No outer dependencies and influences. We can keep recording commands in history, but have unique entries when call fzf by `Ctrl - R`.

#49 #88 #492 #600 