### PR TITLE
Add MSYS2 support as a vim plugin

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -50,7 +50,9 @@ if s:is_win
   " Use utf-8 for fzf.vim commands
   " Return array of shell commands for cmd.exe
   function! s:wrap_cmds(cmds)
-    return map(['@echo off', 'set TERM= > nul', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001 > nul'] +
+    return map(['@echo off'] +
+          \ (has('gui_running') ? ['set TERM= > nul'] : []) + 
+          \ ['for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001 > nul'] +
           \ (type(a:cmds) == type([]) ? a:cmds : [a:cmds]) +
           \ ['chcp %origchcp% > nul'], 'v:val."\r"')
   endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -77,7 +77,7 @@ function! s:shellesc_cmd(arg)
 endfunction
 
 function! fzf#shellescape(arg, ...)
-  let shell = get(a:000, 0, s:is_win ? 'cmd.exe' : &shell)
+  let shell = get(a:000, 0, s:is_win ? 'cmd.exe' : 'sh')
   if shell =~# 'cmd.exe$'
     return s:shellesc_cmd(a:arg)
   endif

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -50,7 +50,7 @@ if s:is_win
   " Use utf-8 for fzf.vim commands
   " Return array of shell commands for cmd.exe
   function! s:wrap_cmds(cmds)
-    return map(['@echo off', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001 > nul'] +
+    return map(['@echo off', 'set TERM= > nul', 'for /f "tokens=4" %%a in (''chcp'') do set origchcp=%%a', 'chcp 65001 > nul'] +
           \ (type(a:cmds) == type([]) ? a:cmds : [a:cmds]) +
           \ ['chcp %origchcp% > nul'], 'v:val."\r"')
   endfunction
@@ -334,19 +334,20 @@ function! fzf#wrap(...)
 endfunction
 
 function! s:use_sh()
-  let [shell, shellslash] = [&shell, &shellslash]
+  let [shell, shellslash, shellcmdflag] = [&shell, &shellslash, &shellcmdflag]
   if s:is_win
     set shell=cmd.exe
+    set shellcmdflag=/c
     set noshellslash
   else
     set shell=sh
   endif
-  return [shell, shellslash]
+  return [shell, shellslash, shellcmdflag]
 endfunction
 
 function! fzf#run(...) abort
 try
-  let [shell, shellslash] = s:use_sh()
+  let [shell, shellslash, shellcmdflag] = s:use_sh()
 
   let dict   = exists('a:1') ? s:upgrade(a:1) : {}
   let temps  = { 'result': s:fzf_tempname() }
@@ -416,7 +417,7 @@ try
   call s:callback(dict, lines)
   return lines
 finally
-  let [&shell, &shellslash] = [shell, shellslash]
+  let [&shell, &shellslash, &shellcmdflag] = [shell, shellslash, shellcmdflag]
 endtry
 endfunction
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -75,7 +75,7 @@ function! s:shellesc_cmd(arg)
 endfunction
 
 function! fzf#shellescape(arg, ...)
-  let shell = get(a:000, 0, &shell)
+  let shell = get(a:000, 0, s:is_win ? 'cmd.exe' : &shell)
   if shell =~# 'cmd.exe$'
     return s:shellesc_cmd(a:arg)
   endif

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -336,20 +336,21 @@ function! fzf#wrap(...)
 endfunction
 
 function! s:use_sh()
-  let [shell, shellslash, shellcmdflag] = [&shell, &shellslash, &shellcmdflag]
+  let [shell, shellslash, shellcmdflag, shellxquote] = [&shell, &shellslash, &shellcmdflag, &shellxquote]
   if s:is_win
     set shell=cmd.exe
     set noshellslash
     let &shellcmdflag = has('nvim') ? '/s /c' : '/c'
+    let &shellxquote = has('nvim') ? '"' : '('
   else
     set shell=sh
   endif
-  return [shell, shellslash, shellcmdflag]
+  return [shell, shellslash, shellcmdflag, shellxquote]
 endfunction
 
 function! fzf#run(...) abort
 try
-  let [shell, shellslash, shellcmdflag] = s:use_sh()
+  let [shell, shellslash, shellcmdflag, shellxquote] = s:use_sh()
 
   let dict   = exists('a:1') ? s:upgrade(a:1) : {}
   let temps  = { 'result': s:fzf_tempname() }
@@ -419,7 +420,7 @@ try
   call s:callback(dict, lines)
   return lines
 finally
-  let [&shell, &shellslash, &shellcmdflag] = [shell, shellslash, shellcmdflag]
+  let [&shell, &shellslash, &shellcmdflag, &shellxquote] = [shell, shellslash, shellcmdflag, shellxquote]
 endtry
 endfunction
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -339,8 +339,8 @@ function! s:use_sh()
   let [shell, shellslash, shellcmdflag] = [&shell, &shellslash, &shellcmdflag]
   if s:is_win
     set shell=cmd.exe
-    set shellcmdflag=/c
     set noshellslash
+    let &shellcmdflag = has('nvim') ? '/s /c' : '/c'
   else
     set shell=sh
   endif


### PR DESCRIPTION
Add &shellcmdflag and TERM environment variable treatment.

- Make &shellcmdflag `/C` when &shell turns into `cmd.exe`
- Delete %TERM% environment variable before fzf execution

On MSYS2 environment, vim is typically configured as follows:

- &shell: bash
- &shellcmdflag: -c
- $TERM(%TERM%): xterm or something

Since this plugin does not change &shellcmdflag while it replaces &shell with cmd.exe,
vim on MSYS2 environment cannot start fzf properly.
(It try to do `cmd.exe -c something...` but it should be `cmd.exe /C something...`.)

And at the time of starting cmd.exe %TERM% is no longer needed.
So delete this environment variable in the batch file to be executed.

