### PR TITLE
10x faster AtomicBool implementation

### DIFF
--- a/src/util/atomicbool.go
+++ b/src/util/atomicbool.go
@@ -1,32 +1,38 @@
 package util
 
-import "sync"
+import (
+	"sync/atomic"
+)
 
 // AtomicBool is a boxed-class that provides synchronized access to the
 // underlying boolean value
 type AtomicBool struct {
-	mutex sync.Mutex
-	state bool
+	state int32 // "1" is true, "0" is false
 }
 
 // NewAtomicBool returns a new AtomicBool
 func NewAtomicBool(initialState bool) *AtomicBool {
-	return &AtomicBool{
-		mutex: sync.Mutex{},
-		state: initialState}
+	var state int32 = 0
+	if initialState == true {
+		state = 1
+	}
+	return &AtomicBool{state: state}
 }
 
 // Get returns the current boolean value synchronously
 func (a *AtomicBool) Get() bool {
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-	return a.state
+	if atomic.LoadInt32(&a.state) != 0 {
+		return true
+	}
+	return false
 }
 
 // Set updates the boolean value synchronously
 func (a *AtomicBool) Set(newState bool) bool {
-	a.mutex.Lock()
-	defer a.mutex.Unlock()
-	a.state = newState
-	return a.state
+	var state int32 = 0
+	if newState == true {
+		state = 1
+	}
+	atomic.StoreInt32(&a.state, state)
+	return newState
 }

--- a/src/util/atomicbool.go
+++ b/src/util/atomicbool.go
@@ -4,6 +4,13 @@ import (
 	"sync/atomic"
 )
 
+func convertBoolToInt32(b bool) int32 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 // AtomicBool is a boxed-class that provides synchronized access to the
 // underlying boolean value
 type AtomicBool struct {
@@ -12,11 +19,7 @@ type AtomicBool struct {
 
 // NewAtomicBool returns a new AtomicBool
 func NewAtomicBool(initialState bool) *AtomicBool {
-	var state int32 = 0
-	if initialState == true {
-		state = 1
-	}
-	return &AtomicBool{state: state}
+	return &AtomicBool{state: convertBoolToInt32(initialState)}
 }
 
 // Get returns the current boolean value synchronously
@@ -26,10 +29,6 @@ func (a *AtomicBool) Get() bool {
 
 // Set updates the boolean value synchronously
 func (a *AtomicBool) Set(newState bool) bool {
-	var state int32 = 0
-	if newState == true {
-		state = 1
-	}
-	atomic.StoreInt32(&a.state, state)
+	atomic.StoreInt32(&a.state, convertBoolToInt32(newState))
 	return newState
 }

--- a/src/util/atomicbool.go
+++ b/src/util/atomicbool.go
@@ -21,10 +21,7 @@ func NewAtomicBool(initialState bool) *AtomicBool {
 
 // Get returns the current boolean value synchronously
 func (a *AtomicBool) Get() bool {
-	if atomic.LoadInt32(&a.state) != 0 {
-		return true
-	}
-	return false
+	return atomic.LoadInt32(&a.state) == 1
 }
 
 // Set updates the boolean value synchronously


### PR DESCRIPTION
It's very straightforward to use _actual_ atomic instead of mutex. And it's paying off in nearly 10x margin in terms of performance
```
goos: linux
goarch: amd64
pkg: github.com/junegunn/fzf/src/util
BenchmarkMutex_Set-4            20000000                69.4 ns/op
BenchmarkMutex_Get-4            20000000                68.9 ns/op
BenchmarkAtomic_Set-4           200000000                7.66 ns/op
BenchmarkAtomic_Get-4           2000000000               0.42 ns/op
```