### PR TITLE
Use fzf-redraw-prompt in history widget

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -109,7 +109,7 @@ fzf-history-widget() {
       zle vi-fetch-history -n $num
     fi
   fi
-  zle reset-prompt
+  zle fzf-redraw-prompt
   return $ret
 }
 zle     -N   fzf-history-widget


### PR DESCRIPTION
I am using Powerlevel10k. When I use `fzf-tmux` with the history widget, it corrupts my prompt. After selecting from the widget, the command is printed, but it seems the cursor position is wrong. After typing anything, the command is duplicated like this:
```
❯ echo fooecho foo
```

Using `fzf-redraw-prompt` for the history widget fixes the problem.