### PR TITLE
Fix bug of validation of jump-labels

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -1303,6 +1303,7 @@ func parseOptions(opts *Options, allArgs []string) {
 				opts.HscrollOff = atoi(value)
 			} else if match, value := optString(arg, "--jump-labels="); match {
 				opts.JumpLabels = value
+				validateJumpLabels = true
 			} else {
 				errorExit("unknown option: " + arg)
 			}


### PR DESCRIPTION
# tl;dr

```zsh
fzf --jump-labels="아" --bind='ctrl-s:jump'
```

will correctly warn the non-ascii character with with message `non-ascii jump labels are not allowed`

---

When I was working on https://github.com/junegunn/fzf/pull/1844, a minor bug was found, so I opened this PR separately, cause the PR https://github.com/junegunn/fzf/pull/1844 is `feature` PR.

If this bug-fix should be included in https://github.com/junegunn/fzf/pull/1844, please feel free to close it 👍 