### PR TITLE
[bash] Put C-t items at point in vi mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
 language: go
-dist: xenial
+env: GO111MODULE=on
+os:
+  - linux
+  - osx
+dist: bionic # For fish >= 2.3.0 string builtin
 addons:
   apt:
-    sources:
-      - sourceline: "ppa:pi-rho/dev"
-      - sourceline: "ppa:fish-shell/release-2"
     packages:
-    - tmux
-    - zsh
-    - fish
-
-env:
-  - GO111MODULE=on
-
-jobs:
-  include:
-    - stage: unittest
-      go: "1.13.x"
-      script: make && make test
-
-    - stage: cli
-      go: "1.13.x"
-      rvm: "2.5"
-      script: |
-        make install && ./install --all && tmux new "ruby test/test_go.rb > out && touch ok" && cat out && [ -e ok ]
-
+      - fish
+      - zsh
+  homebrew:
+    packages:
+      - fish
+      - tmux
+    update: true
+script:
+  - make test
+  # LC_ALL=C to avoid escape codes in
+  # printf %q $'\355\205\214\354\212\244\355\212\270' on macOS. Bash on
+  # macOS is built without HANDLE_MULTIBYTE?
+  - make install && ./install --all && LC_ALL=C tmux new-session -d && ruby test/test_go.rb

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -84,36 +84,20 @@ bind -m emacs-standard '"\C-r": " \C-e\C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\er\
 # ALT-C - cd into the selected directory
 bind -m emacs-standard '"\ec": " \C-e\C-u`__fzf_cd__`\e\C-e\er\C-m"'
 
-# We'd usually use "\e" to enter vi-movement-mode so we can do our magic,
-# but this incurs a very noticeable delay of a half second or so,
-# because many other commands start with "\e".
-# Instead, we bind an unused key, "\C-x\C-a",
-# to also enter vi-movement-mode,
-# and then use that thereafter.
-# (We imagine that "\C-x\C-a" is relatively unlikely to be in use.)
-bind -m vi-insert '"\C-x\C-a": vi-movement-mode'
-
-bind -m vi-insert '"\C-x\C-e": shell-expand-line'
-bind -m vi-insert '"\C-x\C-r": redraw-current-line'
-bind -m vi-insert '"\C-x^": history-expand-line'
+bind -m vi-command '"\C-z": emacs-editing-mode'
+bind -m vi-insert '"\C-z": emacs-editing-mode'
+bind -m emacs-standard '"\C-z": vi-editing-mode'
 
 # CTRL-T - Paste the selected file path into the command line
-# - FIXME: Selected items are attached to the end regardless of cursor position
-if [ $BASH_VERSINFO -gt 3 ]; then
-  bind -m vi-insert -x '"\C-t": "fzf-file-widget"'
-elif __fzf_use_tmux__; then
-  bind -m vi-insert '"\C-t": "\C-x\C-a$a \C-x\C-addi`__fzf_select_tmux__`\C-x\C-e\C-x\C-a0P$xa"'
-else
-  bind -m vi-insert '"\C-t": "\C-x\C-a$a \C-x\C-addi`__fzf_select__`\C-x\C-e\C-x\C-a0Px$a \C-x\C-r\C-x\C-axa "'
-fi
-bind -m vi-command '"\C-t": "i\C-t"'
+bind -m vi-command '"\C-t": "\C-z\C-t\C-z"'
+bind -m vi-insert '"\C-t": "\C-z\C-t\C-z"'
 
 # CTRL-R - Paste the selected command from history into the command line
-bind -m vi-insert '"\C-r": "\C-x\C-addi`__fzf_history__`\C-x\C-e\C-x\C-r\C-x^\C-x\C-a$a"'
-bind -m vi-command '"\C-r": "i\C-r"'
+bind -m vi-command '"\C-r": "\C-z\C-r\C-z"'
+bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
 
 # ALT-C - cd into the selected directory
-bind -m vi-insert '"\ec": "\C-x\C-addi`__fzf_cd__`\C-x\C-e\C-x\C-r\C-m"'
-bind -m vi-command '"\ec": "ddi`__fzf_cd__`\C-x\C-e\C-x\C-r\C-m"'
+bind -m vi-command '"\ec": "\C-z\ec\C-z"'
+bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
 
 fi

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -115,7 +115,7 @@ class Tmux
   end
 
   def paste(str)
-    `tmux setb '#{str.gsub("'", "'\\''")}' \\; pasteb -t #{win} \\; send-keys -t #{win} Enter`
+    system('tmux', 'setb', str, ';', 'pasteb', '-t', win, ';', 'send-keys', '-t', win, 'Enter')
   end
 
   def capture(pane = 0)
@@ -491,7 +491,7 @@ class TestGoFZF < TestBase
   end
 
   def test_query_unicode
-    tmux.paste "(echo abc; echo 가나다) | #{fzf :query, '가다'}"
+    tmux.paste "(echo abc; echo $'\\352\\260\\200\\353\\202\\230\\353\\213\\244') | #{fzf :query, "$'\\352\\260\\200\\353\\213\\244'"}"
     tmux.until { |lines| lines[-2].include? '1/2' }
     tmux.send_keys :Enter
     assert_equal ['가나다'], readonce.split($INPUT_RECORD_SEPARATOR)
@@ -1741,7 +1741,7 @@ module TestShell
     tmux.until { |lines| lines.select_count == 2 }
 
     tmux.send_keys :Enter
-    tmux.until { |lines| lines.any_include?(/echo.*fzf-unicode.*1.*fzf-unicode.*2/) }
+    tmux.until { |lines| lines.join.match(/echo.*fzf-unicode.*1.*fzf-unicode.*2/) }
     tmux.send_keys :Enter
     tmux.until { |lines| lines.any_include?(/^fzf-unicode.*1.*fzf-unicode.*2/) }
   end
@@ -1958,7 +1958,7 @@ module CompletionTest
 
   def test_file_completion_unicode
     FileUtils.mkdir_p '/tmp/fzf-test'
-    tmux.paste 'cd /tmp/fzf-test; echo -n test3 > "fzf-unicode 테스트1"; echo -n test4 > "fzf-unicode 테스트2"'
+    tmux.paste "cd /tmp/fzf-test; echo -n test3 > $'fzf-unicode \\355\\205\\214\\354\\212\\244\\355\\212\\2701'; echo -n test4 > $'fzf-unicode \\355\\205\\214\\354\\212\\244\\355\\212\\2702'"
     tmux.prepare
     tmux.send_keys 'cat fzf-unicode**', :Tab
     tmux.until { |lines| lines.match_count == 2 }


### PR DESCRIPTION
Be consistent with emacs mode and put the items at the point vs. the end
of the command line.