### PR TITLE
zsh completion: Add support for per-command completion triggers.

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -4,12 +4,13 @@
 #  / __/ / /_/ __/
 # /_/   /___/_/ completion.zsh
 #
-# - $FZF_TMUX                 (default: 0)
-# - $FZF_TMUX_OPTS            (default: empty)
-# - $FZF_COMPLETION_TRIGGER   (default: '**')
-# - $FZF_COMPLETION_OPTS      (default: empty)
-# - $FZF_COMPLETION_PATH_OPTS (default: empty)
-# - $FZF_COMPLETION_DIR_OPTS  (default: empty)
+# - $FZF_TMUX                        (default: 0)
+# - $FZF_TMUX_OPTS                   (default: empty)
+# - $FZF_COMPLETION_TRIGGER          (default: '**')
+# - $FZF_PER_CMD_COMPLETION_TRIGGERS (default: none)
+# - $FZF_COMPLETION_OPTS             (default: empty)
+# - $FZF_COMPLETION_PATH_OPTS        (default: empty)
+# - $FZF_COMPLETION_DIR_OPTS         (default: empty)
 
 
 # Both branches of the following `if` do the same thing -- define
@@ -141,12 +142,31 @@ __fzf_comprun() {
   fi
 }
 
-# Extract the name of the command. e.g. ls; foo=1 ssh **<tab>
-__fzf_extract_command() {
+# The $words array is only available in user-defined completion ZLE
+# widgets.
+__fzf_extract_command_zle() {
   # Control completion with the "compstate" parameter, insert and list nothing
   compstate[insert]=
   compstate[list]=
   cmd_word="${(Q)words[1]}"
+}
+
+# Extract the name of the command. e.g. ls; foo=1 ssh **<tab>
+# The command name is stored in the $cmd_word variable.
+__fzf_extract_command() {
+  # Check if at least one completion system (old or new) is active.
+  # If at least one user-defined completion widget is detected, nothing will
+  # be completed if neither the old nor the new completion system is enabled.
+  # In such cases, the 'zsh/compctl' module is loaded as a fallback.
+  if ! zmodload -F zsh/parameter p:functions 2>/dev/null || ! (( ${+functions[compdef]} )); then
+    zmodload -F zsh/compctl 2>/dev/null
+  fi
+  {
+    zle -C __fzf_extract_command_zle .complete-word __fzf_extract_command_zle
+    zle __fzf_extract_command_zle
+  } always {
+    zle -D __fzf_extract_command_zle 2>/dev/null
+  }
 }
 
 __fzf_generic_path_completion() {
@@ -402,8 +422,15 @@ fzf-completion() {
     return
   fi
 
-  # Explicitly allow for empty trigger.
+  __fzf_extract_command
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
+
+  if (( ${+FZF_PER_CMD_COMPLETION_TRIGGERS} )); then
+    # Use a per-command completion trigger if available.
+    trigger=${FZF_PER_CMD_COMPLETION_TRIGGERS[$cmd_word]-$trigger}
+  fi
+
+  # Explicitly allow for empty trigger.
   [[ -z $trigger && ${LBUFFER[-1]} == ' ' ]] && tokens+=("")
 
   # When the trigger starts with ';', it becomes a separate token
@@ -419,25 +446,14 @@ fzf-completion() {
   if [ ${#tokens} -gt 1 -a "$tail" = "$trigger" ]; then
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS-cd pushd rmdir})
 
-    {
+    [ -n $trigger ] && {
       cursor_pos=$CURSOR
       # Move the cursor before the trigger to preserve word array elements when
       # trigger chars like ';' or '`' would otherwise reset the 'words' array.
       CURSOR=$((cursor_pos - ${#trigger} - 1))
-      # Check if at least one completion system (old or new) is active.
-      # If at least one user-defined completion widget is detected, nothing will
-      # be completed if neither the old nor the new completion system is enabled.
-      # In such cases, the 'zsh/compctl' module is loaded as a fallback.
-      if ! zmodload -F zsh/parameter p:functions 2>/dev/null || ! (( ${+functions[compdef]} )); then
-        zmodload -F zsh/compctl 2>/dev/null
-      fi
-      # Create a completion widget to access the 'words' array (man zshcompwid)
-      zle -C __fzf_extract_command .complete-word __fzf_extract_command
-      zle __fzf_extract_command
+      __fzf_extract_command
     } always {
       CURSOR=$cursor_pos
-      # Delete the completion widget
-      zle -D __fzf_extract_command  2>/dev/null
     }
 
     [ -z "$trigger"      ] && prefix=${tokens[-1]} || prefix=${tokens[-1]:0:-${#trigger}}

--- a/test/test_shell_integration.rb
+++ b/test/test_shell_integration.rb
@@ -924,6 +924,14 @@ class TestZsh < TestBase
     end
   end
 
+  def test_per_cmd_completion_triggers
+    tmux.send_keys 'declare -A FZF_PER_CMD_COMPLETION_TRIGGERS', :Enter
+    tmux.send_keys 'FZF_PER_CMD_COMPLETION_TRIGGERS[ls]=""', :Enter
+    tmux.send_keys 'ls /', :Tab
+    tmux.until { |lines| assert_operator lines.match_count, :>, 0 }
+    tmux.send_keys :Enter
+  end
+
   # Helper function to run test with Perl and again with Awk
   def self.test_perl_and_awk(name, &block)
     define_method(:"test_#{name}") do


### PR DESCRIPTION
Allow users to configure custom completion triggers on a per-command
basis. For example, if FZF_COMPLETION_TRIGGER='**' and
FZF_PER_CMD_COMPLETION_TRIGGERS=(ssh ''), then:

ssh<space><tab> triggers fzf completion.

but

ls<space><tab> will not.

Previously, completion for the kill command was special cased to not
require a completion trigger. This patch reimplements kill in terms of
FZF_PER_CMD_COMPLETION_TRIGGERS as well. Doing this also required
modifying _fzf_complete to respect quotes when doing word splitting on
its fzf_opts param.

This is a minor behavior change for kill completion. Previously, kill's
hardcoded fzf invocation enabled the following options by default:

--height ${FZF_TMUX_HEIGHT:-50%}
--min-height 15

and also allowed any options to be overriden by FZF_COMPLETION_OPTS.
When reusing _fzf_complete, this will no longer happen (consistent with
all of the other built-in completion functions).