### PR TITLE
remove perl dependency for bash

### DIFF
--- a/file
+++ b/file
@@ -1,4 +1,0 @@
-"one", 
-"three
-four",
-"seven"

--- a/file
+++ b/file
@@ -1,0 +1,4 @@
+"one", 
+"three
+four",
+"seven"

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -290,7 +290,7 @@ d_cmds="${FZF_COMPLETION_DIR_COMMANDS:-cd pushd rmdir}"
 a_cmds="
   awk cat diff diff3
   emacs emacsclient ex file ftp g++ gcc gvim head hg java
-  javac ld less more mvim nvim patch perl python ruby
+  javac ld less more mvim nvim patch python ruby
   sed sftp sort source tail tee uniq vi view vim wc xdg-open
   basename bunzip2 bzip2 chmod chown curl cp dirname du
   find git grep gunzip gzip hg jar

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -290,7 +290,7 @@ d_cmds="${FZF_COMPLETION_DIR_COMMANDS:-cd pushd rmdir}"
 a_cmds="
   awk cat diff diff3
   emacs emacsclient ex file ftp g++ gcc gvim head hg java
-  javac ld less more mvim nvim patch python ruby
+  javac ld less more mvim nvim patch perl python ruby
   sed sftp sort source tail tee uniq vi view vim wc xdg-open
   basename bunzip2 bzip2 chmod chown curl cp dirname du
   find git grep gunzip gzip hg jar

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -55,7 +55,7 @@ __fzf_cd__() {
 __fzf_history__() {
   local output
   output=$(
-    HISTTIMEFORMAT='' builtin fc -lr -2147483648 | sed -r -e 's/^([0-9]+\t) +/\1/g;' | sed -z -r -e 's/\n([0-9]+\t)/\x00/g;' |
+    HISTTIMEFORMAT='' builtin fc -lr -2147483648 | sed -z -r -e 's/([0-9]+\t) +/\1/g;s/\n([0-9]+\t)/\x00\1/g;' |
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -55,7 +55,7 @@ __fzf_cd__() {
 __fzf_history__() {
   local output
   output=$(
-    HISTTIMEFORMAT='' builtin fc -lr -2147483648 | awk 'BEGIN{RS="\n[0-9]+\t ";ORS="\x00";OFS=""}NR==1{$0=gensub(/^([0-9]+\t) +/,"\\1","g",$0)}{print num,$0}{num=gensub(/\n([0-9]+\t) +/,"\\1","g",RT)}' |
+    HISTTIMEFORMAT='' builtin fc -lr -2147483648 | awk 'BEGIN{RS="\n[0-9]+\t ";ORS="\x00";OFS=""}{sub("^\n","",RT);sub("\t ","\t",RT)}NR==1{sub("\t ","\t",$0)}{print sRT,$0}{sRT=RT}' |
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -55,7 +55,7 @@ __fzf_cd__() {
 __fzf_history__() {
   local output
   output=$(
-    HISTTIMEFORMAT='' fc -lr -2147483648 | sed -r -e 's/^([0-9]+\t) +/\1/g;' | sed -z -r -e 's/\n^([0-9]+\t)/\x00/g;'
+    HISTTIMEFORMAT='' builtin fc -lr -2147483648 | sed -r -e 's/^([0-9]+\t) +/\1/g;' | sed -z -r -e 's/\n([0-9]+\t)/\x00/g;' |
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -55,7 +55,7 @@ __fzf_cd__() {
 __fzf_history__() {
   local output
   output=$(
-    HISTTIMEFORMAT='' builtin fc -lr -2147483648 | sed -z -r -e 's/([0-9]+\t) +/\1/g;s/\n([0-9]+\t)/\x00\1/g;' |
+    HISTTIMEFORMAT='' builtin fc -lr -2147483648 | awk 'BEGIN{RS="\n[0-9]+\t ";ORS="\x00";OFS=""}NR==1{$0=gensub(/^([0-9]+\t) +/,"\\1","g",$0)}{print num,$0}{num=gensub(/\n([0-9]+\t) +/,"\\1","g",RT)}' |
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -51,10 +51,11 @@ __fzf_cd__() {
   dir=$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m) && printf 'cd %q' "$dir"
 }
 
+# sed -z option is only available for version 4.2.2+
 __fzf_history__() {
   local output
   output=$(
-    HISTTIMEFORMAT='' fc -lr -2147483648 | sed -r 's/^([0-9]+\t) +/\1/g;' | tr '\n' '\000' |
+    HISTTIMEFORMAT='' fc -lr -2147483648 | sed -r -e 's/^([0-9]+\t) +/\1/g;' | sed -z -r -e 's/\n^([0-9]+\t)/\x00/g;'
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -51,7 +51,7 @@ __fzf_cd__() {
   dir=$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m) && printf 'cd %q' "$dir"
 }
 
-# sed -z option is only available for version 4.2.2+
+# use sub for compatibility of BSD awk
 __fzf_history__() {
   local output
   output=$(

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -54,8 +54,7 @@ __fzf_cd__() {
 __fzf_history__() {
   local output
   output=$(
-    builtin fc -lnr -2147483648 |
-      last_hist=$(HISTTIMEFORMAT='' builtin history 1) perl -p -l0 -e 'BEGIN { getc; $/ = "\n\t"; $HISTCMD = $ENV{last_hist} + 1 } s/^[ *]//; $_ = $HISTCMD - $. . "\t$_"' |
+    HISTTIMEFORMAT='' builtin history | sort -rn | sed -r 's/^ *//g;s/^([0-9]+) +/\1\t/g;' | tr '\n' '\000' |
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -54,7 +54,7 @@ __fzf_cd__() {
 __fzf_history__() {
   local output
   output=$(
-    HISTTIMEFORMAT='' builtin history | sort -rn | sed -r 's/^ *//g;s/^([0-9]+) +/\1\t/g;' | tr '\n' '\000' |
+    HISTTIMEFORMAT='' fc -lr -2147483648 | sed -r 's/^([0-9]+\t) +/\1/g;' | tr '\n' '\000' |
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return
   READLINE_LINE=${output#*$'\t'}


### PR DESCRIPTION
refer to https://github.com/junegunn/fzf/issues/1931

juse use builtin histtory and sort by reverse order, and use sed and tr to replace perl