### PR TITLE
Add Scarf install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Table of Contents
    * [Installation](#installation)
       * [Using Homebrew or Linuxbrew](#using-homebrew-or-linuxbrew)
       * [Using git](#using-git)
+      * [Using Scarf](#using-scarf)
       * [As Vim plugin](#as-vim-plugin)
       * [Arch Linux](#arch-linux)
       * [Debian](#debian)
@@ -104,6 +105,15 @@ Alternatively, you can "git clone" this repository to any directory and run
 ```sh
 git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 ~/.fzf/install
+```
+
+### Using Scarf
+
+You can install fzf with [Scarf](https://scarf.sh), which supports the developers by
+sending anonymized usage statistics.
+
+```sh
+scarf install fzf
 ```
 
 ### As Vim plugin


### PR DESCRIPTION
Hello @junegunn! This README change adds instructions to install with the [Scarf](https://scarf.sh) package manager (disclaimer: I'm the author of Scarf). 

If you're interested in seeing `fzf`'s usage stats or charging companies when using fzf in a commercial setting, I'd be happy to either transfer package ownership to you or add you as a co-maintainer. Let me know what you think!