### PR TITLE
shell: add support to deduplicate history command output

### DIFF
--- a/shell/key-bindings-common.sh
+++ b/shell/key-bindings-common.sh
@@ -1,0 +1,8 @@
+# Keep in sync with version for fish (in key-bindings.fish)
+__fzf_history_dedup__() {
+  if [ "$FZF_HIST_FIND_NO_DUPS" = on ]; then
+    perl -ne 'print if !$seen{($_ =~ s/^[0-9\s]*//r)}++'
+  else
+    cat
+  fi
+}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -13,6 +13,10 @@ __fzf_select__() {
 
 if [[ $- =~ i ]]; then
 
+# https://stackoverflow.com/a/246128
+CWD="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+source "$CWD/key-bindings-common.sh"
+
 __fzf_use_tmux__() {
   [ -n "$TMUX_PANE" ] && [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ]
 }
@@ -54,7 +58,7 @@ __fzf_cd__() {
 __fzf_history__() {
   local output
   output=$(
-    builtin fc -lnr -2147483648 |
+    builtin fc -lnr -2147483648 | __fzf_history_dedup__ |
       last_hist=$(HISTTIMEFORMAT='' builtin history 1) perl -p -l0 -e 'BEGIN { getc; $/ = "\n\t"; $HISTCMD = $ENV{last_hist} + 1 } s/^[ *]//; $_ = $HISTCMD - $. . "\t$_"' |
       FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS +m --read0" $(__fzfcmd) --query "$READLINE_LINE"
   ) || return

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -47,14 +47,23 @@ function fzf_key_bindings
       # history's -z flag was added in fish 2.4.0, so don't use it for versions
       # before 2.4.0.
       if [ "$FISH_MAJOR" -gt 2 -o \( "$FISH_MAJOR" -eq 2 -a "$FISH_MINOR" -ge 4 \) ];
-        history -z | eval (__fzfcmd) --read0 --print0 -q '(commandline)' | read -lz result
+        history -z | __fzf_history_dedup__ | eval (__fzfcmd) --read0 --print0 -q '(commandline)' | read -lz result
         and commandline -- $result
       else
-        history | eval (__fzfcmd) -q '(commandline)' | read -l result
+        history | __fzf_history_dedup__ | eval (__fzfcmd) -q '(commandline)' | read -l result
         and commandline -- $result
       end
     end
     commandline -f repaint
+  end
+
+  # Keep in sync with common version (in key-bindings-common.sh)
+  function __fzf_history_dedup__
+    if [ "$FZF_HIST_FIND_NO_DUPS" = on ]
+      perl -ne 'print if !$seen{($_ =~ s/^[0-9\s]*//r)}++'
+    else
+      cat
+    end
   end
 
   function fzf-cd-widget -d "Change directory"

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -2,6 +2,10 @@
 # ------------
 if [[ $- == *i* ]]; then
 
+# https://unix.stackexchange.com/a/115431
+CWD="${0:a:h}"
+source "$CWD/key-bindings-common.sh"
+
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
   local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
@@ -66,9 +70,13 @@ bindkey '\ec' fzf-cd-widget
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
+  if [ -z "$FZF_HIST_FIND_NO_DUPS" ]; then
+    export FZF_HIST_FIND_NO_DUPS="${options[HIST_FIND_NO_DUPS]}"
+  fi
+
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
-  selected=( $(fc -rl 1 |
+  selected=( $(fc -rl 1 | __fzf_history_dedup__ |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then


### PR DESCRIPTION
This change allows to deduplicate commands from the shell history
when filtering with fzf.

To enable deduplication, set "FZF_HIST_FIND_NO_DUPS" to "on":

    export FZF_HIST_FIND_NO_DUPS=on

On zsh, fall back to reading the "HIST_FIND_NO_DUPS" shell option
which can be set as follows:

    setopt HIST_FIND_NO_DUPS

A big »Thanks« goes to Felix Breuer for his idea which this change is
based upon ([0]).

Updates [1] and [2].

[0]: https://github.com/junegunn/fzf/pull/1363#issuecomment-598228199
[1]: https://github.com/junegunn/fzf/pull/1287
[2]: https://github.com/junegunn/fzf/pull/1363