### PR TITLE
Add --tiebreak proximity=path

### DIFF
--- a/src/chunklist_test.go
+++ b/src/chunklist_test.go
@@ -9,7 +9,13 @@ import (
 
 func TestChunkList(t *testing.T) {
 	// FIXME global
-	sortCriteria = []criterion{byScore, byLength}
+	sortCriteria = []criterion{criterion{
+		by:  byScore,
+		arg: "",
+	}, criterion{
+		by:  byLength,
+		arg: "",
+	}}
 
 	cl := NewChunkList(func(item *Item, s []byte) bool {
 		item.text = util.ToChars(s)

--- a/src/core.go
+++ b/src/core.go
@@ -127,11 +127,11 @@ func Run(opts *Options, revision string) {
 	// Matcher
 	forward := true
 	for _, cri := range opts.Criteria[1:] {
-		if cri == byEnd {
+		if cri.by == byEnd {
 			forward = false
 			break
 		}
-		if cri == byBegin {
+		if cri.by == byBegin {
 			break
 		}
 	}

--- a/src/result_test.go
+++ b/src/result_test.go
@@ -54,7 +54,13 @@ func TestRankComparison(t *testing.T) {
 // Match length, string length, index
 func TestResultRank(t *testing.T) {
 	// FIXME global
-	sortCriteria = []criterion{byScore, byLength}
+	sortCriteria = []criterion{criterion{
+		by:  byScore,
+		arg: "",
+	}, criterion{
+		by:  byLength,
+		arg: "",
+	}}
 
 	strs := [][]rune{[]rune("foo"), []rune("foobar"), []rune("bar"), []rune("baz")}
 	item1 := buildResult(


### PR DESCRIPTION
This patch adds a new type of `tiebreak`: `proximity=path`. It works by ranking equally-scored candidates by their proximity to the given path argument, where proximity is defined as the number of shared leading path segments when split by the OS path separator.

Consider the following simple file hierarchy:

    test.txt
    bar/test.txt
    bar/main.txt
    misc/test.txt

Where a user is currently in the context of `bar/main.txt`. This could be for a number of reasons, such as it being the file that is currently open in their editor (see junegunn/fzf.vim#360 and junegunn/fzf.vim#492). They now want to open `bar/test.txt`. If they invoke `fzf` and type, well, any search, the `by_length` scoring will make the `test.txt` file in the root the "best" candidate, as would `by_start`. `by_end` would propose `misc/test.txt`. `by_score` would also likely suggest `test.txt` in the root. None of these take into account the user's current location.

With this patch, the user can invoke `fzf --tiebreak path=bar/main.txt`, which will cause it to rank files that share a prefix segment (`bar/` in this case) to rank higher. Thus, when the user types, say, `t`, `bar/test.txt` will immediately be the top recommendation. In editor context, the user's editor should probably automatically add this flag based on the user's current file.

The flag also allows for more natural search in deeper hierarchies. For example, if the user is in `foobar/controller/admin.rb` here:

    baz/controller/admin.rb
    baz/views/admin.rb
    foobar/controller/admin.rb
    foobar/views/admin.rb

And wants to quickly edit the view for that application (i.e., `foobar/views/admin.rb`), then

    fzf --tiebreak path=foobar/controller/admin.rb

will rank `foobar/views/admin.rb` higher than `baz/views/admin.rb` for a search of `admin.rb`, which is what the user most likely expected.

Note that contrary to other suggestions like only listing files at or below the user's current directory, this patch does *not* limit the user's ability to search beyond the scope of their current context (e.g., they *can* get to `baz/controller/admin.rb` if they so wish).