### PR TITLE
README: Use --line-range instead of head in bat example

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ syntax-highlights the content of a file.
 - Highlight: http://www.andre-simon.de/doku/highlight/en/highlight.php
 
 ```bash
-fzf --preview 'bat --style=numbers --color=always --line-range :99 {}'
+fzf --preview 'bat --style=numbers --color=always --line-range :500 {}'
 ```
 
 You can customize the size, position, and border of the preview window using
@@ -582,7 +582,7 @@ not a good idea to add `--preview` option to your `$FZF_DEFAULT_OPTS`**.
 # *********************
 # ** DO NOT DO THIS! **
 # *********************
-export FZF_DEFAULT_OPTS='--preview "bat --style=numbers --color=always --line-range :99 {}"'
+export FZF_DEFAULT_OPTS='--preview "bat --style=numbers --color=always --line-range :500 {}"'
 
 # bat doesn't work with any input other than the list of files
 ps -ef | fzf

--- a/README.md
+++ b/README.md
@@ -529,9 +529,10 @@ See *KEY BINDINGS* section of the man page for details.
 
 ### Preview window
 
-When `--preview` option is set, fzf automatically starts an external process with
-the current line as the argument and shows the result in the split window. Your
-`$SHELL` is used to execute the command with `$SHELL -c COMMAND`.
+When the `--preview` option is set, fzf automatically starts an external process 
+with the current line as the argument and shows the result in the split window. 
+Your `$SHELL` is used to execute the command with `$SHELL -c COMMAND`. 
+The window can be scrolled using the mouse or custom key bindings.
 
 ```bash
 # {} is replaced to the single-quoted string of the focused line
@@ -547,10 +548,9 @@ fzf --preview 'head -100 {}'
 ```
 
 Preview window supports ANSI colors, so you can use any program that
-syntax-highlights the content of a file.
-
-- Bat: https://github.com/sharkdp/bat
-- Highlight: http://www.andre-simon.de/doku/highlight/en/highlight.php
+syntax-highlights the content of a file, such as 
+[Bat](https://github.com/sharkdp/bat) or
+[Highlight](http://www.andre-simon.de/doku/highlight/en/highlight.php):
 
 ```bash
 fzf --preview 'bat --style=numbers --color=always --line-range :500 {}'

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ syntax-highlights the content of a file.
 - Highlight: http://www.andre-simon.de/doku/highlight/en/highlight.php
 
 ```bash
-fzf --preview 'bat --style=numbers --color=always {} | head -500'
+fzf --preview 'bat --style=numbers --color=always --line-range :99 {}'
 ```
 
 You can customize the size, position, and border of the preview window using
@@ -582,7 +582,7 @@ not a good idea to add `--preview` option to your `$FZF_DEFAULT_OPTS`**.
 # *********************
 # ** DO NOT DO THIS! **
 # *********************
-export FZF_DEFAULT_OPTS='--preview "bat --style=numbers --color=always {} | head -500"'
+export FZF_DEFAULT_OPTS='--preview "bat --style=numbers --color=always --line-range :99 {}"'
 
 # bat doesn't work with any input other than the list of files
 ps -ef | fzf


### PR DESCRIPTION
From the bat man page:
```
       -r, --line-range <N:M>...

              Only print the specified range of lines for each file. For example:

              --line-range 30:40
                     prints lines 30 to 40

              --line-range :40
                     prints lines 1 to 40
```
I think this should be more efficient than head? 
And either way, it is the proper way, better to make it easy to find because it took me some time to find it :sweat_smile: 

Also, why 500 lines? What insane terminal is that where you can see 500 lines vertically without scrolling? ^^