### PR TITLE
Resolves #1349

### DIFF
--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -306,8 +306,13 @@ func (r *LightRenderer) getBytesInternal(buffer []byte, nonblock bool) []byte {
 				continue
 			}
 			break
+		} else if c == ESC {
+			// if we find another ESC, restart retries to
+			// see if the ESC is by itself:
+			retries = r.escDelay / escPollInterval
+		} else {
+			retries = 0
 		}
-		retries = 0
 		buffer = append(buffer, byte(c))
 	}
 

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -297,6 +297,7 @@ func (r *LightRenderer) getBytesInternal(buffer []byte, nonblock bool) []byte {
 	}
 	buffer = append(buffer, byte(c))
 
+	pc := c
 	for {
 		c, ok = r.getch(true)
 		if !ok {
@@ -306,14 +307,13 @@ func (r *LightRenderer) getBytesInternal(buffer []byte, nonblock bool) []byte {
 				continue
 			}
 			break
-		} else if c == ESC {
-			// if we find another ESC, restart retries to
-			// see if the ESC is by itself:
+		} else if c == ESC && pc != c {
 			retries = r.escDelay / escPollInterval
 		} else {
 			retries = 0
 		}
 		buffer = append(buffer, byte(c))
+		pc = c
 	}
 
 	return buffer


### PR DESCRIPTION
If an ESC char is found whiile processing characters,
continue to check for characters. This prevent fzf from
prematurely exiting.