### PR TITLE
[vim] Use native border for popup terminal window

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -859,7 +859,6 @@ else
       \ borderchars: borderchars,
       \ borderhighlight: [a:hl],
       \ padding: padding,
-      \ zindex: 50,
       \ })
     let &g:wincolor = a:hl
   endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -860,7 +860,7 @@ else
       \ padding: padding,
       \ })
     let &g:wincolor = a:hl
-    execute 'autocmd BufWipeout * ++once bwipeout! '..buf
+    execute 'autocmd TerminalWinOpen * ++once autocmd BufWipeout <buffer> ++once bwipeout! '..buf
   endfunction
 endif
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -861,6 +861,7 @@ else
       \ padding: padding,
       \ })
     let &g:wincolor = a:hl
+    execute 'autocmd BufWipeout * ++once bwipeout! '..buf
   endfunction
 endif
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -857,7 +857,6 @@ else
       \ minheight: a:opts.height,
       \ border: [],
       \ borderchars: borderchars,
-      \ borderhighlight: [a:hl],
       \ padding: padding,
       \ })
     let &g:wincolor = a:hl


### PR DESCRIPTION
Currently, when an `fzf` command is invoked from Vim, and the user has configured the plugin to use Vim's popup terminal window, `fzf` creates 2 popup windows; one for the terminal, and one for the border.

I think it would be better to only create 1 popup window, and make Vim draw the border using the `border`, `borderchars`, `borderhighlight`, and `padding` keys (cf. `:h popup_create-arguments`).

It would allow the removal of the one-shot autocmd listening to `BufWipeOut`, and make the logic around the Vim's implementation a little simpler.

I've tried to make sure that the geometry of the window was identical as in Neovim.

Feel free to close the PR if you prefer the current implementation.
