### PR TITLE
[vim] use cterm colors on Windows

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -244,7 +244,7 @@ function! s:common_sink(action, lines) abort
 endfunction
 
 function! s:get_color(attr, ...)
-  let gui = has('termguicolors') && &termguicolors
+  let gui = !s:is_win && !has('win32unix') && has('termguicolors') && &termguicolors
   let fam = gui ? 'gui' : 'cterm'
   let pat = gui ? '^#[a-f0-9]\+' : '^[0-9]\+$'
   for group in a:000


### PR DESCRIPTION
Truecolor does not work on default Windows terminal.
It is a problem in neovim GUIs.

https://github.com/sainnhe/edge/issues/5#issuecomment-565748240