### PR TITLE
Quote external linker flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ROOT_DIR       := $(shell dirname $(MAKEFILE))
 SOURCES        := $(wildcard *.go src/*.go src/*/*.go) $(MAKEFILE)
 
 REVISION       := $(shell git log -n 1 --pretty=format:%h -- $(SOURCES))
-BUILD_FLAGS    := -a -ldflags "-X main.revision=$(REVISION) -w -extldflags=$(LDFLAGS)" -tags "$(TAGS)"
+BUILD_FLAGS    := -a -ldflags "-X main.revision=$(REVISION) -w \"-extldflags=$(LDFLAGS)\"" -tags "$(TAGS)"
 
 BINARY32       := fzf-$(GOOS)_386
 BINARY64       := fzf-$(GOOS)_amd64


### PR DESCRIPTION
If there are multiple ld flags `go build` will treat the latter ones as regular options and fail. In order to prevent this '-extldflags=$(LDFLAGS)' must be quoted[1].

[1] https://github.com/golang/go/issues/6234