### PR TITLE
[bash] Restore insertion point pre Bash 4

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -73,16 +73,16 @@ bind -m emacs-standard '"\e^": history-expand-line'
 if [ $BASH_VERSINFO -gt 3 ]; then
   bind -m emacs-standard -x '"\C-t": "fzf-file-widget"'
 elif __fzf_use_tmux__; then
-  bind -m emacs-standard '"\C-t": " \C-u \C-a\C-k`__fzf_select_tmux__`\e\C-e\C-y\C-a\C-d\C-y\ey\C-h"'
+  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select_tmux__`\e\C-e\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-d"'
 else
-  bind -m emacs-standard '"\C-t": " \C-u \C-a\C-k`__fzf_select__`\e\C-e\C-y\C-a\C-y\ey\C-h\C-e\er \C-h"'
+  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\er\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-d"'
 fi
 
 # CTRL-R - Paste the selected command from history into the command line
-bind -m emacs-standard '"\C-r": " \C-e\C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\er\e^"'
+bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\er\e^"'
 
 # ALT-C - cd into the selected directory
-bind -m emacs-standard '"\ec": " \C-e\C-u`__fzf_cd__`\e\C-e\er\C-m"'
+bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
 
 bind -m vi-command '"\C-z": emacs-editing-mode'
 bind -m vi-insert '"\C-z": emacs-editing-mode'

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -73,9 +73,9 @@ bind -m emacs-standard '"\e^": history-expand-line'
 if [ $BASH_VERSINFO -gt 3 ]; then
   bind -m emacs-standard -x '"\C-t": "fzf-file-widget"'
 elif __fzf_use_tmux__; then
-  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select_tmux__`\e\C-e\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-d"'
+  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select_tmux__`\e\C-e\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
 else
-  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\er\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-d"'
+  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\er\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
 fi
 
 # CTRL-R - Paste the selected command from history into the command line


### PR DESCRIPTION
Make <kbd>C-t</kbd> more consistent pre and post Bash 4. It already kills the
command line separately before and after the insertion point. Add
[`set-mark`](https://www.gnu.org/software/bash/manual/bash#index-set_002dmark-_0028C_002d_0040_0029) and [`exchange-point-and-mark`](https://www.gnu.org/software/bash/manual/bash#index-exchange_002dpoint_002dand_002dmark-_0028C_002dx-C_002dx_0029) to restore the insertion point
after yanking back and apply the same behavior to <kbd>M-c</kbd>.