### PR TITLE
shell/bash/history-search: filter out duplicates

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -55,7 +55,7 @@ __fzf_history__() (
   local line
   shopt -u nocaseglob nocasematch
   line=$(
-    HISTTIMEFORMAT= builtin history |
+    HISTTIMEFORMAT= builtin history | awk '!visited[substr($0, index($0, $2))]++' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS --tac --sync -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m" $(__fzfcmd) |
     command grep '^ *[0-9]') &&
     if [[ $- =~ H ]]; then

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -55,7 +55,7 @@ __fzf_history__() (
   local line
   shopt -u nocaseglob nocasematch
   line=$(
-    HISTTIMEFORMAT= builtin history | awk '!visited[substr($0, index($0, $2))]++' |
+    HISTTIMEFORMAT= builtin history | awk 'match($0, /^[[:space:]*[[:digit:]]+[*]?[[:space:]]+/) && !visited[substr($0, RSTART+RLENGTH)]++' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS --tac --sync -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m" $(__fzfcmd) |
     command grep '^ *[0-9]') &&
     if [[ $- =~ H ]]; then


### PR DESCRIPTION
This solves #1309. #626 should be solvable in a similar fashion.

Credit for the cleverness in the awk associative array approach goes to
@iridakos's [remove-duplicate-lines-preserving-order-linux](https://iridakos.com/programming/2019/05/16/remove-duplicate-lines-preserving-order-linux).