### PR TITLE
zsh: prevent the current directory from appearing as `~dir` in prompts

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -56,6 +56,7 @@ fzf-cd-widget() {
     return 0
   fi
   cd "$dir"
+  unset dir # ensure this doesn't end up appearing in prompt expansion
   local ret=$?
   zle fzf-redraw-prompt
   return $ret


### PR DESCRIPTION
# Purpose
The zsh version of the cd widget sets the variable `dir` to the path of the target directory before invoking `cd`. This causes zsh to treat the target directory as a named directory, which has the effect of zsh substituting '%~' with '~dir' instead of the proper path when it performs prompt expansion.

This commit will cause the widget to unset `dir` before redrawing the prompt to fix this issue.

Details of zsh prompt expansion can be found in:
http://zsh.sourceforge.net/Doc/Release/Prompt-Expansion.html

# How to replicate the issue
1. Start a zsh session.
2. Configure the prompt by running `PROMPT='%~%# '`
3. Run the cd widget and select a directory (e.g., `~/destination`)

## What should've happened:
The prompt would be shown as `~/destination%`.

## What actually happens:
The prompt is shown as `~dir%`.