### PR TITLE
Update fzf-tmux

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -133,8 +133,10 @@ argsf="${TMPDIR:-/tmp}/fzf-args-$id"
 fifo1="${TMPDIR:-/tmp}/fzf-fifo1-$id"
 fifo2="${TMPDIR:-/tmp}/fzf-fifo2-$id"
 fifo3="${TMPDIR:-/tmp}/fzf-fifo3-$id"
+fzf_rm_cmd="${FZF_CLEANUP_CMD:-/bin/rm}"
 cleanup() {
-  \rm -f $argsf $fifo1 $fifo2 $fifo3
+  $fzf_rm_cmd -f $argsf $fifo1 $fifo2 $fifo3
+
 
   # Restore tmux window options
   if [[ "${#tmux_win_opts[@]}" -gt 0 ]]; then


### PR DESCRIPTION
In my case I have defined  `alias rm=~/bin/safe-rm` which move it into trash, `fzf-tmux` generate temporary file which can safe be deleted immediate. so add hook `FZF_CLEANUP_CMD` which default is  `/bin/rm`