### PR TITLE
remove -y flag from Arch Linux installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Plug 'junegunn/fzf', { 'dir': '~/.fzf', 'do': './install --all' }
 ### Arch Linux
 
 ```sh
-sudo pacman -Sy fzf
+sudo pacman -S fzf
 ```
 
 ### Fedora


### PR DESCRIPTION
per https://wiki.archlinux.org/index.php/Partial_upgrades#Partial_upgrades_are_unsupported you should never `pacman -Sy <pkg>`, Arch users are expected to keep their system already up-to-date before installing anything.