### PR TITLE
Support building on machines with `uname -m` == "aarch64"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,8 @@ else ifeq ($(UNAME_M),armv7l)
 	BINARY := $(BINARYARM7)
 else ifeq ($(UNAME_M),armv8l)
 	BINARY := $(BINARYARM8)
+else ifeq ($(UNAME_M),aarch64)
+	BINARY := $(BINARYARM8)
 else ifeq ($(UNAME_M),ppc64le)
 	BINARY := $(BINARYPPC64LE)
 else


### PR DESCRIPTION
I was attempting to build fzf inside termux on an android phone and it failed because the phone reports its architecture as "aarch64", not as "armv8l":

```
$ uname -a
Linux localhost 4.4.189-perf+ #1 SMP PREEMPT Wed Oct 2 11:49:20 UTC 2019 aarch64 Android
$ go env
GO111MODULE=""
GOARCH="arm64"
GOBIN=""
GOCACHE="/data/data/com.termux/files/home/.cache/go-build"
GOENV="/data/data/com.termux/files/home/.config/go/env"
GOEXE=""
GOFLAGS=""
GOHOSTARCH="arm64"
GOHOSTOS="android"
GONOPROXY=""
GONOSUMDB=""
GOOS="android"
GOPATH="/data/data/com.termux/files/home/go"
GOPRIVATE=""
GOPROXY="https://proxy.golang.org,direct"
GOROOT="/data/data/com.termux/files/usr/lib/go"
GOSUMDB="sum.golang.org"
GOTMPDIR=""
GOTOOLDIR="/data/data/com.termux/files/usr/lib/go/pkg/tool/android_arm64"
GCCGO="gccgo"
AR="ar"
CC="aarch64-linux-android-clang"
CXX="aarch64-linux-android-clang++"
CGO_ENABLED="1"
GOMOD="/data/data/com.termux/files/home/.fzf/go.mod"
CGO_CFLAGS="-g -O2"
CGO_CPPFLAGS=""
CGO_CXXFLAGS="-g -O2"
CGO_FFLAGS="-g -O2"
CGO_LDFLAGS="-g -O2"
PKG_CONFIG="pkg-config"
GOGCCFLAGS="-fPIC -pthread -fno-caret-diagnostics -Qunused-arguments -fmessage-length=0 -fdebug-prefix-map=/data/data/com.termux/files/usr/tmp/go-build401736825=/tmp/go-build -gno-record-gcc-switches"
$ make
Makefile:48: *** "Build on aarch64 is not supported, yet.".  Stop.
```

This pull request adds "aarch64" as an alias for "armv8l" so that attempting to build on an aarch64 machine will build for GOARCH=arm64.