### PR TITLE
[bash, zsh] Fix missing fuzzy completions

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -148,7 +148,7 @@ __fzf_generic_path_completion() {
     base=${cur:0:${#cur}-${#trigger}}
     eval "base=$base"
 
-    dir="$base"
+    [[ $base = *"/"* ]] && dir="$base"
     while true; do
       if [ -z "$dir" ] || [ -d "$dir" ]; then
         leftover=${base/#"$dir"}

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -36,8 +36,7 @@ __fzfcmd_complete() {
 
 __fzf_generic_path_completion() {
   local base lbuf compgen fzf_opts suffix tail fzf dir leftover matches
-  # (Q) flag removes a quoting level: "foo\ bar" => "foo bar"
-  base=${(Q)1}
+  base=$1
   lbuf=$2
   compgen=$3
   fzf_opts=$4
@@ -46,15 +45,14 @@ __fzf_generic_path_completion() {
   fzf="$(__fzfcmd_complete)"
 
   setopt localoptions nonomatch
-  eval "abspath=$1" 2> /dev/null
-  [[ $abspath = *"/"* ]] && dir="$base"
+  eval "base=$base"
+  [[ $base = *"/"* ]] && dir="$base"
   while [ 1 ]; do
-    if [[ -z "$dir" || -d ${~dir} ]]; then
+    if [[ -z "$dir" || -d ${dir} ]]; then
       leftover=${base/#"$dir"}
       leftover=${leftover/#\/}
       [ -z "$dir" ] && dir='.'
       [ "$dir" != "/" ] && dir="${dir/%\//}"
-      dir=${~dir}
       matches=$(eval "$compgen $(printf %q "$dir")" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" ${=fzf} ${=fzf_opts} -q "$leftover" | while read item; do
         echo -n "${(q)item}$suffix "
       done)

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -46,7 +46,7 @@ __fzf_generic_path_completion() {
   fzf="$(__fzfcmd_complete)"
 
   setopt localoptions nonomatch
-  dir="$base"
+  [[ $base = *"/"* ]] && dir="$base"
   while [ 1 ]; do
     if [[ -z "$dir" || -d ${~dir} ]]; then
       leftover=${base/#"$dir"}

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -46,6 +46,7 @@ __fzf_generic_path_completion() {
   fzf="$(__fzfcmd_complete)"
 
   setopt localoptions nonomatch
+  eval "base=$base"
   [[ $base = *"/"* ]] && dir="$base"
   while [ 1 ]; do
     if [[ -z "$dir" || -d ${~dir} ]]; then

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -46,8 +46,8 @@ __fzf_generic_path_completion() {
   fzf="$(__fzfcmd_complete)"
 
   setopt localoptions nonomatch
-  eval "base=$base"
-  [[ $base = *"/"* ]] && dir="$base"
+  eval "abspath=$1" 2> /dev/null
+  [[ $abspath = *"/"* ]] && dir="$base"
   while [ 1 ]; do
     if [[ -z "$dir" || -d ${~dir} ]]; then
       leftover=${base/#"$dir"}


### PR DESCRIPTION
`cat foo**<TAB>` did not display the file `foobar` if there was a directory
named `foo`.

Fixes #1301