### PR TITLE
[README.md] Add `bat` to preview syntax highlighting examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,15 +494,17 @@ fzf --preview 'head -100 {}'
 Preview window supports ANSI colors, so you can use programs that
 syntax-highlights the content of a file.
 
+- Bat: https://github.com/sharkdp/bat
 - Highlight: http://www.andre-simon.de/doku/highlight/en/highlight.php
 - CodeRay: http://coderay.rubychan.de/
 - Rouge: https://github.com/jneen/rouge
 
 ```bash
-# Try highlight, coderay, rougify in turn, then fall back to cat
+# Try bat, highlight, coderay, rougify in turn, then fall back to cat
 fzf --preview '[[ $(file --mime {}) =~ binary ]] &&
                  echo {} is a binary file ||
-                 (highlight -O ansi -l {} ||
+                 (bat --style=numbers --color=always {} ||
+                  highlight -O ansi -l {} ||
                   coderay {} ||
                   rougify {} ||
                   cat {}) 2> /dev/null | head -500'


### PR DESCRIPTION
... Since bat is pretty awesome :)

Similar to this PR from fzf.vim:
https://github.com/junegunn/fzf.vim/pull/712

Looks like this:
<img width="1218" alt="screenshot" src="https://user-images.githubusercontent.com/133680/55061370-d85aea80-5030-11e9-9801-e0a0db01ff40.png">
