### PR TITLE
Adding initial support for running interactive commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,19 @@ For more advanced examples, see [Key bindings for git with fzf][fzf-git]
 
 [fzf-git]: https://junegunn.kr/2016/07/fzf-git/
 
+### Using fzf in interactive mode
+
+You can also use fzf in "interactive command" mode. This mode changes the "default"
+way how fzf retrieves input for filtering. Instead of reading from stdin, fzf
+executes command specified by `--cmd` option. Every change to the filter query
+results in the command being reevaulated and the result is fed back to fzf.
+The query is passed to the command through `{}`.
+
+```bash
+# Run grep continuosly in current directory
+fzf -c 'ag -i {} *'
+```
+
 Tips
 ----
 

--- a/src/chunklist.go
+++ b/src/chunklist.go
@@ -26,6 +26,10 @@ func NewChunkList(trans ItemBuilder) *ChunkList {
 		trans:  trans}
 }
 
+func (cs *ChunkList) clear() {
+	cs.chunks = nil
+}
+
 func (c *Chunk) push(trans ItemBuilder, data []byte) bool {
 	if trans(&c.items[c.count], data) {
 		c.count++

--- a/src/options.go
+++ b/src/options.go
@@ -35,7 +35,8 @@ const usage = `usage: fzf [options]
     --tac                 Reverse the order of the input
     --tiebreak=CRI[,..]   Comma-separated list of sort criteria to apply
                           when the scores are tied [length|begin|end|index]
-                          (default: length)
+						  (default: length)
+	-c, --cmd=CMD		  Interactive mode command
 
   Interface
     -m, --multi           Enable multi-select with tab/shift-tab
@@ -155,6 +156,7 @@ type Options struct {
 	FuzzyAlgo   algo.Algo
 	Extended    bool
 	Case        Case
+	Command     string
 	Normalize   bool
 	Nth         []Range
 	WithNth     []Range
@@ -208,6 +210,7 @@ func defaultOptions() *Options {
 		FuzzyAlgo:   algo.FuzzyMatchV2,
 		Extended:    true,
 		Case:        CaseSmart,
+		Command:     "",
 		Normalize:   true,
 		Nth:         make([]Range, 0),
 		WithNth:     make([]Range, 0),
@@ -998,6 +1001,8 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.Fuzzy = true
 		case "-q", "--query":
 			opts.Query = nextString(allArgs, &i, "query string required")
+		case "-c", "--cmd":
+			opts.Command = nextString(allArgs, &i, "command string required")
 		case "-f", "--filter":
 			filter := nextString(allArgs, &i, "query string required")
 			opts.Filter = &filter

--- a/src/reader.go
+++ b/src/reader.go
@@ -67,6 +67,14 @@ func (r *Reader) ReadSource() {
 	r.fin(success)
 }
 
+// ReadSourceCustom reads data from the default command or from standard input
+func (r *Reader) ReadSourceCustom(cmd string) {
+	r.startEventPoller()
+	var success bool
+	success = r.readFromCommand("sh", cmd)
+	r.fin(success)
+}
+
 func (r *Reader) feed(src io.Reader) {
 	delim := byte('\n')
 	if r.delimNil {


### PR DESCRIPTION
I looked at feature request #751 and I it seems to me that this is a recurring topic. I would give it a try. This is a straightforward implementation of running interactive command in fzf:
- we specify the command using -c param
- query is fed directly to the command
- the command is run every time the query changes (is rerun as-you-type)
- the list is fed with the new result of the command (and any current selection is gone)
The speed is acceptable, even though we run a command multiple times. 
I've put some more observations in #751.
