### PR TITLE
Don't drop buffered input data in findOffset()

### DIFF
--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -27,7 +27,7 @@ const (
 
 const consoleDevice string = "/dev/tty"
 
-var offsetRegexp *regexp.Regexp = regexp.MustCompile("\x1b\\[([0-9]+);([0-9]+)R")
+var offsetRegexp *regexp.Regexp = regexp.MustCompile("(.*)\x1b\\[([0-9]+);([0-9]+)R")
 
 func openTtyIn() *os.File {
 	in, err := os.OpenFile(consoleDevice, syscall.O_RDONLY, 0)
@@ -154,8 +154,10 @@ func (r *LightRenderer) findOffset() (row int, col int) {
 	for tries := 0; tries < offsetPollTries; tries++ {
 		bytes = r.getBytesInternal(bytes, tries > 0)
 		offsets := offsetRegexp.FindSubmatch(bytes)
-		if len(offsets) > 2 {
-			return atoi(string(offsets[1]), 0) - 1, atoi(string(offsets[2]), 0) - 1
+		if len(offsets) > 3 {
+			// add anything we skipped over to the input buffer
+			r.buffer = append(r.buffer, offsets[1]...)
+			return atoi(string(offsets[2]), 0) - 1, atoi(string(offsets[3]), 0) - 1
 		}
 	}
 	return -1, -1


### PR DESCRIPTION
Sometimes when `fzf` takes a while to startup, I start typing but my input gets dropped once the UI actually renders, and it's slightly annoying. It's rare (because `fzf` is usually quick), but noticeable particularly on first run after booting.

To reproduce, you can simulate a slow load with:

```
git ls-files | (sleep 1; fzf)
```

Currently anything you type in the first second will be dropped, with this change it gets consumed as search input once fzf loads.

I don't know if it's a bit weird to modify `r.buffer` during `findOffsets()`. It could alternatively return `(skipped, row, col)` and leave it up to the caller to add `skipped` to `r.buffer`, but that might get awkward.

I also don't know if this is the only place which needs this fix - is there a dark TUI as well as a light one?