### PR TITLE
Two fixes and one cosmetics for install script

### DIFF
--- a/install
+++ b/install
@@ -91,7 +91,7 @@ ask() {
 check_binary() {
   echo -n "  - Checking fzf executable ... "
   local output
-  output=$("$fzf_base"/bin/fzf --version 2>&1 | awk '{print $1}')
+  output=$(set -o pipefail; "$fzf_base"/bin/fzf --version 2>&1 | awk '{print $1}')
   if [ $? -ne 0 ]; then
     echo "Error: $output"
     binary_error="Invalid binary"
@@ -110,8 +110,8 @@ check_binary() {
 link_fzf_in_path() {
   if which_fzf="$(command -v fzf)"; then
     echo "  - Found in \$PATH"
-    echo "  - Creating symlink: $which_fzf -> bin/fzf"
-    (cd "$fzf_base"/bin && rm -f fzf && ln -sf "$which_fzf" fzf)
+    echo "  - Creating symlink: bin/fzf ->  $which_fzf"
+    (mkdir -p "$fzf_base"/bin && cd "$fzf_base"/bin && rm -f fzf && ln -sf "$which_fzf" fzf)
     check_binary && return
   fi
   return 1


### PR DESCRIPTION

Fix: line 94: it is possible for `fzf --version` to fail with output
that satisfies awk, therefore $? is 0 in spite of the error. Fixed by
adding pipefail. Seen in attached install log. Due to previous error in
the same log.

Change: line 113 (cosmetics). Reverse `->` link notation to match that
of `ls -l`.

Fix: line 114: It is possible for the bin directory to not exist. Fixed
by adding `mkdir -p`. Seen in attached install log. Execution continued
to expose the error on line 94 (fixed above).

Attached: install log file [install-log-2018-12-30.txt](https://github.com/junegunn/fzf/files/2717556/install-log-2018-12-30.txt)
