### PR TITLE
Support for ppc64le

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,36 @@
 ifndef GOOS
-GOOS        := $(word 1, $(subst /, " ", $(word 4, $(shell go version))))
+GOOS           := $(word 1, $(subst /, " ", $(word 4, $(shell go version))))
 endif
 
-MAKEFILE    := $(realpath $(lastword $(MAKEFILE_LIST)))
-ROOT_DIR    := $(shell dirname $(MAKEFILE))
-GOPATH      := $(ROOT_DIR)/gopath
-SRC_LINK    := $(GOPATH)/src/github.com/junegunn/fzf/src
-VENDOR_LINK := $(GOPATH)/src/github.com/junegunn/fzf/vendor
+MAKEFILE       := $(realpath $(lastword $(MAKEFILE_LIST)))
+ROOT_DIR       := $(shell dirname $(MAKEFILE))
+GOPATH         := $(ROOT_DIR)/gopath
+SRC_LINK       := $(GOPATH)/src/github.com/junegunn/fzf/src
+VENDOR_LINK    := $(GOPATH)/src/github.com/junegunn/fzf/vendor
 export GOPATH
 
-GLIDE_YAML  := glide.yaml
-GLIDE_LOCK  := glide.lock
-SOURCES     := $(wildcard *.go src/*.go src/*/*.go) $(SRC_LINK) $(VENDOR_LINK) $(GLIDE_LOCK) $(MAKEFILE)
+GLIDE_YAML     := glide.yaml
+GLIDE_LOCK     := glide.lock
+SOURCES        := $(wildcard *.go src/*.go src/*/*.go) $(SRC_LINK) $(VENDOR_LINK) $(GLIDE_LOCK) $(MAKEFILE)
 
-REVISION    := $(shell git log -n 1 --pretty=format:%h -- $(SOURCES))
-BUILD_FLAGS := -a -ldflags "-X main.revision=$(REVISION) -w -extldflags=$(LDFLAGS)" -tags "$(TAGS)"
+REVISION       := $(shell git log -n 1 --pretty=format:%h -- $(SOURCES))
+BUILD_FLAGS    := -a -ldflags "-X main.revision=$(REVISION) -w -extldflags=$(LDFLAGS)" -tags "$(TAGS)"
 
-BINARY32    := fzf-$(GOOS)_386
-BINARY64    := fzf-$(GOOS)_amd64
-BINARYARM5  := fzf-$(GOOS)_arm5
-BINARYARM6  := fzf-$(GOOS)_arm6
-BINARYARM7  := fzf-$(GOOS)_arm7
-BINARYARM8  := fzf-$(GOOS)_arm8
-VERSION     := $(shell awk -F= '/version =/ {print $$2}' src/constants.go | tr -d "\" ")
-RELEASE32   := fzf-$(VERSION)-$(GOOS)_386
-RELEASE64   := fzf-$(VERSION)-$(GOOS)_amd64
-RELEASEARM5 := fzf-$(VERSION)-$(GOOS)_arm5
-RELEASEARM6 := fzf-$(VERSION)-$(GOOS)_arm6
-RELEASEARM7 := fzf-$(VERSION)-$(GOOS)_arm7
-RELEASEARM8 := fzf-$(VERSION)-$(GOOS)_arm8
+BINARY32       := fzf-$(GOOS)_386
+BINARY64       := fzf-$(GOOS)_amd64
+BINARYARM5     := fzf-$(GOOS)_arm5
+BINARYARM6     := fzf-$(GOOS)_arm6
+BINARYARM7     := fzf-$(GOOS)_arm7
+BINARYARM8     := fzf-$(GOOS)_arm8
+BINARYPPC64LE  := fzf-$(GOOS)_ppc64le
+VERSION        := $(shell awk -F= '/version =/ {print $$2}' src/constants.go | tr -d "\" ")
+RELEASE32      := fzf-$(VERSION)-$(GOOS)_386
+RELEASE64      := fzf-$(VERSION)-$(GOOS)_amd64
+RELEASEARM5    := fzf-$(VERSION)-$(GOOS)_arm5
+RELEASEARM6    := fzf-$(VERSION)-$(GOOS)_arm6
+RELEASEARM7    := fzf-$(VERSION)-$(GOOS)_arm7
+RELEASEARM8    := fzf-$(VERSION)-$(GOOS)_arm8
+RELEASEPPC64LE := fzf-$(VERSION)-$(GOOS)_ppc64le
 
 # https://en.wikipedia.org/wiki/Uname
 UNAME_M := $(shell uname -m)
@@ -48,6 +50,8 @@ else ifeq ($(UNAME_M),armv7l)
 	BINARY := $(BINARYARM7)
 else ifeq ($(UNAME_M),armv8l)
 	BINARY := $(BINARYARM8)
+else ifeq ($(UNAME_M),ppc64le)
+	BINARY := $(BINARYPPC64LE)
 else
 $(error "Build on $(UNAME_M) is not supported, yet.")
 endif
@@ -63,13 +67,14 @@ release: target/$(BINARY32) target/$(BINARY64)
 	cd target && cp -f $(BINARY64) fzf.exe && zip $(RELEASE64).zip fzf.exe
 	cd target && rm -f fzf.exe
 else ifeq ($(GOOS),linux)
-release: target/$(BINARY32) target/$(BINARY64) target/$(BINARYARM5) target/$(BINARYARM6) target/$(BINARYARM7) target/$(BINARYARM8)
+release: target/$(BINARY32) target/$(BINARY64) target/$(BINARYARM5) target/$(BINARYARM6) target/$(BINARYARM7) target/$(BINARYARM8) target/$(BINARYPPC64LE)
 	cd target && cp -f $(BINARY32) fzf && tar -czf $(RELEASE32).tgz fzf
 	cd target && cp -f $(BINARY64) fzf && tar -czf $(RELEASE64).tgz fzf
 	cd target && cp -f $(BINARYARM5) fzf && tar -czf $(RELEASEARM5).tgz fzf
 	cd target && cp -f $(BINARYARM6) fzf && tar -czf $(RELEASEARM6).tgz fzf
 	cd target && cp -f $(BINARYARM7) fzf && tar -czf $(RELEASEARM7).tgz fzf
 	cd target && cp -f $(BINARYARM8) fzf && tar -czf $(RELEASEARM8).tgz fzf
+	cd target && cp -f $(BINARYPPC64LE) fzf && tar -czf $(RELEASEPPC64LE).tgz fzf
 	cd target && rm -f fzf
 else
 release: target/$(BINARY32) target/$(BINARY64)
@@ -126,6 +131,9 @@ target/$(BINARYARM7): $(SOURCES) vendor
 
 target/$(BINARYARM8): $(SOURCES) vendor
 	GOARCH=arm64 go build $(BUILD_FLAGS) -o $@
+
+target/$(BINARYPPC64LE): $(SOURCES) vendor
+	GOARCH=ppc64le go build $(BUILD_FLAGS) -o $@
 
 bin/fzf: target/$(BINARY) | bin
 	cp -f target/$(BINARY) bin/fzf

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,6 @@
-hash: 92a208bfbaecdf8d1ccaf99a465884c49f9cd91f44f1756d7bbf3290795c781b
-updated: 2017-12-03T13:37:23.420874333+09:00
+hash: b617c76661b399f586276767bb93ee67b65dd03cfd1348ecad409e372ea97b3e
+updated: 2018-06-27T18:37:20.189962-07:00
 imports:
-- name: github.com/bjwbell/gensimd
-  version: 06eb18285485c0d572cc7f024050fc6cb652ed4c
-  subpackages:
-  - simd
 - name: github.com/codegangsta/cli
   version: c6af8847eb2b7b297d07c3ede98903e95e680ef9
 - name: github.com/gdamore/encoding
@@ -25,44 +21,12 @@ imports:
   version: 14207d285c6c197daabb5c9793d63e7af9ab2d50
 - name: github.com/mattn/go-shellwords
   version: 02e3cf038dcea8290e44424da473dd12be796a8a
-- name: github.com/mengzhuo/intrinsic
-  version: 34b800838e0bcd9c5b6abd414e3ad03dc1a686b8
-  subpackages:
-  - sse2
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
 - name: golang.org/x/crypto
-  version: e1a4589e7d3ea14a3352255d04b6f1a418845e5e
+  version: 558b6879de74bc843225cde5686419267ff707ca
   subpackages:
-  - acme
-  - blowfish
-  - cast5
-  - chacha20poly1305/internal/chacha20
-  - curve25519
-  - ed25519
-  - ed25519/internal/edwards25519
-  - hkdf
-  - nacl/secretbox
-  - openpgp
-  - openpgp/armor
-  - openpgp/elgamal
-  - openpgp/errors
-  - openpgp/packet
-  - openpgp/s2k
-  - pbkdf2
-  - pkcs12/internal/rc2
-  - poly1305
-  - ripemd160
-  - salsa20/salsa
-  - ssh
-  - ssh/agent
   - ssh/terminal
-  - ssh/testdata
-- name: golang.org/x/net
-  version: a8b9294777976932365dabb6640cf1468d95c70f
-  subpackages:
-  - context
-  - context/ctxhttp
 - name: golang.org/x/sys
   version: b90f89a1e7a9c1f6b918820b3daa7f08488c8594
   subpackages:
@@ -70,65 +34,15 @@ imports:
 - name: golang.org/x/text
   version: 4ee4af566555f5fbe026368b75596286a312663a
   subpackages:
-  - cases
-  - collate
-  - collate/build
-  - currency
   - encoding
   - encoding/charmap
-  - encoding/ianaindex
   - encoding/internal
   - encoding/internal/identifier
   - encoding/japanese
   - encoding/korean
   - encoding/simplifiedchinese
   - encoding/traditionalchinese
-  - encoding/unicode
-  - encoding/unicode/utf32
-  - internal
-  - internal/colltab
-  - internal/format
-  - internal/gen
-  - internal/stringset
-  - internal/tag
-  - internal/testtext
-  - internal/triegen
-  - internal/ucd
-  - internal/utf8internal
-  - language
-  - language/display
-  - message
-  - runes
-  - secure/bidirule
   - transform
-  - unicode/bidi
-  - unicode/cldr
-  - unicode/norm
-  - unicode/rangetable
-  - width
-- name: golang.org/x/tools
-  version: 04447353bc504b9a5c02eb227b9ecd252e64ea20
-  subpackages:
-  - go/ast/astutil
-  - go/buildutil
-  - go/loader
 - name: gopkg.in/yaml.v2
   version: 287cf08546ab5e7e37d55a84f7ed3fd1db036de5
-testImports:
-- name: github.com/gopherjs/gopherjs
-  version: 444abdf920945de5d4a977b572bcc6c674d1e4eb
-  subpackages:
-  - js
-- name: github.com/jtolds/gls
-  version: 77f18212c9c7edc9bd6a33d383a7b545ce62f064
-- name: github.com/smartystreets/assertions
-  version: 0b37b35ec7434b77e77a4bb29b79677cced992ea
-  subpackages:
-  - internal/go-render/render
-  - internal/oglematchers
-- name: github.com/smartystreets/goconvey
-  version: e5b2b7c9111590d019a696c7800593f666e1a7f4
-  subpackages:
-  - convey
-  - convey/gotest
-  - convey/reporting
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -11,6 +11,6 @@ import:
   subpackages:
   - encoding
 - package: golang.org/x/crypto
-  version: e1a4589e7d3ea14a3352255d04b6f1a418845e5e
+  version: 558b6879de74bc843225cde5686419267ff707ca
   subpackages:
   - ssh/terminal


### PR DESCRIPTION
These patches add ppc64le to the build system and update the crypto lib to pull in a fix [1] for syscalls that's needed to get fzf working. These changes and building with Go 1.10 allows fzf to work on ppc64le (tested on Ubuntu 16.04). Building with Go 1.6-1.9 does not produce a working fzf, presumably due to bugs in Go.

[1] https://go.googlesource.com/crypto/+/558b6879de74bc843225cde5686419267ff707ca

Note: I'm not a Go user myself so I have no idea if the generated `glide.lock` file is correct, it's what was emitted when I did `glide update`.