### PR TITLE
fix issue #1637 show error message when preview command fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ doc/tags
 vendor
 gopath
 *.zwc
+fzf

--- a/README.md
+++ b/README.md
@@ -484,7 +484,8 @@ See *KEY BINDINGS* section of the man page for details.
 ### Preview window
 
 When `--preview` option is set, fzf automatically starts an external process with
-the current line as the argument and shows the result in the split window.
+the current line as the argument and shows the result in the split window. Your
+`$SHELL` is used to execute the command with `$SHELL -c COMMAND`
 
 ```bash
 # {} is replaced to the single-quoted string of the focused line

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1572,7 +1572,10 @@ func (t *Terminal) Loop() {
 					var out bytes.Buffer
 					cmd.Stdout = &out
 					cmd.Stderr = &out
-					cmd.Start()
+					err := cmd.Start()
+					if err != nil {
+						out.Write([]byte(err.Error()))
+					}
 					finishChan := make(chan bool, 1)
 					updateChan := make(chan bool)
 					go func() {


### PR DESCRIPTION
fix #1637 

## STEPS
```
SHELL=kaka go run .  --preview 'cat {}'
```

## BEFORE:
[preview window is empty]

## AFTER
Preview window:
```
 exec: "kaka": executable file not found in $PATH
```

## Other Testing
test suite pass
```
 make test > /dev/null && echo $?                                   
0
```

### Test existing behavior with return code ~= 0
```
  138   go run .  --preview 'cat {} |grep fzf'
  149   go run .  --preview 'cat {} |grep -v fzf'
  152   go run .  --preview 'cat {} |grep -v fzf'
```