### PR TITLE
[bash] Start C-r search with current command line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ script:
   # LC_ALL=C to avoid escape codes in
   # printf %q $'\355\205\214\354\212\244\355\212\270' on macOS. Bash on
   # macOS is built without HANDLE_MULTIBYTE?
-  - make install && ./install --all && LC_ALL=C tmux new-session -d && ruby test/test_go.rb
+  - make install && ./install --all && LC_ALL=C tmux new-session -d && ruby test/test_go.rb --verbose

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -51,47 +51,56 @@ __fzf_cd__() {
   dir=$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m) && printf 'cd %q' "$dir"
 }
 
-__fzf_history__() (
-  local line
-  line=$(
+__fzf_history__() {
+  local output
+  output=$(
     builtin fc -lnr -2147483648 |
-      perl -p -l0 -e 'BEGIN { getc; $/ = "\n\t" } s/^[ *]//; $_ = '"$1"' - $. . "\t$_"' |
-      FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd)
-  )
-  echo "${line#*$'\t'}"
-)
+      last_hist=$(HISTTIMEFORMAT='' builtin history 1) perl -p -l0 -e 'BEGIN { getc; $/ = "\n\t"; $HISTCMD = $ENV{last_hist} + 1 } s/^[ *]//; $_ = $HISTCMD - $. . "\t$_"' |
+      FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --query $(printf %q "$READLINE_LINE") --read0" $(__fzfcmd)
+  ) || return
+  READLINE_LINE=${output#*$'\t'}
+  if [ -z "$READLINE_POINT" ]; then
+    echo "$READLINE_LINE"
+  else
+    READLINE_POINT=0x7fffffff
+  fi
+}
 
 # Required to refresh the prompt after fzf
 bind -m emacs-standard '"\er": redraw-current-line'
-
-# CTRL-T - Paste the selected file path into the command line
-if [ $BASH_VERSINFO -gt 3 ]; then
-  bind -m emacs-standard -x '"\C-t": "fzf-file-widget"'
-elif __fzf_use_tmux__; then
-  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select_tmux__`\e\C-e\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
-else
-  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\er\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
-fi
-
-# CTRL-R - Paste the selected command from history into the command line
-bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u__fzf_history__ $HISTCMD\e\C-e`"\C-a"`\C-e\e\C-e\er"'
-
-# ALT-C - cd into the selected directory
-bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
 
 bind -m vi-command '"\C-z": emacs-editing-mode'
 bind -m vi-insert '"\C-z": emacs-editing-mode'
 bind -m emacs-standard '"\C-z": vi-editing-mode'
 
-# CTRL-T - Paste the selected file path into the command line
-bind -m vi-command '"\C-t": "\C-z\C-t\C-z"'
-bind -m vi-insert '"\C-t": "\C-z\C-t\C-z"'
+if [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  # CTRL-T - Paste the selected file path into the command line
+  if __fzf_use_tmux__; then
+    bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select_tmux__`\e\C-e\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
+  else
+    bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\er\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
+  fi
+  bind -m vi-command '"\C-t": "\C-z\C-t\C-z"'
+  bind -m vi-insert '"\C-t": "\C-z\C-t\C-z"'
 
-# CTRL-R - Paste the selected command from history into the command line
-bind -m vi-command '"\C-r": "\C-z\C-r\C-z"'
-bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
+  # CTRL-R - Paste the selected command from history into the command line
+  bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u"$(__fzf_history__)"\e\C-e\er"'
+  bind -m vi-command '"\C-r": "\C-z\C-r\C-z"'
+  bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
+else
+  # CTRL-T - Paste the selected file path into the command line
+  bind -m emacs-standard -x '"\C-t": fzf-file-widget'
+  bind -m vi-command -x '"\C-t": fzf-file-widget'
+  bind -m vi-insert -x '"\C-t": fzf-file-widget'
+
+  # CTRL-R - Paste the selected command from history into the command line
+  bind -m emacs-standard -x '"\C-r": __fzf_history__'
+  bind -m vi-command -x '"\C-r": __fzf_history__'
+  bind -m vi-insert -x '"\C-r": __fzf_history__'
+fi
 
 # ALT-C - cd into the selected directory
+bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
 bind -m vi-command '"\ec": "\C-z\ec\C-z"'
 bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
 


### PR DESCRIPTION
Retain the current command line when aborting <kbd>C-r</kbd>. Add `--query
"$READLINE_LINE"` and fall back to the current behavior pre Bash 4.

Fixes #432
Fixes #731