### PR TITLE
[bash,zsh] unique shell history (optional through FZF_UNIQUE_HISTORY)

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -51,11 +51,18 @@ __fzf_cd__() {
   dir=$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m) && printf 'cd %q' "$dir"
 }
 
+__fzf_history_dedup__() {
+  if [ -z ${FZF_UNIQUE_HISTORY+x} ]; then
+    cat
+  else
+    perl -ne 'print if !$seen{($_ =~ s/^[0-9\s]*//r)}++'
+  fi
+}
 __fzf_history__() (
   local line
   shopt -u nocaseglob nocasematch
   line=$(
-    HISTTIMEFORMAT= history |
+    HISTTIMEFORMAT= history | __fzf_history_dedup__ |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS --tac --sync -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m" $(__fzfcmd) |
     command grep '^ *[0-9]') &&
     if [[ $- =~ H ]]; then

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -65,11 +65,19 @@ fzf-cd-widget() {
 zle     -N    fzf-cd-widget
 bindkey '\ec' fzf-cd-widget
 
+fzf-history-dedup() {
+  if [ -z ${FZF_UNIQUE_HISTORY+x} ]; then
+    cat
+  else
+    perl -ne 'print if !$seen{($_ =~ s/^[0-9\s]*//r)}++'
+  fi
+}
+
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail 2> /dev/null
-  selected=( $(fc -rl 1 |
+  selected=( $(fc -rl 1 | fzf-history-dedup  |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then


### PR DESCRIPTION
Hey,

I like to have a deduplicated shell history when using CTRL-R.

Yes, I am aware that it is a recurring question and I have seen them (#749, #270, #49, #88, #492, #600).
And thus it occurred to me, that it might bother some more people than myself.

The solutions so far did not solve my desire, as most of them would omit the duplicated entries from the history entirely and I want to keep it for histories sake.
Others propose nanuniq, which is yet an other not standard tool (not even in my software repositories), and thus I did not want to rely on it. Further I guess I have an easier approach with much less code counting in nauniq.
Using an alternative CTRL-R command would be able to solve the problem as well, but that was declined (with reasonable arguments) and I feel it would be a to complicated feature for a simple task.

Therefore I provided an option ( FZF_UNIQUE_HISTORY=1 ) to enable a unique history without changing the default as it is (therefore breaking no tests). I am sad that I can not provide further tests for the new "feature" as I have experience in go yet (maybe it's time to start).
I only rely on perl which is installed on most systems per default (perl was only choosen as I guess it's the most compact and simple way to express the duplicate filtering).
Lines are filtered for uniqueness ignoring numbers and spaces at the beginning.
Only the first match is included. It could easily be extended to include only the last match, but it yould require two tail -r. I'd like to open that up for discussion if it is worth it (haven't taken any performance measures).
I included and tested bash and zsh. I am unfamiliar with fish, but per default it does filter out duplicates in history on my system - therefore I didn't dig any deeper.

I really hope this might be included or may at least help some others looking for a simple solution without extra scripts.

Cheers and thanks for this awesome project,
 Andrej