### PR TITLE
Fix name-based colours for gvim/8.0 without the in-built terminal

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -501,12 +501,12 @@ function! s:dopopd()
 endfunction
 
 function! s:xterm_launcher()
-  let fmt = 'xterm -T "[fzf]" -bg "\%s" -fg "\%s" -geometry %dx%d+%d+%d -e bash -ic %%s'
+  let fmt = 'xterm -T "[fzf]" -bg "%s" -fg "%s" -geometry %dx%d+%d+%d -e bash -ic %%s'
   if has('gui_macvim')
     let fmt .= '&& osascript -e "tell application \"MacVim\" to activate"'
   endif
   return printf(fmt,
-    \ synIDattr(hlID("Normal"), "bg"), synIDattr(hlID("Normal"), "fg"),
+    \ escape(synIDattr(hlID("Normal"), "bg"), '#'), escape(synIDattr(hlID("Normal"), "fg"), '#'),
     \ &columns, &lines/2, getwinposx(), getwinposy())
 endfunction
 unlet! s:launcher


### PR DESCRIPTION
Name-based colour specifications for guibg and guifg end up trying to call xterm with spurious backslashes. While this works for hex colours, it causes issues with the name-based colours. This removes the backslash in the format string and, instead, escapes the pound character as needed (i.e. if it is present).