### PR TITLE
[zsh-completion] Fix a bug where _fzf_complete did not iterate through args

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -112,7 +112,7 @@ _fzf_complete() {
   local args rest str_arg i sep
   args=("$@")
   sep=
-  for i in {0..$#args}; do
+  for i in {0..${#args[@]}}; do
     if [[ "${args[$i]}" = -- ]]; then
       sep=$i
       break

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2176,7 +2176,7 @@ unset <%= UNSETS.join(' ') %>
 
 # Old API
 _fzf_complete_f() {
-  _fzf_complete "--multi --prompt \"prompt-f> \"" "$@" < <(
+  _fzf_complete "+m --multi --prompt \"prompt-f> \"" "$@" < <(
     echo foo
     echo bar
   )
@@ -2184,7 +2184,7 @@ _fzf_complete_f() {
 
 # New API
 _fzf_complete_g() {
-  _fzf_complete --multi --prompt "prompt-g> " -- "$@" < <(
+  _fzf_complete +m --multi --prompt "prompt-g> " -- "$@" < <(
     echo foo
     echo bar
   )


### PR DESCRIPTION
## Summary

This PR fixes a bug in `_fzf_complete` in Zsh completion where it did not iterate through its arguments due to the usage of `ksh_arrays`.

## Effect of `ksh_arrays`

See below as to how `ksh_arrays` changes the expansion behaviour in `$#foo` where `foo` is the name of an array.

### `ksh_arrays`: off (default)
```zsh
foo=(a b c d e f g)
echo $#foo      # => 7 (the number of elements in foo)
echo ${#foo[@]} # => 7 (the number of elements in foo)
```

### `ksh_arrays`: on (this case)
```zsh
foo=(a b c d e f g)
echo $#foo      # => 1 (the number of characters in the first element of foo)
echo ${#foo[@]} # => 7 (the number of elements in foo)
```

## Conclusion

As a result, `_fzf_complete` only works as expected either when `--` is the first argument passed to `_fzf_complete` or when `--` appears at the position in which it is less than the number of characters of the first argument to `_fzf_complete`. This fix should now properly iterate by the number of the array instead to find `--`.

Thanks.

Note: this PR is slightly related to #1924.