### PR TITLE
add pre / post completion 'hooks'

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,12 +236,6 @@ Also check out `--reverse` and `--layout` options if you prefer
 vim $(fzf --height 40% --reverse)
 ```
 
-You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
-default. For example,
-
-```sh
-export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
-```
 
 #### Search syntax
 
@@ -273,12 +267,24 @@ or `py`.
 
 #### Environment variables
 
+##### Default
+
 - `FZF_DEFAULT_COMMAND`
     - Default command to use when input is tty
     - e.g. `export FZF_DEFAULT_COMMAND='fd --type f'`
 - `FZF_DEFAULT_OPTS`
-    - Default options
-    - e.g. `export FZF_DEFAULT_OPTS="--layout=reverse --inline-info"`
+    - Default options for any `fzf` invocation
+    - e.g. `export FZF_DEFAULT_OPTS='--layout=reverse --inline-info'`
+    - e.g. `export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'`
+
+##### Completion specific
+
+- `FZF_COMPLETION_TRIGGER`
+    - Trigger to initiate completions
+    - e.g. `**`
+- `FZF_COMPLETION_OPTS`
+    - Additional options for `fzf` completion invocation
+    - e.g. `+c -x`
 
 #### Options
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,12 @@ or `py`.
 - `FZF_COMPLETION_OPTS`
     - Additional options for `fzf` completion invocation
     - e.g. `+c -x`
+- `FZF_COMPLETION_PRE_CMDS`
+    - Shell commands to be executed pre-completion
+    - e.g. `local rt=REPORTTIME; unset REPORTTIME`
+- `FZF_COMPLETION_POST_CMDS`
+    - Shell commands to be executed post-completion
+    - e.g. `REPORTTIME=$rt`
 
 #### Options
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -4,10 +4,12 @@
 #  / __/ / /_/ __/
 # /_/   /___/_/-completion.bash
 #
-# - $FZF_TMUX               (default: 0)
-# - $FZF_TMUX_HEIGHT        (default: '40%')
-# - $FZF_COMPLETION_TRIGGER (default: '**')
-# - $FZF_COMPLETION_OPTS    (default: empty)
+# - $FZF_TMUX                  (default: 0)
+# - $FZF_TMUX_HEIGHT           (default: '40%')
+# - $FZF_COMPLETION_TRIGGER    (default: '**')
+# - $FZF_COMPLETION_OPTS       (default: empty)
+# - $FZF_COMPLETION_PRE_CMDS   (default: empty)
+# - $FZF_COMPLETION_POST_CMDS  (default: empty)
 
 if [[ $- =~ i ]]; then
 
@@ -187,6 +189,11 @@ _fzf_complete() {
   type -t "$post" > /dev/null 2>&1 || post=cat
   fzf="$(__fzfcmd_complete)"
 
+  # run pre-completion commands
+  [ -n "$FZF_COMPLETION_PRE_CMDS" ] &&
+    { eval "$FZF_COMPLETION_PRE_CMDS" ||
+    { echo "pre-completion commands failure" && return 1; } }
+
   cmd="${COMP_WORDS[0]//[^A-Za-z0-9_=]/_}"
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
   cur="${COMP_WORDS[COMP_CWORD]}"
@@ -205,6 +212,11 @@ _fzf_complete() {
     shift
     _fzf_handle_dynamic_completion "$cmd" "$@"
   fi
+
+  # run post-completion commands
+  [ -n "$FZF_COMPLETION_POST_CMDS" ] &&
+    { eval "$FZF_COMPLETION_POST_CMDS" ||
+    { echo "post-completion commands failure" && return 1; } }
 }
 
 _fzf_path_completion() {

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -4,10 +4,12 @@
 #  / __/ / /_/ __/
 # /_/   /___/_/-completion.zsh
 #
-# - $FZF_TMUX               (default: 0)
-# - $FZF_TMUX_HEIGHT        (default: '40%')
-# - $FZF_COMPLETION_TRIGGER (default: '**')
-# - $FZF_COMPLETION_OPTS    (default: empty)
+# - $FZF_TMUX                  (default: 0)
+# - $FZF_TMUX_HEIGHT           (default: '40%')
+# - $FZF_COMPLETION_TRIGGER    (default: '**')
+# - $FZF_COMPLETION_OPTS       (default: empty)
+# - $FZF_COMPLETION_PRE_CMDS   (default: empty)
+# - $FZF_COMPLETION_POST_CMDS  (default: empty)
 
 if [[ $- =~ i ]]; then
 
@@ -154,6 +156,11 @@ fzf-completion() {
 
   cmd=${tokens[1]}
 
+  # run pre-completion commands
+  [ -n "$FZF_COMPLETION_PRE_CMDS" ] &&
+    { eval "$FZF_COMPLETION_PRE_CMDS" ||
+    { echo "pre-completion commands failure" && return 1; } }
+
   # Explicitly allow for empty trigger.
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
   [ -z "$trigger" -a ${LBUFFER[-1]} = ' ' ] && tokens+=("")
@@ -185,6 +192,11 @@ fzf-completion() {
   else
     zle ${fzf_default_completion:-expand-or-complete}
   fi
+
+  # run post-completion commands
+  [ -n "$FZF_COMPLETION_POST_CMDS" ] &&
+    { eval "$FZF_COMPLETION_POST_CMDS" ||
+    { echo "post-completion commands failure" && return 1; } }
 }
 
 [ -z "$fzf_default_completion" ] && {


### PR DESCRIPTION
Hi,

Thanks for your excellent project!

I hit an issue with terminal text corruption in the completion output when moving (up/down) through the initial completion. It appeared like the set the fzf was iterating through was 'one off' that displayed on the screen. This left some nasty artifacts and made it difficult to read what was currently selected.

This turned out to be due to zsh's builtin 'timing statistics' outputting on the first line. The sledgehammer disabling of that feature wasn't palatable and hence this PR which, as per the example add to the `README.md` allows me to tune the environment pre and post fzf execution.

I duplicated what I only really needed for zsh, to the `completion.bash` script too ..the changes appear (TM) to do what I want them to do ..you are clearly in a better position to determine side-affects ..I've only been using fzf a day or so.

Cheers.