### PR TITLE
Use the vim-specific shell instead of the environment variable

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -367,7 +367,7 @@ try
   if !has_key(dict, 'source') && !empty($FZF_DEFAULT_COMMAND) && !s:is_win
     let temps.source = s:fzf_tempname()
     call writefile(s:wrap_cmds(split($FZF_DEFAULT_COMMAND, "\n")), temps.source)
-    let dict.source = (empty($SHELL) ? &shell : $SHELL).' '.fzf#shellescape(temps.source)
+    let dict.source = &shell.' '.fzf#shellescape(temps.source)
   endif
 
   if has_key(dict, 'source')


### PR DESCRIPTION
This will allow to use a specific shell for vim, without needing to change the $SHELL environment variable too.

The shell option is set by default to $SHELL, so it should not matter for users with standard setup.