### PR TITLE
Make fzf conditionally respect old zsh key bindings

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -103,9 +103,11 @@ bindkey '\ec' fzf-cd-widget
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local oldbinding=$__fzf_old_binding[^R]
+  setopt local_options extended_glob
 
-  # If the cursor is not at the start of the line, then fall back to the old key binding.
-  if [[ -n $oldbinding ]] && (( CURSOR )); then
+  # If the command line is empty or only whitespace, use fzf. Otherwise fall
+  # back to old binding.
+  if [[ -n $oldbinding && $BUFFER != (#s)[[:space:]]#(#e) ]]; then
     zle $oldbinding
     return $?
   fi

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -103,7 +103,7 @@ fzf-history-widget() {
 
   # If the command line is empty or only whitespace, use fzf. Otherwise fall
   # back to old binding.
-  if [[ -n $oldbinding && $BUFFER != (#s)[[:space:]]#(#e) ]]; then
+  if [[ -n $oldbinding && $BUFFER != [[:space:]]# ]]; then
     zle $oldbinding
     return $?
   fi

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -70,7 +70,6 @@ zle -N fzf-redraw-prompt
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  local aroundcursor="${LBUFFER[-1]:- }${RBUFFER[1]:- }${RBUFFER[2]:- }"
   local oldbinding=$__fzf_old_binding[\ec]
 
   # If the cursor is not surrounded by whitespace fall back to what alt-c was
@@ -81,9 +80,6 @@ fzf-cd-widget() {
     return $?
   fi
 
-  # If the cursor is not surrounded by whitespace fall back to what ctrl-t was
-  # bound to before fzf overwrote it.
-  if [[ -n $oldbinding && $aroundcursor != '   ' ]]
   local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type d -print 2> /dev/null | cut -b3-"}"
   setopt localoptions pipefail 2> /dev/null


### PR DESCRIPTION
I'm annoyed that fzf overrides some key-bindings unconditionally. I find the default bindings of `C-r`, `C-t` and `M-c` very useful. I also think fzf is very useful. This pull request mixes both behaviors. I've been using this for a while and I'm very happy with it.

Specifically, these changes make fzf respect old zsh key-bindings (if any) in certain situations:
- `C-t`, `M-c`: If the cursor is not surrounded by whitespace, then use old binding.
- `C-r`: only use fzf if the command line is empty or only whitespace

In all cases, if old bindings were not set, fzf is used.