### PR TITLE
fix issue #1916

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -723,9 +723,6 @@ function! s:execute_term(dict, command, temps) abort
       call self.switch_back(1)
     else
       if bufnr('') == self.buf
-        if exists('*win_gettype') && win_gettype() ==# 'popup'
-          call term_sendkeys(bufnr('#'), "exit\<CR>")
-        endif
         " We use close instead of bd! since Vim does not close the split when
         " there's no other listed buffer (nvim +'set nobuflisted')
         close
@@ -853,6 +850,8 @@ else
       call setwinvar(id, '&wincolor', a:hl)
       call setbufline(winbufnr(id), 1, a:opts.border)
       execute 'autocmd BufWipeout * ++once call popup_close('..id..')'
+    else
+      execute 'autocmd BufWipeout * ++once call term_sendkeys('..buf..', "exit\<CR>")'
     endif
     return winbufnr(id)
   endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -723,7 +723,9 @@ function! s:execute_term(dict, command, temps) abort
       call self.switch_back(1)
     else
       if bufnr('') == self.buf
-        if !has('nvim') | call term_sendkeys(bufnr('#'), "exit\<CR>") | endif
+        if exists('*win_gettype') && win_gettype() ==# 'popup'
+          call term_sendkeys(bufnr('#'), "exit\<CR>")
+        endif
         " We use close instead of bd! since Vim does not close the split when
         " there's no other listed buffer (nvim +'set nobuflisted')
         close


### PR DESCRIPTION
This PR tries to fix the issue #1916.

Here is the purpose of each change:

    -  return {'tab': tabpagenr(), 'win': winnr(), 'cnt': winnr('$'), 'tcnt': tabpagenr('$')}
    +  return {'tab': tabpagenr(), 'win': winnr(), 'winid': win_getid(), 'cnt': winnr('$'), 'tcnt': tabpagenr('$')}

Inside `fzf.on_exit()`, this test wrongly succeeds when fzf has been invoked from a popup terminal:

      if s:getpos() == self.ppos

This is because a popup window does not have a number and `winnr()` always evaluates to 0 in a popup terminal.  By including `win_getid()` in the dictionary, the test correctly fails when fzf is invoked from a popup terminal.

---

    +        if !has('nvim') | call term_sendkeys(bufnr('#'), "exit\<cr>") | endif

This line terminates the `sh` job bound to the `!sh` terminal buffer which [was originally created by fzf](https://github.com/junegunn/fzf/blob/c39113ee41f032c72a08e015b23d00f60d61a57c/plugin/fzf.vim#L840).

It's necessary so that Vim automatically wipes out the buffer when the window is closed.  There's already a one-shot autocmd with the same purpose, but imo, it's better to rely on Vim's builtin mechanism than create an ad-hoc one.

---

    -      execute 'tabnext' self.ppos.tab
    -      execute self.ppos.win.'wincmd w'
    +      silent! execute 'tabnext' self.ppos.tab
    +      silent! execute self.ppos.win.'wincmd w'

Here, `silent!` suppresses `E994` which is raised when we're still in a popup terminal; commands like `:tabnext` and `:wincmd` are forbidden then.

---

    -    let buf = is_frame ? '' : term_start(&shell, #{hidden: 1})
    +    let buf = is_frame ? '' : term_start(&shell, #{hidden: 1, term_finish: 'close'})

For some reason, `term_finish: 'close'` is necessary for the `!sh` buffer to be automatically wiped out by Vim.  Not sure why; it's not necessary to close the window, since the exit callback already executes `:close`; [it could be a bug](https://github.com/vim/vim/issues/5768).

---

    -    else
    -      execute 'autocmd BufWipeout * ++once bwipeout! '..buf

This one-shot autocmd is not necessary anymore; Vim automatically wipes out a terminal buffer when:

   - its associated job is finished (hence the previous `term_sendkeys(...exit...)`)
   - it's hidden
   - it's not modified

See `:h E947`.

> When the job has finished and no changes were made to the buffer: closing the
> window will wipe out the buffer.
