### PR TITLE
Added auto select only filtered option

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -152,6 +152,9 @@ actions are affected:
 .TP
 .BI "--jump-labels=" "CHARS"
 Label characters for \fBjump\fR and \fBjump-accept\fR
+.TP
+.B "--select-only"
+Automatically select the only filtered match
 .SS Layout
 .TP
 .BI "--height=" "HEIGHT[%]"

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -93,6 +93,7 @@ _fzf_opts_completion() {
     --preview-window
     -q --query
     -1 --select-1
+    --select-only
     -0 --exit-0
     -f --filter
     --print-query

--- a/src/options.go
+++ b/src/options.go
@@ -50,6 +50,7 @@ const usage = `usage: fzf [options]
                           highlighted substring (default: 10)
     --filepath-word       Make word-wise movements respect path separators
     --jump-labels=CHARS   Label characters for jump and jump-accept
+    --select-only         Automatically select the only filtered match
 
   Layout
     --height=HEIGHT[%]    Display fzf window below the cursor with the given
@@ -197,6 +198,7 @@ type Options struct {
 	Marker      string
 	Query       string
 	Select1     bool
+	SelectOnly  bool
 	Exit0       bool
 	Filter      *string
 	ToggleSort  bool
@@ -252,6 +254,7 @@ func defaultOptions() *Options {
 		Marker:      ">",
 		Query:       "",
 		Select1:     false,
+		SelectOnly:  false,
 		Exit0:       false,
 		Filter:      nil,
 		ToggleSort:  false,
@@ -1183,6 +1186,10 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.Select1 = true
 		case "+1", "--no-select-1":
 			opts.Select1 = false
+		case "--select-only":
+			opts.SelectOnly = true
+		case "--no-select-only":
+			opts.SelectOnly = false
 		case "-0", "--exit-0":
 			opts.Exit0 = true
 		case "+0", "--no-exit-0":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -93,6 +93,7 @@ type Terminal struct {
 	printQuery   bool
 	history      *History
 	cycle        bool
+	selectOnly   bool
 	header       []string
 	header0      []string
 	ansi         bool
@@ -422,6 +423,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		cleanExit:  opts.ClearOnExit,
 		strong:     strongAttr,
 		cycle:      opts.Cycle,
+		selectOnly: opts.SelectOnly,
 		header:     header,
 		header0:    header,
 		ansi:       opts.Ansi,
@@ -1668,6 +1670,12 @@ func (t *Terminal) Loop() {
 								t.cancelPreview()
 								t.previewBox.Set(reqPreviewEnqueue, list)
 							}
+						}
+						if t.selectOnly && t.merger.Length() == 1 {
+							exit(func() int {
+								t.output()
+								return exitOk
+							})
 						}
 					case reqJump:
 						if t.merger.Length() == 0 {


### PR DESCRIPTION
So basically what `--select-1` does but the check (for only one item) is performed every time the user types a character (interactive mode).

I added a new option instead of changing the `--select-1` behavior because this is more like a user choice than a "script" choice.

The name `--select-only` is just what came first to mind.

(I'm not very familiar with the code base...)