### PR TITLE
[zsh-completion] Fix quoting/splitting issues

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -55,7 +55,7 @@ __fzf_generic_path_completion() {
       leftover=${leftover/#\/}
       [ -z "$dir" ] && dir='.'
       [ "$dir" != "/" ] && dir="${dir/%\//}"
-      matches=$(eval "$compgen $(printf %q "$dir")" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" ${=fzf} ${=fzf_opts} -q "$leftover" | while read item; do
+      matches=$(eval "$compgen $(printf %q "$dir")" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" ${(Q)${(Z+n+)fzf}} ${(Q)${(Z+n+)fzf_opts}} -q "$leftover" | while read item; do
         echo -n "${(q)item}$suffix "
       done)
       matches=${matches% }
@@ -97,7 +97,7 @@ _fzf_complete() {
   fzf="$(__fzfcmd_complete)"
 
   _fzf_feed_fifo "$fifo"
-  matches=$(cat "$fifo" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" ${=fzf} ${=fzf_opts} -q "${(Q)prefix}" | $post | tr '\n' ' ')
+  matches=$(cat "$fifo" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_COMPLETION_OPTS" ${(Q)${(Z+n+)fzf}} ${(Q)${(Z+n+)fzf_opts}} -q "${(Q)prefix}" | $post | tr '\n' ' ')
   if [ -n "$matches" ]; then
     LBUFFER="$lbuf$matches"
   fi
@@ -168,7 +168,7 @@ fzf-completion() {
   # Kill completion (do not require trigger sequence)
   if [ $cmd = kill -a ${LBUFFER[-1]} = ' ' ]; then
     fzf="$(__fzfcmd_complete)"
-    matches=$(command ps -ef | sed 1d | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-50%} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS" ${=fzf} -m | awk '{print $2}' | tr '\n' ' ')
+    matches=$(command ps -ef | sed 1d | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-50%} --min-height 15 --reverse $FZF_DEFAULT_OPTS --preview 'echo {}' --preview-window down:3:wrap $FZF_COMPLETION_OPTS" ${(Q)${(Z+n+)fzf}} -m | awk '{print $2}' | tr '\n' ' ')
     if [ -n "$matches" ]; then
       LBUFFER="$LBUFFER$matches"
     fi
@@ -181,7 +181,7 @@ fzf-completion() {
     [ -z "${tokens[-1]}" ] && lbuf=$LBUFFER        || lbuf=${LBUFFER:0:-${#tokens[-1]}}
 
     if eval "type _fzf_complete_${cmd} > /dev/null"; then
-      eval "prefix=\"$prefix\" _fzf_complete_${cmd} \"$lbuf\""
+      prefix="$prefix" eval _fzf_complete_${cmd} ${(q)lbuf}
     elif [ ${d_cmds[(i)$cmd]} -le ${#d_cmds} ]; then
       _fzf_dir_completion "$prefix" "$lbuf"
     else


### PR DESCRIPTION
This PR fixes issues derived from quoting and word-splitting in Zsh completion.

## Quoting issue

Since `fzf-completion` calls `eval` without carefully quoting `$lbuf`, it broke in the following situation.

First, type:
```zsh
telnet -l "User that is quoted" **<TAB>
```
and hit <kbd>enter</kbd> to select `localhost` resulted in:
```zsh
telnet -l Userlocalhost
```
whereas the correct behaviour should be:
```zsh
telnet -l "User that is quoted" localhost
```

Simply quote the parameter using `${(q)lbuf}` solves this issue.

## Word-splitting issue

`_fzf_complete` splits its parameter (`$1`) in order to pass them to `fzf` in shell manner; however, the way it does this is not exactly the same way as Zsh. For instance, let's say we want to pass a parameter that contains spaces as follows:

```zsh
_fzf_complete '--tiebreak index --preview "echo {}"' < <(find . -type f)
```

`${=fzf_opts}` splits the `$fzf_opts` in this way:
- `--tiebreak`
- `index`
- `--preview`
- `"echo`
- `{}"`

but the expected way should look like:
- `--tiebreak`
- `index`
- `--preview`
- `echo {}`

Using [`Z:`*opts*`:`](http://zsh.sourceforge.net/Doc/Release/Expansion.html#index-substitution_002c-parameter_002c-flags) and `Q` together enables this shell parsing not word-splitting.

Thanks.