### PR TITLE
[vim] Use keepjump

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -664,7 +664,7 @@ function! s:execute_term(dict, command, temps) abort
   function! fzf.switch_back(inplace)
     if a:inplace && bufnr('') == self.buf
       if bufexists(self.pbuf)
-        execute 'keepalt b' self.pbuf
+        execute 'keepalt keepjump b' self.pbuf
       endif
       " No other listed buffer
       if bufnr('') == self.buf


### PR DESCRIPTION
I use FZF with 'window': 'enew'. When FZF switches back, the current position in the FZF buffer will be added to the jumplist. When I then want to jump back to the position I was in before I started FZF, it is a buffer that no longer exists, so I end up at the beginning of the current file for some reason.

By adding 'keepjump' when switching back, the position is not added anymore. I believe this also fixes #595, at least for me.