### PR TITLE
$(...) calls should be quoted: "$(...)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ to install fzf.
 brew install fzf
 
 # To install useful key bindings and fuzzy completion:
-$(brew --prefix)/opt/fzf/install
+"$(brew --prefix)/opt/fzf/install"
 ```
 
 fzf is also available [via MacPorts][portfile]: `sudo port install fzf`
@@ -244,7 +244,7 @@ files excluding hidden ones. (You can override the default command with
 `FZF_DEFAULT_COMMAND`)
 
 ```sh
-vim $(fzf)
+vim "$(fzf)"
 ```
 
 #### Using the finder
@@ -262,14 +262,14 @@ fzf by default starts in fullscreen mode, but you can make it start below the
 cursor with `--height` option.
 
 ```sh
-vim $(fzf --height 40%)
+vim "$(fzf --height 40%)"
 ```
 
 Also check out `--reverse` and `--layout` options if you prefer
 "top-down" layout instead of the default "bottom-up" layout.
 
 ```sh
-vim $(fzf --height 40% --reverse)
+vim "$(fzf --height 40% --reverse)"
 ```
 
 You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by


### PR DESCRIPTION
`vim $(fzf)` will not open files that have a space in the name. To fix that, use double quotes.