### PR TITLE
os.Kill signal cannot be trapped

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1423,7 +1423,7 @@ func (t *Terminal) Loop() {
 	<-t.startChan
 	{ // Late initialization
 		intChan := make(chan os.Signal, 1)
-		signal.Notify(intChan, os.Interrupt, os.Kill, syscall.SIGTERM)
+		signal.Notify(intChan, os.Interrupt, syscall.SIGTERM)
 		go func() {
 			<-intChan
 			t.reqBox.Set(reqQuit, nil)


### PR DESCRIPTION
We're already trapping SIGTERM as well, not much else we can do.