### PR TITLE
add support for a limit when using --multi

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -39,6 +39,7 @@ const usage = `usage: fzf [options]
 
   Interface
     -m, --multi           Enable multi-select with tab/shift-tab
+    --multi-limit=LIMIT   Max limit for multi-select (default: no limit)
     --no-mouse            Disable mouse
     --bind=KEYBINDS       Custom key bindings. Refer to the man page.
     --cycle               Enable cyclic scroll
@@ -163,6 +164,7 @@ type Options struct {
 	Tac         bool
 	Criteria    []criterion
 	Multi       bool
+	MultiLimit  int
 	Ansi        bool
 	Mouse       bool
 	Theme       *tui.ColorTheme
@@ -215,6 +217,7 @@ func defaultOptions() *Options {
 		Tac:         false,
 		Criteria:    []criterion{byScore, byLength},
 		Multi:       false,
+		MultiLimit:  0,
 		Ansi:        false,
 		Mouse:       true,
 		Theme:       tui.EmptyTheme(),
@@ -1224,6 +1227,8 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.HscrollOff = atoi(value)
 			} else if match, value := optString(arg, "--jump-labels="); match {
 				opts.JumpLabels = value
+			} else if match, value := optString(arg, "--multi-limit="); match {
+				opts.MultiLimit = atoi(value)
 			} else {
 				errorExit("unknown option: " + arg)
 			}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -74,6 +74,7 @@ type Terminal struct {
 	yanked     []rune
 	input      []rune
 	multi      bool
+	multiLimit int
 	sort       bool
 	toggleSort bool
 	delimiter  Delimiter
@@ -384,6 +385,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		yanked:     []rune{},
 		input:      input,
 		multi:      opts.Multi,
+		multiLimit: opts.MultiLimit,
 		sort:       opts.Sort > 0,
 		toggleSort: opts.ToggleSort,
 		delimiter:  opts.Delimiter,
@@ -744,7 +746,7 @@ func (t *Terminal) printInfo() {
 			output += " -S"
 		}
 	}
-	if t.multi && len(t.selected) > 0 {
+	if t.multi && len(t.selected) > 0 && (t.multiLimit == 0 || len(t.selected) <= t.multiLimit) {
 		output += fmt.Sprintf(" (%d)", len(t.selected))
 	}
 	if t.progress > 0 && t.progress < 100 {
@@ -1785,6 +1787,7 @@ func (t *Terminal) Loop() {
 				}
 			case actToggle:
 				if t.multi && t.merger.Length() > 0 {
+					if _, found := t.selected[t.merger.Get(t.cy).item.Index()]; !found && t.multiLimit > 0 && len(t.selected) >= t.multiLimit { break }
 					toggle()
 					req(reqList)
 				}
@@ -1807,12 +1810,14 @@ func (t *Terminal) Loop() {
 				return doAction(action{t: actToggleUp}, mapkey)
 			case actToggleDown:
 				if t.multi && t.merger.Length() > 0 {
+					if _, found := t.selected[t.merger.Get(t.cy).item.Index()]; !found && t.multiLimit > 0 && len(t.selected) >= t.multiLimit { break }
 					toggle()
 					t.vmove(-1, true)
 					req(reqList)
 				}
 			case actToggleUp:
 				if t.multi && t.merger.Length() > 0 {
+					if _, found := t.selected[t.merger.Get(t.cy).item.Index()]; !found && t.multiLimit > 0 && len(t.selected) >= t.multiLimit { break }
 					toggle()
 					t.vmove(1, true)
 					req(reqList)


### PR DESCRIPTION
I have implemented an option --multi-limit=LIMIT which allows to set a max number of selections one can make.

closes #1718