### PR TITLE
Abort history search, but keep already typed text

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -267,7 +267,7 @@ func defaultKeymap() map[int][]action {
 	keymap[tui.CtrlA] = toActions(actBeginningOfLine)
 	keymap[tui.CtrlB] = toActions(actBackwardChar)
 	keymap[tui.CtrlC] = toActions(actAbort)
-	keymap[tui.CtrlG] = toActions(actAbort)
+	keymap[tui.CtrlG] = toActions(actPrintQuery)
 	keymap[tui.CtrlQ] = toActions(actAbort)
 	keymap[tui.ESC] = toActions(actAbort)
 	keymap[tui.CtrlD] = toActions(actDeleteCharEOF)


### PR DESCRIPTION
When searching through history fails (nothing found), pressing Ctrl-G
aborts the search but retains already typed text. This prevents one from
having to type it again.