### PR TITLE
Issue #1719 Add --preview-stdin

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -73,6 +73,8 @@ const usage = `usage: fzf [options]
 
   Preview
     --preview=COMMAND     Command to preview highlighted line ({})
+    --preview-stdin       The preview script will be given the selected entries
+                          on stdin
     --preview-window=OPT  Preview window layout (default: right:50%)
                           [up|down|left|right][:SIZE[%]][:wrap][:hidden]
 
@@ -147,6 +149,7 @@ type previewOpts struct {
 	size     sizeSpec
 	hidden   bool
 	wrap     bool
+	stdin    bool
 }
 
 // Options stores the values of command-line options
@@ -236,7 +239,7 @@ func defaultOptions() *Options {
 		ToggleSort:  false,
 		Expect:      make(map[int]string),
 		Keymap:      make(map[int][]action),
-		Preview:     previewOpts{"", posRight, sizeSpec{50, true}, false, false},
+		Preview:     previewOpts{"", posRight, sizeSpec{50, true}, false, false, false},
 		PrintQuery:  false,
 		ReadZero:    false,
 		Printer:     func(str string) { fmt.Println(str) },
@@ -1142,6 +1145,8 @@ func parseOptions(opts *Options, allArgs []string) {
 		case "--preview-window":
 			parsePreviewWindow(&opts.Preview,
 				nextString(allArgs, &i, "preview window layout required: [up|down|left|right][:SIZE[%]][:wrap][:hidden]"))
+		case "--preview-stdin":
+			opts.Preview.stdin = true
 		case "--height":
 			opts.Height = parseHeight(nextString(allArgs, &i, "height required: HEIGHT[%]"))
 		case "--min-height":

--- a/src/terminal_test.go
+++ b/src/terminal_test.go
@@ -32,90 +32,101 @@ func TestReplacePlaceholder(t *testing.T) {
 	}
 
 	// {}, preserve ansi
-	result = replacePlaceholder("echo {}", false, Delimiter{}, false, "query", items1)
+	result = replacePlaceholder("echo {}", false, Delimiter{}, false, false, "query", items1)
 	check("echo '  foo'\\''bar \x1b[31mbaz\x1b[m'")
 
 	// {}, strip ansi
-	result = replacePlaceholder("echo {}", true, Delimiter{}, false, "query", items1)
+	result = replacePlaceholder("echo {}", true, Delimiter{}, false, false, "query", items1)
 	check("echo '  foo'\\''bar baz'")
 
 	// {}, with multiple items
-	result = replacePlaceholder("echo {}", true, Delimiter{}, false, "query", items2)
+	result = replacePlaceholder("echo {}", true, Delimiter{}, false, false, "query", items2)
 	check("echo 'foo'\\''bar baz'")
 
+	// {}, with multiple items, requesting newline join as no=op
+	result = replacePlaceholder("echo {}", true, Delimiter{}, false, true, "query", items2)
+	check("echo 'foo'\\''bar baz'")
+
+	// {+}, with multiple items, returned with an item per line
+	result = replacePlaceholder("echo {+}", true, Delimiter{}, false, true, "query", items2)
+	check("echo 'foo'\\''bar baz'\n'FOO'\\''BAR BAZ'")
+
 	// {..}, strip leading whitespaces, preserve ansi
-	result = replacePlaceholder("echo {..}", false, Delimiter{}, false, "query", items1)
+	result = replacePlaceholder("echo {..}", false, Delimiter{}, false, false, "query", items1)
 	check("echo 'foo'\\''bar \x1b[31mbaz\x1b[m'")
 
 	// {..}, strip leading whitespaces, strip ansi
-	result = replacePlaceholder("echo {..}", true, Delimiter{}, false, "query", items1)
+	result = replacePlaceholder("echo {..}", true, Delimiter{}, false, false, "query", items1)
 	check("echo 'foo'\\''bar baz'")
 
 	// {q}
-	result = replacePlaceholder("echo {} {q}", true, Delimiter{}, false, "query", items1)
+	result = replacePlaceholder("echo {} {q}", true, Delimiter{}, false, false, "query", items1)
 	check("echo '  foo'\\''bar baz' 'query'")
 
 	// {q}, multiple items
-	result = replacePlaceholder("echo {+}{q}{+}", true, Delimiter{}, false, "query 'string'", items2)
+	result = replacePlaceholder("echo {+}{q}{+}", true, Delimiter{}, false, false, "query 'string'", items2)
 	check("echo 'foo'\\''bar baz' 'FOO'\\''BAR BAZ''query '\\''string'\\''''foo'\\''bar baz' 'FOO'\\''BAR BAZ'")
 
-	result = replacePlaceholder("echo {}{q}{}", true, Delimiter{}, false, "query 'string'", items2)
+	result = replacePlaceholder("echo {+}{q}{+}", true, Delimiter{}, false, true, "query 'string'", items2)
+	check("echo 'foo'\\''bar baz'\n'FOO'\\''BAR BAZ''query '\\''string'\\''''foo'\\''bar baz'\n'FOO'\\''BAR BAZ'")
+
+	result = replacePlaceholder("echo {}{q}{}", true, Delimiter{}, false, false, "query 'string'", items2)
 	check("echo 'foo'\\''bar baz''query '\\''string'\\''''foo'\\''bar baz'")
 
-	result = replacePlaceholder("echo {1}/{2}/{2,1}/{-1}/{-2}/{}/{..}/{n.t}/\\{}/\\{1}/\\{q}/{3}", true, Delimiter{}, false, "query", items1)
+	result = replacePlaceholder("echo {1}/{2}/{2,1}/{-1}/{-2}/{}/{..}/{n.t}/\\{}/\\{1}/\\{q}/{3}", true, Delimiter{}, false, false, "query", items1)
 	check("echo 'foo'\\''bar'/'baz'/'bazfoo'\\''bar'/'baz'/'foo'\\''bar'/'  foo'\\''bar baz'/'foo'\\''bar baz'/{n.t}/{}/{1}/{q}/''")
 
-	result = replacePlaceholder("echo {1}/{2}/{-1}/{-2}/{..}/{n.t}/\\{}/\\{1}/\\{q}/{3}", true, Delimiter{}, false, "query", items2)
+	result = replacePlaceholder("echo {1}/{2}/{-1}/{-2}/{..}/{n.t}/\\{}/\\{1}/\\{q}/{3}", true, Delimiter{}, false, false, "query", items2)
 	check("echo 'foo'\\''bar'/'baz'/'baz'/'foo'\\''bar'/'foo'\\''bar baz'/{n.t}/{}/{1}/{q}/''")
 
-	result = replacePlaceholder("echo {+1}/{+2}/{+-1}/{+-2}/{+..}/{n.t}/\\{}/\\{1}/\\{q}/{+3}", true, Delimiter{}, false, "query", items2)
+	result = replacePlaceholder("echo {+1}/{+2}/{+-1}/{+-2}/{+..}/{n.t}/\\{}/\\{1}/\\{q}/{+3}", true, Delimiter{}, false, false, "query", items2)
 	check("echo 'foo'\\''bar' 'FOO'\\''BAR'/'baz' 'BAZ'/'baz' 'BAZ'/'foo'\\''bar' 'FOO'\\''BAR'/'foo'\\''bar baz' 'FOO'\\''BAR BAZ'/{n.t}/{}/{1}/{q}/'' ''")
 
 	// forcePlus
-	result = replacePlaceholder("echo {1}/{2}/{-1}/{-2}/{..}/{n.t}/\\{}/\\{1}/\\{q}/{3}", true, Delimiter{}, true, "query", items2)
+	result = replacePlaceholder("echo {1}/{2}/{-1}/{-2}/{..}/{n.t}/\\{}/\\{1}/\\{q}/{3}", true, Delimiter{}, true, false, "query", items2)
 	check("echo 'foo'\\''bar' 'FOO'\\''BAR'/'baz' 'BAZ'/'baz' 'BAZ'/'foo'\\''bar' 'FOO'\\''BAR'/'foo'\\''bar baz' 'FOO'\\''BAR BAZ'/{n.t}/{}/{1}/{q}/'' ''")
 
 	// Whitespace preserving flag with "'" delimiter
-	result = replacePlaceholder("echo {s1}", true, Delimiter{str: &delim}, false, "query", items1)
+	result = replacePlaceholder("echo {s1}", true, Delimiter{str: &delim}, false, false, "query", items1)
 	check("echo '  foo'")
 
-	result = replacePlaceholder("echo {s2}", true, Delimiter{str: &delim}, false, "query", items1)
+	result = replacePlaceholder("echo {s2}", true, Delimiter{str: &delim}, false, false, "query", items1)
 	check("echo 'bar baz'")
 
-	result = replacePlaceholder("echo {s}", true, Delimiter{str: &delim}, false, "query", items1)
+	result = replacePlaceholder("echo {s}", true, Delimiter{str: &delim}, false, false, "query", items1)
 	check("echo '  foo'\\''bar baz'")
 
-	result = replacePlaceholder("echo {s..}", true, Delimiter{str: &delim}, false, "query", items1)
+	result = replacePlaceholder("echo {s..}", true, Delimiter{str: &delim}, false, false, "query", items1)
 	check("echo '  foo'\\''bar baz'")
 
 	// Whitespace preserving flag with regex delimiter
 	regex = regexp.MustCompile("\\w+")
 
-	result = replacePlaceholder("echo {s1}", true, Delimiter{regex: regex}, false, "query", items1)
+	result = replacePlaceholder("echo {s1}", true, Delimiter{regex: regex}, false, false, "query", items1)
 	check("echo '  '")
 
-	result = replacePlaceholder("echo {s2}", true, Delimiter{regex: regex}, false, "query", items1)
+	result = replacePlaceholder("echo {s2}", true, Delimiter{regex: regex}, false, false, "query", items1)
 	check("echo ''\\'''")
 
-	result = replacePlaceholder("echo {s3}", true, Delimiter{regex: regex}, false, "query", items1)
+	result = replacePlaceholder("echo {s3}", true, Delimiter{regex: regex}, false, false, "query", items1)
 	check("echo ' '")
 
 	// No match
-	result = replacePlaceholder("echo {}/{+}", true, Delimiter{}, false, "query", []*Item{nil, nil})
+	result = replacePlaceholder("echo {}/{+}", true, Delimiter{}, false, false, "query", []*Item{nil, nil})
 	check("echo /")
 
 	// No match, but with selections
-	result = replacePlaceholder("echo {}/{+}", true, Delimiter{}, false, "query", []*Item{nil, item1})
+	result = replacePlaceholder("echo {}/{+}", true, Delimiter{}, false, false, "query", []*Item{nil, item1})
 	check("echo /'  foo'\\''bar baz'")
 
 	// String delimiter
-	result = replacePlaceholder("echo {}/{1}/{2}", true, Delimiter{str: &delim}, false, "query", items1)
+	result = replacePlaceholder("echo {}/{1}/{2}", true, Delimiter{str: &delim}, false, false, "query", items1)
 	check("echo '  foo'\\''bar baz'/'foo'/'bar baz'")
 
 	// Regex delimiter
 	regex = regexp.MustCompile("[oa]+")
 	// foo'bar baz
-	result = replacePlaceholder("echo {}/{1}/{3}/{2..3}", true, Delimiter{regex: regex}, false, "query", items1)
+	result = replacePlaceholder("echo {}/{1}/{3}/{2..3}", true, Delimiter{regex: regex}, false, false, "query", items1)
 	check("echo '  foo'\\''bar baz'/'f'/'r b'/''\\''bar b'")
 }
 


### PR DESCRIPTION
If --preview-stdin is given, then the selected list is built as though forcePlus is set, and the data is given to the preview script on stdin, separated by newlines.

`--preview 'mycommand "{+}"` `--preview 'myscript "{}"` and similar continue to work.

These variants will receive selected options on stdin:

`--preview 'mycommand' --preview-stdin` will receive `'option 1'`
`--preview 'mycommand' --preview-stdin -m` will receive 
```
'option1'
'option2'
'option3'
```
