### PR TITLE
Instead of running edit run vsplit for first file and split after

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -205,7 +205,7 @@ function! s:common_sink(action, lines) abort
     return
   endif
   let key = remove(a:lines, 0)
-  let Cmd = get(a:action, key, 'e')
+  let Cmd = get(a:action, key, ( winnr()<2 ? 'vsplit' : 'split' ) )
   if type(Cmd) == type(function('call'))
     return Cmd(a:lines)
   endif


### PR DESCRIPTION
When opening files instead of using edit by default use vsplit if the current window number is less than two otherwise use split.