### PR TITLE
Make pointer and selected sign customizable

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -231,10 +231,10 @@ A synonym for \fB--info=hidden\fB
 .BI "--prompt=" "STR"
 Input prompt (default: '> ')
 .TP
-.BI "--pointer-sign=" "STR"
+.BI "--pointer=" "STR"
 Pointer sign of cursor line (default: '>')
 .TP
-.BI "--selected-sign=" "STR"
+.BI "--marker=" "STR"
 Signs of selected ling in multi-mode  (default: '>')
 .TP
 .BI "--header=" "STR"

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -231,6 +231,12 @@ A synonym for \fB--info=hidden\fB
 .BI "--prompt=" "STR"
 Input prompt (default: '> ')
 .TP
+.BI "--pointer-sign=" "STR"
+Pointer sign of cursor line (default: '>')
+.TP
+.BI "--selected-sign=" "STR"
+Signs of selected ling in multi-mode  (default: '>')
+.TP
 .BI "--header=" "STR"
 The given string will be printed as the sticky header. The lines are displayed
 in the given order from top to bottom regardless of \fB--layout\fR option, and

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -232,10 +232,10 @@ A synonym for \fB--info=hidden\fB
 Input prompt (default: '> ')
 .TP
 .BI "--pointer=" "STR"
-Pointer sign of cursor line (default: '>')
+Pointer to the current line (default: '>')
 .TP
 .BI "--marker=" "STR"
-Signs of selected ling in multi-mode  (default: '>')
+Multi-select marker (default: '>')
 .TP
 .BI "--header=" "STR"
 The given string will be printed as the sticky header. The lines are displayed

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -72,6 +72,8 @@ _fzf_opts_completion() {
     --margin
     --inline-info
     --prompt
+    --pointer-sign
+    --selected-sign
     --header
     --header-lines
     --ansi

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -73,7 +73,7 @@ _fzf_opts_completion() {
     --inline-info
     --prompt
     --pointer
-    --selected
+    --marker
     --header
     --header-lines
     --ansi

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -72,8 +72,8 @@ _fzf_opts_completion() {
     --margin
     --inline-info
     --prompt
-    --pointer-sign
-    --selected-sign
+    --pointer
+    --selected
     --header
     --header-lines
     --ansi

--- a/src/options.go
+++ b/src/options.go
@@ -59,6 +59,8 @@ const usage = `usage: fzf [options]
     --margin=MARGIN       Screen margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
     --info=STYLE          Finder info style [default|inline|hidden]
     --prompt=STR          Input prompt (default: '> ')
+    --pointer-sign=STR    Cursor line pointer sign (default: '>')
+    --selected-sign=STR   Selected sign in multi-select mode (default: '>')
     --header=STR          String to print as header
     --header-lines=N      The first N lines of the input are treated as header
 
@@ -161,108 +163,112 @@ type previewOpts struct {
 
 // Options stores the values of command-line options
 type Options struct {
-	Fuzzy       bool
-	FuzzyAlgo   algo.Algo
-	Extended    bool
-	Phony       bool
-	Case        Case
-	Normalize   bool
-	Nth         []Range
-	WithNth     []Range
-	Delimiter   Delimiter
-	Sort        int
-	Tac         bool
-	Criteria    []criterion
-	Multi       int
-	Ansi        bool
-	Mouse       bool
-	Theme       *tui.ColorTheme
-	Black       bool
-	Bold        bool
-	Height      sizeSpec
-	MinHeight   int
-	Layout      layoutType
-	Cycle       bool
-	Hscroll     bool
-	HscrollOff  int
-	FileWord    bool
-	InfoStyle   infoStyle
-	JumpLabels  string
-	Prompt      string
-	Query       string
-	Select1     bool
-	Exit0       bool
-	Filter      *string
-	ToggleSort  bool
-	Expect      map[int]string
-	Keymap      map[int][]action
-	Preview     previewOpts
-	PrintQuery  bool
-	ReadZero    bool
-	Printer     func(string)
-	PrintSep    string
-	Sync        bool
-	History     *History
-	Header      []string
-	HeaderLines int
-	Margin      [4]sizeSpec
-	Bordered    bool
-	Unicode     bool
-	Tabstop     int
-	ClearOnExit bool
-	Version     bool
+	Fuzzy        bool
+	FuzzyAlgo    algo.Algo
+	Extended     bool
+	Phony        bool
+	Case         Case
+	Normalize    bool
+	Nth          []Range
+	WithNth      []Range
+	Delimiter    Delimiter
+	Sort         int
+	Tac          bool
+	Criteria     []criterion
+	Multi        int
+	Ansi         bool
+	Mouse        bool
+	Theme        *tui.ColorTheme
+	Black        bool
+	Bold         bool
+	Height       sizeSpec
+	MinHeight    int
+	Layout       layoutType
+	Cycle        bool
+	Hscroll      bool
+	HscrollOff   int
+	FileWord     bool
+	InfoStyle    infoStyle
+	JumpLabels   string
+	Prompt       string
+	PointerSign  string
+	SelectedSign string
+	Query        string
+	Select1      bool
+	Exit0        bool
+	Filter       *string
+	ToggleSort   bool
+	Expect       map[int]string
+	Keymap       map[int][]action
+	Preview      previewOpts
+	PrintQuery   bool
+	ReadZero     bool
+	Printer      func(string)
+	PrintSep     string
+	Sync         bool
+	History      *History
+	Header       []string
+	HeaderLines  int
+	Margin       [4]sizeSpec
+	Bordered     bool
+	Unicode      bool
+	Tabstop      int
+	ClearOnExit  bool
+	Version      bool
 }
 
 func defaultOptions() *Options {
 	return &Options{
-		Fuzzy:       true,
-		FuzzyAlgo:   algo.FuzzyMatchV2,
-		Extended:    true,
-		Phony:       false,
-		Case:        CaseSmart,
-		Normalize:   true,
-		Nth:         make([]Range, 0),
-		WithNth:     make([]Range, 0),
-		Delimiter:   Delimiter{},
-		Sort:        1000,
-		Tac:         false,
-		Criteria:    []criterion{byScore, byLength},
-		Multi:       0,
-		Ansi:        false,
-		Mouse:       true,
-		Theme:       tui.EmptyTheme(),
-		Black:       false,
-		Bold:        true,
-		MinHeight:   10,
-		Layout:      layoutDefault,
-		Cycle:       false,
-		Hscroll:     true,
-		HscrollOff:  10,
-		FileWord:    false,
-		InfoStyle:   infoDefault,
-		JumpLabels:  defaultJumpLabels,
-		Prompt:      "> ",
-		Query:       "",
-		Select1:     false,
-		Exit0:       false,
-		Filter:      nil,
-		ToggleSort:  false,
-		Expect:      make(map[int]string),
-		Keymap:      make(map[int][]action),
-		Preview:     previewOpts{"", posRight, sizeSpec{50, true}, false, false, true},
-		PrintQuery:  false,
-		ReadZero:    false,
-		Printer:     func(str string) { fmt.Println(str) },
-		PrintSep:    "\n",
-		Sync:        false,
-		History:     nil,
-		Header:      make([]string, 0),
-		HeaderLines: 0,
-		Margin:      defaultMargin(),
-		Unicode:     true,
-		Tabstop:     8,
-		ClearOnExit: true,
-		Version:     false}
+		Fuzzy:        true,
+		FuzzyAlgo:    algo.FuzzyMatchV2,
+		Extended:     true,
+		Phony:        false,
+		Case:         CaseSmart,
+		Normalize:    true,
+		Nth:          make([]Range, 0),
+		WithNth:      make([]Range, 0),
+		Delimiter:    Delimiter{},
+		Sort:         1000,
+		Tac:          false,
+		Criteria:     []criterion{byScore, byLength},
+		Multi:        0,
+		Ansi:         false,
+		Mouse:        true,
+		Theme:        tui.EmptyTheme(),
+		Black:        false,
+		Bold:         true,
+		MinHeight:    10,
+		Layout:       layoutDefault,
+		Cycle:        false,
+		Hscroll:      true,
+		HscrollOff:   10,
+		FileWord:     false,
+		InfoStyle:    infoDefault,
+		JumpLabels:   defaultJumpLabels,
+		Prompt:       "> ",
+		PointerSign:  ">",
+		SelectedSign: ">",
+		Query:        "",
+		Select1:      false,
+		Exit0:        false,
+		Filter:       nil,
+		ToggleSort:   false,
+		Expect:       make(map[int]string),
+		Keymap:       make(map[int][]action),
+		Preview:      previewOpts{"", posRight, sizeSpec{50, true}, false, false, true},
+		PrintQuery:   false,
+		ReadZero:     false,
+		Printer:      func(str string) { fmt.Println(str) },
+		PrintSep:     "\n",
+		Sync:         false,
+		History:      nil,
+		Header:       make([]string, 0),
+		HeaderLines:  0,
+		Margin:       defaultMargin(),
+		Unicode:      true,
+		Tabstop:      8,
+		ClearOnExit:  true,
+		Version:      false}
 }
 
 func help(code int) {
@@ -1189,6 +1195,10 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.PrintQuery = false
 		case "--prompt":
 			opts.Prompt = nextString(allArgs, &i, "prompt string required")
+		case "--pointer-sign":
+			opts.PointerSign = nextString(allArgs, &i, "pointer sign string required")
+		case "--selected-sign":
+			opts.SelectedSign = nextString(allArgs, &i, "selected sign string required")
 		case "--sync":
 			opts.Sync = true
 		case "--no-sync":
@@ -1255,6 +1265,10 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.Delimiter = delimiterRegexp(value)
 			} else if match, value := optString(arg, "--prompt="); match {
 				opts.Prompt = value
+			} else if match, value := optString(arg, "--pointer-sign="); match {
+				opts.PointerSign = value
+			} else if match, value := optString(arg, "--selected-sign="); match {
+				opts.SelectedSign = value
 			} else if match, value := optString(arg, "-n", "--nth="); match {
 				opts.Nth = splitNth(value)
 			} else if match, value := optString(arg, "--with-nth="); match {

--- a/src/options.go
+++ b/src/options.go
@@ -60,8 +60,8 @@ const usage = `usage: fzf [options]
     --margin=MARGIN       Screen margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
     --info=STYLE          Finder info style [default|inline|hidden]
     --prompt=STR          Input prompt (default: '> ')
-    --pointer=STR         Cursor line pointer sign (default: '>')
-    --marker=STR          Selected sign in multi-select mode (default: '>')
+    --pointer=STR         Pointer to the current line (default: '>')
+    --marker=STR          Multi-select marker (default: '>')
     --header=STR          String to print as header
     --header-lines=N      The first N lines of the input are treated as header
 

--- a/src/options.go
+++ b/src/options.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/junegunn/fzf/src/algo"
@@ -1369,12 +1370,11 @@ func parseOptions(opts *Options, allArgs []string) {
 }
 
 func validateSign(sign string, signOptName string) error {
-	if strings.Contains(sign, "\n") || strings.Contains(sign, "\t") {
-		return fmt.Errorf("In %v, \\n or \\t cannot be included", signOptName)
-	}
-
 	widthSum := 0
 	for _, r := range sign {
+		if !unicode.IsGraphic(r) {
+			return fmt.Errorf("invalid character in %v", signOptName)
+		}
 		widthSum += runewidth.RuneWidth(r)
 	}
 	if widthSum > 2 {

--- a/src/options.go
+++ b/src/options.go
@@ -59,8 +59,8 @@ const usage = `usage: fzf [options]
     --margin=MARGIN       Screen margin (TRBL / TB,RL / T,RL,B / T,R,B,L)
     --info=STYLE          Finder info style [default|inline|hidden]
     --prompt=STR          Input prompt (default: '> ')
-    --pointer-sign=STR    Cursor line pointer sign (default: '>')
-    --selected-sign=STR   Selected sign in multi-select mode (default: '>')
+    --pointer=STR         Cursor line pointer sign (default: '>')
+    --marker=STR          Selected sign in multi-select mode (default: '>')
     --header=STR          String to print as header
     --header-lines=N      The first N lines of the input are treated as header
 
@@ -163,112 +163,112 @@ type previewOpts struct {
 
 // Options stores the values of command-line options
 type Options struct {
-	Fuzzy        bool
-	FuzzyAlgo    algo.Algo
-	Extended     bool
-	Phony        bool
-	Case         Case
-	Normalize    bool
-	Nth          []Range
-	WithNth      []Range
-	Delimiter    Delimiter
-	Sort         int
-	Tac          bool
-	Criteria     []criterion
-	Multi        int
-	Ansi         bool
-	Mouse        bool
-	Theme        *tui.ColorTheme
-	Black        bool
-	Bold         bool
-	Height       sizeSpec
-	MinHeight    int
-	Layout       layoutType
-	Cycle        bool
-	Hscroll      bool
-	HscrollOff   int
-	FileWord     bool
-	InfoStyle    infoStyle
-	JumpLabels   string
-	Prompt       string
-	PointerSign  string
-	SelectedSign string
-	Query        string
-	Select1      bool
-	Exit0        bool
-	Filter       *string
-	ToggleSort   bool
-	Expect       map[int]string
-	Keymap       map[int][]action
-	Preview      previewOpts
-	PrintQuery   bool
-	ReadZero     bool
-	Printer      func(string)
-	PrintSep     string
-	Sync         bool
-	History      *History
-	Header       []string
-	HeaderLines  int
-	Margin       [4]sizeSpec
-	Bordered     bool
-	Unicode      bool
-	Tabstop      int
-	ClearOnExit  bool
-	Version      bool
+	Fuzzy       bool
+	FuzzyAlgo   algo.Algo
+	Extended    bool
+	Phony       bool
+	Case        Case
+	Normalize   bool
+	Nth         []Range
+	WithNth     []Range
+	Delimiter   Delimiter
+	Sort        int
+	Tac         bool
+	Criteria    []criterion
+	Multi       int
+	Ansi        bool
+	Mouse       bool
+	Theme       *tui.ColorTheme
+	Black       bool
+	Bold        bool
+	Height      sizeSpec
+	MinHeight   int
+	Layout      layoutType
+	Cycle       bool
+	Hscroll     bool
+	HscrollOff  int
+	FileWord    bool
+	InfoStyle   infoStyle
+	JumpLabels  string
+	Prompt      string
+	Pointer     string
+	Marker      string
+	Query       string
+	Select1     bool
+	Exit0       bool
+	Filter      *string
+	ToggleSort  bool
+	Expect      map[int]string
+	Keymap      map[int][]action
+	Preview     previewOpts
+	PrintQuery  bool
+	ReadZero    bool
+	Printer     func(string)
+	PrintSep    string
+	Sync        bool
+	History     *History
+	Header      []string
+	HeaderLines int
+	Margin      [4]sizeSpec
+	Bordered    bool
+	Unicode     bool
+	Tabstop     int
+	ClearOnExit bool
+	Version     bool
 }
 
 func defaultOptions() *Options {
 	return &Options{
-		Fuzzy:        true,
-		FuzzyAlgo:    algo.FuzzyMatchV2,
-		Extended:     true,
-		Phony:        false,
-		Case:         CaseSmart,
-		Normalize:    true,
-		Nth:          make([]Range, 0),
-		WithNth:      make([]Range, 0),
-		Delimiter:    Delimiter{},
-		Sort:         1000,
-		Tac:          false,
-		Criteria:     []criterion{byScore, byLength},
-		Multi:        0,
-		Ansi:         false,
-		Mouse:        true,
-		Theme:        tui.EmptyTheme(),
-		Black:        false,
-		Bold:         true,
-		MinHeight:    10,
-		Layout:       layoutDefault,
-		Cycle:        false,
-		Hscroll:      true,
-		HscrollOff:   10,
-		FileWord:     false,
-		InfoStyle:    infoDefault,
-		JumpLabels:   defaultJumpLabels,
-		Prompt:       "> ",
-		PointerSign:  ">",
-		SelectedSign: ">",
-		Query:        "",
-		Select1:      false,
-		Exit0:        false,
-		Filter:       nil,
-		ToggleSort:   false,
-		Expect:       make(map[int]string),
-		Keymap:       make(map[int][]action),
-		Preview:      previewOpts{"", posRight, sizeSpec{50, true}, false, false, true},
-		PrintQuery:   false,
-		ReadZero:     false,
-		Printer:      func(str string) { fmt.Println(str) },
-		PrintSep:     "\n",
-		Sync:         false,
-		History:      nil,
-		Header:       make([]string, 0),
-		HeaderLines:  0,
-		Margin:       defaultMargin(),
-		Unicode:      true,
-		Tabstop:      8,
-		ClearOnExit:  true,
-		Version:      false}
+		Fuzzy:       true,
+		FuzzyAlgo:   algo.FuzzyMatchV2,
+		Extended:    true,
+		Phony:       false,
+		Case:        CaseSmart,
+		Normalize:   true,
+		Nth:         make([]Range, 0),
+		WithNth:     make([]Range, 0),
+		Delimiter:   Delimiter{},
+		Sort:        1000,
+		Tac:         false,
+		Criteria:    []criterion{byScore, byLength},
+		Multi:       0,
+		Ansi:        false,
+		Mouse:       true,
+		Theme:       tui.EmptyTheme(),
+		Black:       false,
+		Bold:        true,
+		MinHeight:   10,
+		Layout:      layoutDefault,
+		Cycle:       false,
+		Hscroll:     true,
+		HscrollOff:  10,
+		FileWord:    false,
+		InfoStyle:   infoDefault,
+		JumpLabels:  defaultJumpLabels,
+		Prompt:      "> ",
+		Pointer:     ">",
+		Marker:      ">",
+		Query:       "",
+		Select1:     false,
+		Exit0:       false,
+		Filter:      nil,
+		ToggleSort:  false,
+		Expect:      make(map[int]string),
+		Keymap:      make(map[int][]action),
+		Preview:     previewOpts{"", posRight, sizeSpec{50, true}, false, false, true},
+		PrintQuery:  false,
+		ReadZero:    false,
+		Printer:     func(str string) { fmt.Println(str) },
+		PrintSep:    "\n",
+		Sync:        false,
+		History:     nil,
+		Header:      make([]string, 0),
+		HeaderLines: 0,
+		Margin:      defaultMargin(),
+		Unicode:     true,
+		Tabstop:     8,
+		ClearOnExit: true,
+		Version:     false}
 }
 
 func help(code int) {
@@ -1195,10 +1195,10 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.PrintQuery = false
 		case "--prompt":
 			opts.Prompt = nextString(allArgs, &i, "prompt string required")
-		case "--pointer-sign":
-			opts.PointerSign = nextString(allArgs, &i, "pointer sign string required")
-		case "--selected-sign":
-			opts.SelectedSign = nextString(allArgs, &i, "selected sign string required")
+		case "--pointer":
+			opts.Pointer = nextString(allArgs, &i, "pointer sign string required")
+		case "--marker":
+			opts.Marker = nextString(allArgs, &i, "selected sign string required")
 		case "--sync":
 			opts.Sync = true
 		case "--no-sync":
@@ -1265,10 +1265,10 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.Delimiter = delimiterRegexp(value)
 			} else if match, value := optString(arg, "--prompt="); match {
 				opts.Prompt = value
-			} else if match, value := optString(arg, "--pointer-sign="); match {
-				opts.PointerSign = value
-			} else if match, value := optString(arg, "--selected-sign="); match {
-				opts.SelectedSign = value
+			} else if match, value := optString(arg, "--pointer="); match {
+				opts.Pointer = value
+			} else if match, value := optString(arg, "--marker="); match {
+				opts.Marker = value
 			} else if match, value := optString(arg, "-n", "--nth="); match {
 				opts.Nth = splitNth(value)
 			} else if match, value := optString(arg, "--with-nth="); match {

--- a/src/options.go
+++ b/src/options.go
@@ -1376,9 +1376,9 @@ func validateSign(sign string, signOptName string) error {
 			return fmt.Errorf("invalid character in %v", signOptName)
 		}
 		widthSum += runewidth.RuneWidth(r)
-	}
-	if widthSum > 2 {
-		return fmt.Errorf("%v display width should be up to 2", signOptName)
+		if widthSum > 2 {
+			return fmt.Errorf("%v display width should be up to 2", signOptName)
+		}
 	}
 	return nil
 }

--- a/src/options.go
+++ b/src/options.go
@@ -1370,6 +1370,9 @@ func parseOptions(opts *Options, allArgs []string) {
 }
 
 func validateSign(sign string, signOptName string) error {
+	if sign == "" {
+		return fmt.Errorf("%v cannot be empty", signOptName)
+	}
 	widthSum := 0
 	for _, r := range sign {
 		if !unicode.IsGraphic(r) {

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -431,6 +431,7 @@ func TestValidateSign(t *testing.T) {
 		{"> ", true},
 		{"아", true},
 		{"😀", true},
+		{"", false},
 		{">>>", false},
 		{"\n", false},
 		{"\t", false},
@@ -439,11 +440,11 @@ func TestValidateSign(t *testing.T) {
 	for _, testCase := range testCases {
 		err := validateSign(testCase.inputSign, "")
 		if testCase.isValid && err != nil {
-			t.Errorf("Input sign %s caused error", testCase.inputSign)
+			t.Errorf("Input sign `%s` caused error", testCase.inputSign)
 		}
 
 		if !testCase.isValid && err == nil {
-			t.Errorf("Input sign %s did not cause error", testCase.inputSign)
+			t.Errorf("Input sign `%s` did not cause error", testCase.inputSign)
 		}
 	}
 }

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -422,3 +422,28 @@ func TestAdditiveExpect(t *testing.T) {
 		t.Error(opts.Expect)
 	}
 }
+
+func TestValidateSign(t *testing.T) {
+	testCases := []struct {
+		inputSign string
+		isValid   bool
+	}{
+		{"> ", true},
+		{"아", true},
+		{"😀", true},
+		{">>>", false},
+		{"\n", false},
+		{"\t", false},
+	}
+
+	for _, testCase := range testCases {
+		err := validateSign(testCase.inputSign, "")
+		if testCase.isValid && err != nil {
+			t.Errorf("Input sign %s caused error", testCase.inputSign)
+		}
+
+		if !testCase.isValid && err == nil {
+			t.Errorf("Input sign %s did not cause error", testCase.inputSign)
+		}
+	}
+}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -869,7 +869,7 @@ func (t *Terminal) printItem(result Result, line int, i int, current bool) {
 		if i < len(t.jumpLabels) {
 			// Striped
 			current = i%2 == 0
-			label = t.jumpLabels[i : i+1]
+			label = t.jumpLabels[i:i+1] + strings.Repeat(" ", t.pointerLen-1)
 		}
 	} else if current {
 		label = t.pointer

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -59,78 +59,78 @@ var emptyLine = itemLine{}
 
 // Terminal represents terminal input/output
 type Terminal struct {
-	initDelay         time.Duration
-	infoStyle         infoStyle
-	spinner           []string
-	prompt            string
-	promptLen         int
-	pointerSign       string
-	pointerSignLen    int
-	pointerSignEmpty  string
-	selectedSign      string
-	selectedSignLen   int
-	selectedSignEmpty string
-	queryLen          [2]int
-	layout            layoutType
-	fullscreen        bool
-	hscroll           bool
-	hscrollOff        int
-	wordRubout        string
-	wordNext          string
-	cx                int
-	cy                int
-	offset            int
-	xoffset           int
-	yanked            []rune
-	input             []rune
-	multi             int
-	sort              bool
-	toggleSort        bool
-	delimiter         Delimiter
-	expect            map[int]string
-	keymap            map[int][]action
-	pressed           string
-	printQuery        bool
-	history           *History
-	cycle             bool
-	header            []string
-	header0           []string
-	ansi              bool
-	tabstop           int
-	margin            [4]sizeSpec
-	strong            tui.Attr
-	unicode           bool
-	bordered          bool
-	cleanExit         bool
-	border            tui.Window
-	window            tui.Window
-	pborder           tui.Window
-	pwindow           tui.Window
-	count             int
-	progress          int
-	reading           bool
-	failed            *string
-	jumping           jumpMode
-	jumpLabels        string
-	printer           func(string)
-	printsep          string
-	merger            *Merger
-	selected          map[int32]selectedItem
-	version           int64
-	reqBox            *util.EventBox
-	preview           previewOpts
-	previewer         previewer
-	previewBox        *util.EventBox
-	eventBox          *util.EventBox
-	mutex             sync.Mutex
-	initFunc          func()
-	prevLines         []itemLine
-	suppress          bool
-	startChan         chan bool
-	killChan          chan int
-	slab              *util.Slab
-	theme             *tui.ColorTheme
-	tui               tui.Renderer
+	initDelay    time.Duration
+	infoStyle    infoStyle
+	spinner      []string
+	prompt       string
+	promptLen    int
+	pointer      string
+	pointerLen   int
+	pointerEmpty string
+	marker       string
+	markerLen    int
+	markerEmpty  string
+	queryLen     [2]int
+	layout       layoutType
+	fullscreen   bool
+	hscroll      bool
+	hscrollOff   int
+	wordRubout   string
+	wordNext     string
+	cx           int
+	cy           int
+	offset       int
+	xoffset      int
+	yanked       []rune
+	input        []rune
+	multi        int
+	sort         bool
+	toggleSort   bool
+	delimiter    Delimiter
+	expect       map[int]string
+	keymap       map[int][]action
+	pressed      string
+	printQuery   bool
+	history      *History
+	cycle        bool
+	header       []string
+	header0      []string
+	ansi         bool
+	tabstop      int
+	margin       [4]sizeSpec
+	strong       tui.Attr
+	unicode      bool
+	bordered     bool
+	cleanExit    bool
+	border       tui.Window
+	window       tui.Window
+	pborder      tui.Window
+	pwindow      tui.Window
+	count        int
+	progress     int
+	reading      bool
+	failed       *string
+	jumping      jumpMode
+	jumpLabels   string
+	printer      func(string)
+	printsep     string
+	merger       *Merger
+	selected     map[int32]selectedItem
+	version      int64
+	reqBox       *util.EventBox
+	preview      previewOpts
+	previewer    previewer
+	previewBox   *util.EventBox
+	eventBox     *util.EventBox
+	mutex        sync.Mutex
+	initFunc     func()
+	prevLines    []itemLine
+	suppress     bool
+	startChan    chan bool
+	killChan     chan int
+	slab         *util.Slab
+	theme        *tui.ColorTheme
+	tui          tui.Renderer
 }
 
 type selectedItem struct {
@@ -447,11 +447,11 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		tui:        renderer,
 		initFunc:   func() { renderer.Init() }}
 	t.prompt, t.promptLen = t.processTabs([]rune(opts.Prompt), 0)
-	t.pointerSign, t.pointerSignLen = t.processTabs([]rune(opts.PointerSign), 0)
-	t.selectedSign, t.selectedSignLen = t.processTabs([]rune(opts.SelectedSign), 0)
+	t.pointer, t.pointerLen = t.processTabs([]rune(opts.Pointer), 0)
+	t.marker, t.markerLen = t.processTabs([]rune(opts.Marker), 0)
 	// pre-calculated empty pointer and selected signs
-	t.pointerSignEmpty = strings.Repeat(" ", t.pointerSignLen)
-	t.selectedSignEmpty = strings.Repeat(" ", t.selectedSignLen)
+	t.pointerEmpty = strings.Repeat(" ", t.pointerLen)
+	t.markerEmpty = strings.Repeat(" ", t.markerLen)
 
 	return &t
 }
@@ -864,7 +864,7 @@ func (t *Terminal) printList() {
 func (t *Terminal) printItem(result Result, line int, i int, current bool) {
 	item := result.item
 	_, selected := t.selected[item.Index()]
-	label := t.pointerSignEmpty
+	label := t.pointerEmpty
 	if t.jumping != jumpDisabled {
 		if i < len(t.jumpLabels) {
 			// Striped
@@ -872,8 +872,7 @@ func (t *Terminal) printItem(result Result, line int, i int, current bool) {
 			label = t.jumpLabels[i : i+1]
 		}
 	} else if current {
-		label = ">"
-		label = t.pointerSign
+		label = t.pointer
 	}
 
 	// Avoid unnecessary redraw
@@ -892,17 +891,17 @@ func (t *Terminal) printItem(result Result, line int, i int, current bool) {
 	if current {
 		t.window.CPrint(tui.ColCurrentCursor, t.strong, label)
 		if selected {
-			t.window.CPrint(tui.ColCurrentSelected, t.strong, t.selectedSign)
+			t.window.CPrint(tui.ColCurrentSelected, t.strong, t.marker)
 		} else {
-			t.window.CPrint(tui.ColCurrentSelected, t.strong, t.selectedSignEmpty)
+			t.window.CPrint(tui.ColCurrentSelected, t.strong, t.markerEmpty)
 		}
 		newLine.width = t.printHighlighted(result, t.strong, tui.ColCurrent, tui.ColCurrentMatch, true, true)
 	} else {
 		t.window.CPrint(tui.ColCursor, t.strong, label)
 		if selected {
-			t.window.CPrint(tui.ColSelected, t.strong, t.selectedSign)
+			t.window.CPrint(tui.ColSelected, t.strong, t.marker)
 		} else {
-			t.window.Print(t.selectedSignEmpty)
+			t.window.Print(t.markerEmpty)
 		}
 		newLine.width = t.printHighlighted(result, 0, tui.ColNormal, tui.ColMatch, false, true)
 	}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -449,7 +449,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 	t.prompt, t.promptLen = t.processTabs([]rune(opts.Prompt), 0)
 	t.pointer, t.pointerLen = t.processTabs([]rune(opts.Pointer), 0)
 	t.marker, t.markerLen = t.processTabs([]rune(opts.Marker), 0)
-	// pre-calculated empty pointer and selected signs
+	// Pre-calculated empty pointer and marker signs
 	t.pointerEmpty = strings.Repeat(" ", t.pointerLen)
 	t.markerEmpty = strings.Repeat(" ", t.markerLen)
 

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -1407,6 +1407,39 @@ class TestGoFZF < TestBase
     assert_equal '3', readonce.chomp
   end
 
+  def test_pointer
+    pointer = '>>'
+    tmux.send_keys "seq 10 | #{fzf "--pointer '#{pointer}'"}", :Enter
+    tmux.until { |lines| lines[-2] == '  10/10' }
+    lines = tmux.capture
+    # Assert that specified pointer is displayed
+    assert_equal "#{pointer} 1", lines[-3]
+  end
+
+  def test_pointer_with_jump
+    pointer = '>>'
+    tmux.send_keys "seq 10 | #{fzf "--multi --jump-labels 12345 --bind 'ctrl-j:jump' --pointer '#{pointer}'"}", :Enter
+    tmux.until { |lines| lines[-2] == '  10/10' }
+    tmux.send_keys 'C-j'
+    # Correctly padded jump label should appear
+    tmux.until { |lines| lines[-7] == '5  5' }
+    tmux.until { |lines| lines[-8] == '   6' }
+    tmux.send_keys '5'
+    lines = tmux.capture
+    # Assert that specified pointer is displayed
+    assert_equal "#{pointer} 5", lines[-7]
+  end
+
+  def test_marker
+    marker = '>>'
+    tmux.send_keys "seq 10 | #{fzf "--multi --marker '#{marker}'"}", :Enter
+    tmux.until { |lines| lines[-2] == '  10/10' }
+    tmux.send_keys :BTab
+    lines = tmux.capture
+    # Assert that specified marker is displayed
+    assert_equal " #{marker}1", lines[-3]
+  end
+
   def test_preview
     tmux.send_keys %(seq 1000 | sed s/^2$// | #{FZF} -m --preview 'sleep 0.2; echo {{}-{+}}' --bind ?:toggle-preview), :Enter
     tmux.until { |lines| lines[1].include?(' {1-1}') }


### PR DESCRIPTION
Thank you for developing and maintaining this state-of-the-art CLI.

I opened this PR because as well as prompt, pointer sign and selected signs (in multi-select mode) should also be customizable with command line arguments.

![fzf_demo](https://user-images.githubusercontent.com/6816040/73324272-c91a7e00-428d-11ea-9b20-d5c8ab327b92.gif)

Such feature, for example, would be useful in a case, where UI-provider really want users to know "WHAT" will happen ( `multi-delete` :fire: or `multi-star` ⭐️ ) with emoji.