### PR TITLE
Fully qualify Expand-Archive

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -57,7 +57,7 @@ function download {
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
   (New-Object Net.WebClient).DownloadFile($url, $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$temp"))
   if ($?) {
-    (Expand-Archive -Path $temp -DestinationPath .); (Remove-Item $temp)
+    (Microsoft.PowerShell.Archive\Expand-Archive -Path $temp -DestinationPath .); (Remove-Item $temp)
   } else {
     $binary_error="Failed to download with powershell"
   }


### PR DESCRIPTION
If a user has the Powershell Community Extensions installed, it comes
with another command Expand-Archive that doesn't have a DestinationPath
argument, causing an error during installation:
```
Expand-Archive : A parameter cannot be found that matches parameter name 'DestinationPath'.
At W:\env_config\.vim\plugged\fzf\install.ps1:60 char:33
+     (Expand-Archive -Path $temp -DestinationPath .); (Remove-Item $te ...
+                                 ~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidArgument: (:) [Expand-Archive], ParameterBindingException
    + FullyQualifiedErrorId : NamedParameterNotFound,Pscx.Commands.IO.Compression.ExpandArchiveCommand
```

Note the last line, `Pscx.Commands.IO.Compression.ExpandArchiveCommand` indicates that Powershell tried to use the wrong Expand-Archive.

Worse, when using fzf.vim and `fzf#install()`, vim will say "fzf executable not found", offer to install it, run the installer and then (without any error message) again say "fzf executable not found" and offer to install it.

Fully qualifying the default Microsoft Expand-Archive works around that.

See also Pscx/Pscx#68.