### PR TITLE
terminal.go: fix double-lock by adding missing unlock in loop

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2093,6 +2093,7 @@ func (t *Terminal) Loop() {
 				}
 			}
 			if !doActions(actions, mapkey) {
+				t.mutex.Unlock()
 				continue
 			}
 			t.truncateQuery()
@@ -2100,6 +2101,7 @@ func (t *Terminal) Loop() {
 			changed = changed || queryChanged
 			if onChanges, prs := t.keymap[tui.Change]; queryChanged && prs {
 				if !doActions(onChanges, tui.Change) {
+					t.mutex.Unlock()
 					continue
 				}
 			}


### PR DESCRIPTION
t.mutex.Lock() is on Line 1710 in a loop.
The loop starts from Line 1703 to 2140. 
When the loop continue without unlock on Line 2096 and 2103,
double lock happens.