### PR TITLE
Nvim: handle SIGHUP in exit handler

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -527,6 +527,10 @@ endif
 function! s:exit_handler(code, command, ...)
   if a:code == 130
     return 0
+  elseif has('nvim') && a:code == 129
+    " When deleting the terminal buffer while fzf is still running,
+    " Nvim sends SIGHUP.
+    return 0
   elseif a:code > 1
     call s:error('Error running ' . a:command)
     if !empty(a:000)


### PR DESCRIPTION
In recent Nvim versions, an "Error running ..." message is shown even for normal
use cases, such as:

    :Files
    <c-\><c-n>
    :close

Closing the window will :bwipeout! the terminal buffer, because fzf sets
bufhiden=wipe.

When deleting the terminal buffer while fzf is still running, Nvim sends SIGHUP.
This happens for quite some time already, but the bug only manifests since this
commit:

  https://github.com/neovim/neovim/commit/939d9053b

It's The Right Thing to do when the application exited due to a signal.

Before that commit, no "Error running ..." message was shown, because 1 (instead
of 128 + 1 == SIGHUP) was returned which the exit handler in fzf.vim treats as
"NO MATCH".