### PR TITLE
replace from ${TMPDIR:-/tmp}  to /tmp

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -129,10 +129,10 @@ set -e
 
 # Clean up named pipes on exit
 id=$RANDOM
-argsf="${TMPDIR:-/tmp}/fzf-args-$id"
-fifo1="${TMPDIR:-/tmp}/fzf-fifo1-$id"
-fifo2="${TMPDIR:-/tmp}/fzf-fifo2-$id"
-fifo3="${TMPDIR:-/tmp}/fzf-fifo3-$id"
+argsf="/tmp/fzf-args-$id"
+fifo1="/tmp/fzf-fifo1-$id"
+fifo2="/tmp/fzf-fifo2-$id"
+fifo3="/tmp/fzf-fifo3-$id"
 cleanup() {
   \rm -f $argsf $fifo1 $fifo2 $fifo3
 

--- a/install
+++ b/install
@@ -122,7 +122,7 @@ try_curl() {
   if [[ $1 =~ tgz$ ]]; then
     curl -fL $1 | tar -xzf -
   else
-    local temp=${TMPDIR:-/tmp}/fzf.zip
+    local temp=/tmp/fzf.zip
     curl -fLo "$temp" $1 && unzip -o "$temp" && rm -f "$temp"
   fi
 }
@@ -132,7 +132,7 @@ try_wget() {
   if [[ $1 =~ tgz$ ]]; then
     wget -O - $1 | tar -xzf -
   else
-    local temp=${TMPDIR:-/tmp}/fzf.zip
+    local temp=/tmp/fzf.zip
     wget -O "$temp" $1 && unzip -o "$temp" && rm -f "$temp"
   fi
 }
@@ -208,7 +208,7 @@ if [ -n "$binary_error" ]; then
   if command -v go > /dev/null; then
     echo -n "Building binary (go get -u github.com/junegunn/fzf) ... "
     if [ -z "${GOPATH-}" ]; then
-      export GOPATH="${TMPDIR:-/tmp}/fzf-gopath"
+      export GOPATH="/tmp/fzf-gopath"
       mkdir -p "$GOPATH"
     fi
     if go get -u github.com/junegunn/fzf; then

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -86,7 +86,7 @@ _fzf_feed_fifo() (
 
 _fzf_complete() {
   local fifo fzf_opts lbuf fzf matches post
-  fifo="${TMPDIR:-/tmp}/fzf-complete-fifo-$$"
+  fifo="/tmp/fzf-complete-fifo-$$"
   fzf_opts=$1
   lbuf=$2
   post="${funcstack[2]}_post"


### PR DESCRIPTION
Hi All.

I make PR is replace from ${TMPDIR:-/tmp}  to /tmp in some file.

I think need because, `${TMPDIR}` is **global** vars and popular name.
So...If we set `TMPDIR` vars in the another file(for example, .zshrc),
when using fzf-tmux, other software move unintentionally
(for exmaple, other software exec `rm -rf ${TMPDIR}`).

I think This `${TMPDIR}` is noneed set as vars.
And use `${TMPDIR}` in place of `/tmp` (default value).

Do you think?

Thanks.