### PR TITLE
[bash-completion] Fix custom completion for non-standard command names

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -123,11 +123,11 @@ _fzf_handle_dynamic_completion() {
   if [ -n "$orig" ] && type "$orig" > /dev/null 2>&1; then
     $orig "$@"
   elif [ -n "$_fzf_completion_loader" ]; then
-    orig_complete=$(complete -p "$cmd" 2> /dev/null)
+    orig_complete=$(complete -p "$orig_cmd" 2> /dev/null)
     _completion_loader "$@"
     ret=$?
     # _completion_loader may not have updated completion for the command
-    if [ "$(complete -p "$cmd" 2> /dev/null)" != "$orig_complete" ]; then
+    if [ "$(complete -p "$orig_cmd" 2> /dev/null)" != "$orig_complete" ]; then
       eval "$(complete | command grep " -F.* $orig_cmd$" | __fzf_orig_completion_filter)"
       if [[ "$__fzf_nospace_commands" = *" $orig_cmd "* ]]; then
         eval "${orig_complete/ -F / -o nospace -F }"


### PR DESCRIPTION
Related to [previous issue](https://github.com/junegunn/fzf/issues/1170).
[Previous solution](https://github.com/junegunn/fzf/commit/d6588fc835aff6d952d86b1bdc5ed7378a846ab9#diff-c16a25d47a578fa3d03aa4328a4f59b0)
wouldn't work for commands with non-standard names, where `$cmd` and `$orig_cmd` differ,
e.g. `s.foo` -> `s_foo`