### PR TITLE
[zsh-completion] Use noksh_arrays in _fzf_complete

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -107,13 +107,13 @@ _fzf_feed_fifo() (
 )
 
 _fzf_complete() {
-  setopt localoptions ksh_arrays
+  setopt localoptions noksh_arrays
   # Split arguments around --
   local args rest str_arg i sep
   args=("$@")
   sep=
   for i in {0..$#args}; do
-    if [[ "${args[$i]}" = -- ]]; then
+    if [[ "${args[i+1]}" = -- ]]; then
       sep=$i
       break
     fi
@@ -131,9 +131,9 @@ _fzf_complete() {
 
   local fifo lbuf cmd matches post
   fifo="${TMPDIR:-/tmp}/fzf-complete-fifo-$$"
-  lbuf=${rest[0]}
+  lbuf=${rest[1]}
   cmd=$(__fzf_extract_command "$lbuf")
-  post="${funcstack[1]}_post"
+  post="${funcstack[2]}_post"
   type $post > /dev/null 2>&1 || post=cat
 
   _fzf_feed_fifo "$fifo"


### PR DESCRIPTION
The changes produced in 50b7608f9d27c09093846e172f230d92b401f956 broke some behaviours with many other Zsh plugins like [zsh-users/zsh-syntax-highlighting](https://github.com/zsh-users/zsh-syntax-highlighting) that rely on ksh\_arrays not being enabled. The scope of `localoptions` is complicated in widget context as it may be hooked by others and this kind of setting should be kept default unless it cannot be avoided IMO.

The example line of the currently broken plugin:
https://github.com/zsh-users/zsh-syntax-highlighting/blob/b85e313/zsh-syntax-highlighting.zsh#L93