### PR TITLE
Fix for issue #1440

### DIFF
--- a/src/pattern.go
+++ b/src/pattern.go
@@ -385,7 +385,7 @@ func (p *Pattern) transformInput(item *Item) []Token {
 		return *item.transformed
 	}
 
-	tokens := Tokenize(item.text.ToString(), p.delimiter)
+	tokens := Tokenize(string(*item.origText), p.delimiter)
 	ret := Transform(tokens, p.nth)
 	item.transformed = &ret
 	return ret


### PR DESCRIPTION
Fix for #1440. 

Currently, when pattern.go calls `transformInput` (via `basicMatch` or `extendedMatch`), it calls `Tokenize` on `item.text`. `item.text` can be modified by `--with-nth` which means it has the accidental effect of altering the search scope.

The fix makes sure to use the original text sent for an item (which is always stored in `item.origText`).

The tokenized result is still cached in `item.transformed`.

The name `transformed` seems like a bit of a smell to me, should probably be termed 'searchTokens` (you could call text `displayTokens` in partner) or something similar. I assume `--nth` was developed before `--with-nth` and so the names are what they are.