### PR TITLE
Handling EAGAIN on tty with retries for robustness

### DIFF
--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -275,7 +275,10 @@ func (r *LightRenderer) getch(nonblock bool) (int, bool) {
 	b := make([]byte, 1)
 	fd := r.fd()
 	util.SetNonblock(r.ttyin, nonblock)
-	_, err := util.Read(fd, b)
+	var err error = syscall.EAGAIN
+	for tries := 3; err == syscall.EAGAIN && tries > 0; tries-- {
+		_, err = util.Read(fd, b)
+	}
 	if err != nil {
 		return 0, false
 	}


### PR DESCRIPTION
I know #1486 is caused by a kernel regression and there will be fix eventually (hopefully very soon), but I thought it might be good to have some measure of robustness here to handle EAGAINs.
At least it fixes #1486 until the new kernel update is released.

Handles anoying kernel bugs where one might get unexpected EAGAIN when reading
from tty (see https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1813873).
It is solved by up to two retries to provide some robustness.
Fixes #1486

Cheers!