### PR TITLE
fix multiline prompt issue with 'zle reset-prompt'

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -60,8 +60,7 @@ __fzf_generic_path_completion() {
       if [ -n "$matches" ]; then
         LBUFFER="$lbuf$matches$tail"
       fi
-      zle redisplay
-      typeset -f zle-line-init >/dev/null && zle zle-line-init
+      zle reset-prompt
       break
     fi
     dir=$(dirname "$dir")
@@ -100,8 +99,7 @@ _fzf_complete() {
   if [ -n "$matches" ]; then
     LBUFFER="$lbuf$matches"
   fi
-  zle redisplay
-  typeset -f zle-line-init >/dev/null && zle zle-line-init
+  zle reset-prompt
   command rm -f "$fifo"
 }
 
@@ -165,8 +163,7 @@ fzf-completion() {
     if [ -n "$matches" ]; then
       LBUFFER="$LBUFFER$matches"
     fi
-    zle redisplay
-    typeset -f zle-line-init >/dev/null && zle zle-line-init
+    zle reset-prompt
   # Trigger sequence given
   elif [ ${#tokens} -gt 1 -a "$tail" = "$trigger" ]; then
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS:-cd pushd rmdir})

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -29,8 +29,7 @@ __fzfcmd() {
 fzf-file-widget() {
   LBUFFER="${LBUFFER}$(__fsel)"
   local ret=$?
-  zle redisplay
-  typeset -f zle-line-init >/dev/null && zle zle-line-init
+  zle reset-prompt
   return $ret
 }
 zle     -N   fzf-file-widget
@@ -59,7 +58,6 @@ fzf-cd-widget() {
   cd "$dir"
   local ret=$?
   zle fzf-redraw-prompt
-  typeset -f zle-line-init >/dev/null && zle zle-line-init
   return $ret
 }
 zle     -N    fzf-cd-widget
@@ -78,8 +76,7 @@ fzf-history-widget() {
       zle vi-fetch-history -n $num
     fi
   fi
-  zle redisplay
-  typeset -f zle-line-init >/dev/null && zle zle-line-init
+  zle reset-prompt
   return $ret
 }
 zle     -N   fzf-history-widget


### PR DESCRIPTION
Builds upon PR https://github.com/junegunn/fzf/pull/1256, fixes the zsh multiline PS1 issue explained in https://github.com/junegunn/fzf/issues/867.

Tried this with both single and multi-line PS1 prompts and it works for both. This was inspired by a fix to a similar problem with pure (https://github.com/sindresorhus/pure) described here - https://github.com/sindresorhus/pure/issues/143, with the relevant fix here - https://github.com/sindresorhus/pure/pull/273/files#diff-ca464c5c9e47e8a26c7e6ac0ed786406R61.

I don't think this breaks anything, but it would be good to have someone else try this to make sure.