### PR TITLE
Adds initial snapcraft build.

### DIFF
--- a/snap/.gitignore
+++ b/snap/.gitignore
@@ -1,0 +1,3 @@
+*
+!snapcraft.yaml
+!.gitignore

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,15 +7,18 @@ description: |
   files, command history, processes, hostnames, bookmarks, git commits, etc.
 base: core18
 grade: stable
-confinement: classic
+confinement: strict
 
 parts:
   fzf:
     plugin: go
     go-importpath: github.com/junegunn/fzf
-    source: ..
+    source: .
     source-type: git
 
 apps:
   fzf:
     command: bin/fzf
+    plugs:
+      - home
+      - mount-observe

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,21 @@
+name: fzf-unofficial-18-04
+version: '0.20.0'
+summary: A general-purpose command-line fuzzy finder.
+description: |
+  An unofficial snap build of fzf for Ubuntu 18.04.  The fzf package provides an
+  interactive Unix filter for command-line that can be used with any list;
+  files, command history, processes, hostnames, bookmarks, git commits, etc.
+base: core18
+grade: stable
+confinement: classic
+
+parts:
+  fzf:
+    plugin: go
+    go-importpath: github.com/junegunn/fzf
+    source: ..
+    source-type: git
+
+apps:
+  fzf:
+    command: bin/fzf

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ parts:
   fzf:
     plugin: go
     go-importpath: github.com/junegunn/fzf
-    source: .
+    source: ..
     source-type: git
 
 apps:


### PR DESCRIPTION
This is a first pass at #1497, and will require some additional ideas/help (I am willing to provide).

The idea here is to allow targeting 18.04 for conservative farts like me. The snap model is also pretty neat.

Right now this is published under an intentionally `unofficial` name while I continue to sort out permissions and plugins locally. 

But there is another option available.  We can [request to publish this snap under classic confinement](https://forum.snapcraft.io/t/process-for-reviewing-classic-confinement-snaps/1460).  This is a much easier thing to do than piece together the necessary plugs one at a time and asking for auto-connect permissions but it isn't necessarily clear to me if `fzf` would qualify given the link above.  But right now `ripgrep` has `--classic` so I'm thinking it is achievable for `fzf` given a well-reasoned case.

Left to do (assuming there is no consensus around just going the `--classic` route):
- [ ] Identify additional plugs/permissions for `fzf` to work as intended
- [ ] have @junegunn reserve the `fzf` name on snapcraft
- [ ] publish edge release under official snapcraft name
- [ ] Request automatic connections to identified plugs (ideal user experience, imo no point to publication if users must create manual connections *after* installation).
- [ ] (probably) update CI to automatically publish snaps on release
- [ ] Publish first stable snap!

Thanks for an awesome tool @junegunn and contributors!