### PR TITLE
[fzf-tmux] Add option to start fzf in tmux popup window

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,10 @@ own as well.
 [fzf-tmux](bin/fzf-tmux) is a bash script that opens fzf in a tmux pane.
 
 ```sh
-# usage: fzf-tmux [-u|-d [HEIGHT[%]]] [-l|-r [WIDTH[%]]] [--] [FZF OPTIONS]
-#        (-[udlr]: up/down/left/right)
+# usage: fzf-tmux [LAYOUT OPTIONS] [--] [FZF OPTIONS]
+
+# See available options
+fzf-tmux --help
 
 # select git branches in horizontal split below (15 lines)
 git branch | fzf-tmux -d 15
@@ -291,7 +293,7 @@ git branch | fzf-tmux -d 15
 cat /usr/share/dict/words | fzf-tmux -l 20% --multi --reverse
 ```
 
-It will still work even when you're not on tmux, silently ignoring `-[udlr]`
+It will still work even when you're not on tmux, silently ignoring `-[pudlr]`
 options, so you can invariably use `fzf-tmux` in your scripts.
 
 Alternatively, you can use `--height HEIGHT[%]` option not to start fzf in
@@ -318,9 +320,9 @@ fish.
     - Set `FZF_ALT_C_COMMAND` to override the default command
     - Set `FZF_ALT_C_OPTS` to pass additional options
 
-If you're on a tmux session, you can start fzf in a split pane by setting
-`FZF_TMUX` to 1, and change the height of the pane with `FZF_TMUX_HEIGHT`
-(e.g. `20`, `50%`).
+If you're on a tmux session, you can start fzf in a tmux split pane or in
+a tmux popup window by setting `FZF_TMUX_OPTS` (e.g. `-d 40%`).
+See `fzf-tmux --help` for available options.
 
 More tips can be found on [the wiki page](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings).
 

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -130,7 +130,7 @@ while [[ $# -gt 0 ]]; do
   [[ -n "$skip" ]] && args+=("$arg")
 done
 
-if [[ -z "$TMUX" || "$opt" =~ ^-h && "$columns" -le 40 || ! "$opt" =~ ^-h && "$lines" -le 15 ]]; then
+if [[ -z "$TMUX" ]]; then
   "$fzf" "${args[@]}"
   exit $?
 fi
@@ -222,14 +222,14 @@ if [[ -n "$term" ]] || [[ -t 0 ]]; then
   TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
     split-window $opt "${tmux_args[@]}" "$envs bash -c 'cd $(printf %q "$PWD"); exec -a fzf bash $argsf'" $swap \
-    > /dev/null 2>&1
+    > /dev/null 2>&1 || { "$fzf" "${args[@]}"; exit $?; }
 else
   mkfifo $fifo1
   cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" >> $argsf
   TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
     split-window $opt "${tmux_args[@]}" "$envs bash -c 'exec -a fzf bash $argsf'" $swap \
-    > /dev/null 2>&1
+    > /dev/null 2>&1 || { "$fzf" "${args[@]}"; exit $?; }
   cat <&0 > $fifo1 &
 fi
 cat $fifo2

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -207,12 +207,12 @@ if [[ "$opt" =~ "-K -E" ]]; then
   cat $fifo2 &
   if [[ -n "$term" ]] || [[ -t 0 ]]; then
     cat <<< "\"$fzf\" $opts > $fifo2; out=\$? $close; exit \$out" >> $argsf
-    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux popup -d '#{pane_current_path}' "${tmux_args[@]}" $opt -R "$envs bash $argsf" > /dev/null 2>&1
+    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux popup -d "$PWD" "${tmux_args[@]}" $opt -R "$envs bash $argsf" > /dev/null 2>&1
   else
     mkfifo $fifo1
     cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; out=\$? $close; exit \$out" >> $argsf
     cat <&0 > $fifo1 &
-    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux popup -d '#{pane_current_path}' "${tmux_args[@]}" $opt -R "$envs bash $argsf" > /dev/null 2>&1
+    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux popup -d "$PWD" "${tmux_args[@]}" $opt -R "$envs bash $argsf" > /dev/null 2>&1
   fi
   exit $?
 fi

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -180,6 +180,7 @@ trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
 envs="env TERM=$TERM "
+[[ "$opt" =~ "-K -E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 $FZF_DEFAULT_OPTS"
 [[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS")"
 [[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs FZF_DEFAULT_COMMAND=$(printf %q "$FZF_DEFAULT_COMMAND")"
 

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # fzf-tmux: starts fzf in a tmux pane
-# usage: fzf-tmux [-u|-d [HEIGHT[%]]] [-l|-r [WIDTH[%]]] [--] [FZF OPTIONS]
+# usage: fzf-tmux [LAYOUT OPTIONS] [--] [FZF OPTIONS]
 
 fail() {
   >&2 echo "$1"
@@ -10,6 +10,7 @@ fail() {
 fzf="$(command -v fzf 2> /dev/null)" || fzf="$(dirname "$0")/fzf"
 [[ -x "$fzf" ]] || fail 'fzf executable not found'
 
+tmux_args=()
 args=()
 opt=""
 skip=""
@@ -20,15 +21,23 @@ term=""
 [[ -n "$COLUMNS" ]] && columns=$COLUMNS || columns=$(tput cols) || columns=$(tmux display-message -p "#{pane_width}")
 
 help() {
-  >&2 echo 'usage: fzf-tmux [-u|-d [HEIGHT[%]]] [-l|-r [WIDTH[%]]] [--] [FZF OPTIONS]
+  >&2 echo 'usage: fzf-tmux [LAYOUT OPTIONS] [--] [FZF OPTIONS]
 
-  Layout
-    -u [HEIGHT[%]]  Split above (up)
-    -d [HEIGHT[%]]  Split below (down)
-    -l [WIDTH[%]]   Split left
-    -r [WIDTH[%]]   Split right
+  LAYOUT OPTIONS:
+    (default layout: -d 50%)
 
-    (default: -d 50%)
+    Popup window (requires tmux 3.2 or above):
+      -p [WIDTH[%][,HEIGHT[%]]]  (default: 50%)
+      -w WIDTH[%]
+      -h HEIGHT[%]
+      -x COL
+      -y ROW
+
+    Split pane:
+      -u [HEIGHT[%]]             Split above (up)
+      -d [HEIGHT[%]]             Split below (down)
+      -l [WIDTH[%]]              Split left
+      -r [WIDTH[%]]              Split right
 '
   exit
 }
@@ -47,8 +56,10 @@ while [[ $# -gt 0 ]]; do
       echo "fzf-tmux (with fzf $("$fzf" --version))"
       exit
       ;;
-    -w*|-h*|-d*|-u*|-r*|-l*)
-      if [[ "$arg" =~ ^.[lrw] ]]; then
+    -p*|-w*|-h*|-x*|-y*|-d*|-u*|-r*|-l*)
+      if [[ "$arg" =~ ^-[pwhxy] ]]; then
+        [[ "$opt" =~ "-K -E" ]] || opt="-K -E"
+      elif [[ "$arg" =~ ^.[lr] ]]; then
         opt="-h"
         if [[ "$arg" =~ ^.l ]]; then
           opt="$opt -d"
@@ -66,7 +77,7 @@ while [[ $# -gt 0 ]]; do
       if [[ ${#arg} -gt 2 ]]; then
         size="${arg:2}"
       else
-        if [[ "$1" =~ ^[0-9]+%?$ ]]; then
+        if [[ "$1" =~ ^[0-9%,C]+$ ]]; then
           size="$1"
           shift
         else
@@ -74,7 +85,15 @@ while [[ $# -gt 0 ]]; do
         fi
       fi
 
-      if [[ "$size" =~ %$ ]]; then
+      if [[ "$arg" =~ ^-p ]]; then
+        if [[ -n "$size" ]]; then
+          w=${size%%,*}
+          h=${size##*,}
+          opt="$opt -w$w -h$h"
+        fi
+      elif [[ "$arg" =~ ^-[whxy] ]]; then
+        opt="$opt ${arg:0:2}$size"
+      elif [[ "$size" =~ %$ ]]; then
         size=${size:0:((${#size}-1))}
         if [[ -n "$swap" ]]; then
           opt="$opt -p $(( 100 - size ))"
@@ -100,6 +119,8 @@ while [[ $# -gt 0 ]]; do
       # "--" can be used to separate fzf-tmux options from fzf options to
       # avoid conflicts
       skip=1
+      tmux_args=("${args[@]}")
+      args=()
       continue
       ;;
     *)
@@ -115,7 +136,7 @@ if [[ -z "$TMUX" || "$opt" =~ ^-h && "$columns" -le 40 || ! "$opt" =~ ^-h && "$l
 fi
 
 # --height option is not allowed
-args+=("--no-height")
+args=("--no-height" "${args[@]}")
 
 # Handle zoomed tmux pane by moving it to a temp window
 if tmux list-panes -F '#F' | grep -q Z; then
@@ -181,21 +202,34 @@ close="; trap - EXIT SIGINT SIGTERM $close"
 
 tmux_win_opts=( $(tmux show-window-options remain-on-exit \; show-window-options synchronize-panes | sed '/ off/d; s/^/set-window-option /; s/$/ \\;/') )
 
+if [[ "$opt" =~ "-K -E" ]]; then
+  cat $fifo2 &
+  if [[ -n "$term" ]] || [[ -t 0 ]]; then
+    cat <<< "\"$fzf\" $opts > $fifo2; out=\$? $close; exit \$out" >> $argsf
+    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux popup -d '#{pane_current_path}' "${tmux_args[@]}" $opt -R "$envs bash $argsf" > /dev/null 2>&1
+  else
+    mkfifo $fifo1
+    cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; out=\$? $close; exit \$out" >> $argsf
+    cat <&0 > $fifo1 &
+    TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux popup -d '#{pane_current_path}' "${tmux_args[@]}" $opt -R "$envs bash $argsf" > /dev/null 2>&1
+  fi
+  exit $?
+fi
+
 if [[ -n "$term" ]] || [[ -t 0 ]]; then
   cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf
   TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
-    split-window $opt "$envs bash -c 'cd $(printf %q "$PWD"); exec -a fzf bash $argsf'" $swap \
+    split-window $opt "${tmux_args[@]}" "$envs bash -c 'cd $(printf %q "$PWD"); exec -a fzf bash $argsf'" $swap \
     > /dev/null 2>&1
 else
   mkfifo $fifo1
   cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" >> $argsf
   TMUX=$(echo $TMUX | cut -d , -f 1,2) tmux set-window-option synchronize-panes off \;\
     set-window-option remain-on-exit off \;\
-    split-window $opt "$envs bash -c 'exec -a fzf bash $argsf'" $swap \
+    split-window $opt "${tmux_args[@]}" "$envs bash -c 'exec -a fzf bash $argsf'" $swap \
     > /dev/null 2>&1
   cat <&0 > $fifo1 &
 fi
 cat $fifo2
 exit "$(cat $fifo3)"
-

--- a/man/man1/fzf-tmux.1
+++ b/man/man1/fzf-tmux.1
@@ -27,19 +27,33 @@ THE SOFTWARE.
 fzf-tmux - open fzf in tmux split pane
 
 .SH SYNOPSIS
-.B fzf-tmux [-u|-d [HEIGHT[%]]] [-l|-r [WIDTH[%]]] [--] [FZF OPTIONS]
+.B fzf-tmux [LAYOUT OPTIONS] [--] [FZF OPTIONS]
 
 .SH DESCRIPTION
-fzf-tmux is a wrapper script for fzf that opens fzf in a tmux split pane. It is
-designed to work just like fzf except that it does not take up the whole
-screen. You can safely use fzf-tmux instead of fzf in your scripts as the extra
-options will be silently ignored if you're not on tmux.
+fzf-tmux is a wrapper script for fzf that opens fzf in a tmux split pane or in
+a tmux popup window. It is designed to work just like fzf except that it does
+not take up the whole screen. You can safely use fzf-tmux instead of fzf in
+your scripts as the extra options will be silently ignored if you're not on
+tmux.
 
-.SH OPTIONS
-.SS Layout
+.SH LAYOUT OPTIONS
 
-(default: \fB-d 50%\fR)
+(default layout: \fB-d 50%\fR)
 
+.SS Popup window
+(requires tmux 3.2 or above)
+.TP
+.B "-p [WIDTH[%][,HEIGHT[%]]]"
+.TP
+.B "-w WIDTH[%]"
+.TP
+.B "-h WIDTH[%]"
+.TP
+.B "-x COL"
+.TP
+.B "-y ROW"
+
+.SS Split pane
 .TP
 .B "-u [height[%]]"
 Split above (up)

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -2,10 +2,10 @@
 #    / __/___  / __/
 #   / /_/_  / / /_
 #  / __/ / /_/ __/
-# /_/   /___/_/-completion.bash
+# /_/   /___/_/ completion.bash
 #
 # - $FZF_TMUX               (default: 0)
-# - $FZF_TMUX_HEIGHT        (default: '40%')
+# - $FZF_TMUX_OPTS          (default: empty)
 # - $FZF_COMPLETION_TRIGGER (default: '**')
 # - $FZF_COMPLETION_OPTS    (default: empty)
 
@@ -37,9 +37,9 @@ bind '"\e[0n": redraw-current-line'
 __fzf_comprun() {
   if [ "$(type -t _fzf_comprun 2>&1)" = function ]; then
     _fzf_comprun "$@"
-  elif [ -n "$TMUX_PANE" ] && [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ]; then
+  elif [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] || [ -n "$FZF_TMUX_OPTS" ]; }; then
     shift
-    fzf-tmux -d "${FZF_TMUX_HEIGHT:-40%}" "$@"
+    fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} -- "$@"
   else
     shift
     fzf "$@"

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -37,7 +37,7 @@ bind '"\e[0n": redraw-current-line'
 __fzf_comprun() {
   if [ "$(type -t _fzf_comprun 2>&1)" = function ]; then
     _fzf_comprun "$@"
-  elif [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] || [ -n "$FZF_TMUX_OPTS" ]; }; then
+  elif [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "$FZF_TMUX_OPTS" ]; }; then
     shift
     fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} -- "$@"
   else

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -2,10 +2,10 @@
 #    / __/___  / __/
 #   / /_/_  / / /_
 #  / __/ / /_/ __/
-# /_/   /___/_/-completion.zsh
+# /_/   /___/_/ completion.zsh
 #
 # - $FZF_TMUX               (default: 0)
-# - $FZF_TMUX_HEIGHT        (default: '40%')
+# - $FZF_TMUX_OPTS          (default: '-d 40%')
 # - $FZF_COMPLETION_TRIGGER (default: '**')
 # - $FZF_COMPLETION_OPTS    (default: empty)
 
@@ -99,9 +99,9 @@ fi
 __fzf_comprun() {
   if [[ "$(type _fzf_comprun 2>&1)" =~ function ]]; then
     _fzf_comprun "$@"
-  elif [ -n "$TMUX_PANE" ] && [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ]; then
+  elif [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] || [ -n "$FZF_TMUX_OPTS" ]; }; then
     shift
-    fzf-tmux -d "${FZF_TMUX_HEIGHT:-40%}" "$@"
+    fzf-tmux ${(Q)${(Z+n+)FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}}} -- "$@"
   else
     shift
     fzf "$@"

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -99,7 +99,7 @@ fi
 __fzf_comprun() {
   if [[ "$(type _fzf_comprun 2>&1)" =~ function ]]; then
     _fzf_comprun "$@"
-  elif [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] || [ -n "$FZF_TMUX_OPTS" ]; }; then
+  elif [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "$FZF_TMUX_OPTS" ]; }; then
     shift
     fzf-tmux ${(Q)${(Z+n+)FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}}} -- "$@"
   else

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -101,7 +101,11 @@ __fzf_comprun() {
     _fzf_comprun "$@"
   elif [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "$FZF_TMUX_OPTS" ]; }; then
     shift
-    fzf-tmux ${(Q)${(Z+n+)FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}}} -- "$@"
+    if [ -n "$FZF_TMUX_OPTS" ]; then
+      fzf-tmux ${(Q)${(Z+n+)FZF_TMUX_OPTS}} -- "$@"
+    else
+      fzf-tmux -d ${FZF_TMUX_HEIGHT:-40%} -- "$@"
+    fi
   else
     shift
     fzf "$@"

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -27,7 +27,7 @@ __fzf_select__() {
 if [[ $- =~ i ]]; then
 
 __fzfcmd() {
-  [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] || [ -n "$FZF_TMUX_OPTS" ]; } &&
+  [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "$FZF_TMUX_OPTS" ]; } &&
     echo "fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} -- " || echo "fzf"
 }
 

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -1,3 +1,16 @@
+#     ____      ____
+#    / __/___  / __/
+#   / /_/_  / / /_
+#  / __/ / /_/ __/
+# /_/   /___/_/ key-bindings.fish
+#
+# - $FZF_TMUX_OPTS
+# - $FZF_CTRL_T_COMMAND
+# - $FZF_CTRL_T_OPTS
+# - $FZF_CTRL_R_OPTS
+# - $FZF_ALT_C_COMMAND
+# - $FZF_ALT_C_OPTS
+
 # Key bindings
 # ------------
 function fzf_key_bindings
@@ -84,8 +97,10 @@ function fzf_key_bindings
   function __fzfcmd
     test -n "$FZF_TMUX"; or set FZF_TMUX 0
     test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
-    if [ $FZF_TMUX -eq 1 ]
-      echo "fzf-tmux -d$FZF_TMUX_HEIGHT"
+    if [ -n "$FZF_TMUX_OPTS" ]
+      echo "fzf-tmux $FZF_TMUX_OPTS -- "
+    else if [ $FZF_TMUX -eq 1 ]
+      echo "fzf-tmux -d$FZF_TMUX_HEIGHT -- "
     else
       echo "fzf"
     end

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -1,3 +1,16 @@
+#     ____      ____
+#    / __/___  / __/
+#   / /_/_  / / /_
+#  / __/ / /_/ __/
+# /_/   /___/_/ key-bindings.zsh
+#
+# - $FZF_TMUX_OPTS
+# - $FZF_CTRL_T_COMMAND
+# - $FZF_CTRL_T_OPTS
+# - $FZF_CTRL_R_OPTS
+# - $FZF_ALT_C_COMMAND
+# - $FZF_ALT_C_OPTS
+
 # Key bindings
 # ------------
 
@@ -40,13 +53,9 @@ __fsel() {
   return $ret
 }
 
-__fzf_use_tmux__() {
-  [ -n "$TMUX_PANE" ] && [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ]
-}
-
 __fzfcmd() {
-  __fzf_use_tmux__ &&
-    echo "fzf-tmux -d${FZF_TMUX_HEIGHT:-40%}" || echo "fzf"
+  [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] || [ -n "$FZF_TMUX_OPTS" ]; } &&
+    echo "fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} -- " || echo "fzf"
 }
 
 fzf-file-widget() {

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -54,7 +54,7 @@ __fsel() {
 }
 
 __fzfcmd() {
-  [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] && [ ${LINES:-40} -gt 15 ] || [ -n "$FZF_TMUX_OPTS" ]; } &&
+  [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "$FZF_TMUX_OPTS" ]; } &&
     echo "fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} -- " || echo "fzf"
 }
 

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2036,7 +2036,6 @@ module CompletionTest
     tmux.send_keys 'C-c'
 
     # FZF_TMUX=1
-    skip 'screen size too small' if `tput lines`.to_i < 15
     new_shell
     tmux.focus
     tmux.send_keys 'unset FZFFOOBR**', :Tab


### PR DESCRIPTION
Requires latest tmux built from source (e.g. `brew install tmux --HEAD`)

Examples:

```
# 50% width and height on the center of the screen
fzf-tmux -p

# 80%
fzf-tmux -p80%

# 80% width 40% height
fzf-tmux -p80%,40%

# Separate -w and -h
fzf-tmux -w80% -h40%

# 80%/40% at position (0, 0)
fzf-tmux -w80% -h40% -x0 -y0
```

You can configure key bindings and fuzzy completion to open in tmux
popup window like so:

```sh
FZF_TMUX_OPTS='-p 80%'
```

Screenshot:

![image](https://user-images.githubusercontent.com/700826/78034673-ffb26900-73a2-11ea-8d8c-c6d106f6c96f.png)

Issues with tmux popup window:
- Not mature
- Rendering isn't as efficient
- ~~Mouse doesn't work~~ ([works](https://github.com/tmux/tmux/issues/1842#issuecomment-607129692))