### PR TITLE
preserve current directory in case someone changes it

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -236,8 +236,8 @@ function! s:common_sink(action, lines) abort
   endif
   try
     let empty = empty(s:fzf_expand('%')) && line('$') == 1 && empty(getline(1)) && !&modified
-    " Preserve current directory in case current working directory is changed
-    " during the execution
+    " Preserve the current working directory in case it's changed during
+    " the execution (e.g. `set autochdir` or `autocmd BufEnter * lcd ...`)
     let cwd = exists('w:fzf_pushd') ? w:fzf_pushd.dir : expand('%:p:h')
     for item in a:lines
       if item[0] != '~' && item !~ (s:is_win ? '^[A-Z]:\' : '^/')

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -240,13 +240,18 @@ function! s:common_sink(action, lines) abort
     set noautochdir
     " preserve current directory in case current directory is changed by others
     " after the call of s:open
-    let currdir = expand('%:p:h') . (s:is_win ? '\\' : '/')
+    let currdir = expand('%:p:h') 
+    if exists('w:fzf_pushd')
+        let currdir = w:fzf_pushd.dir 
+    endif
+"    let currdir = currdir . (s:is_win ? '\\' : '/')
     for item in a:lines
       if empty
         execute 'e' s:escape(item)
         let empty = 0
       else
-        call s:open(Cmd, currdir . item)
+        let abspath = item =~ (s:is_win ? '^[A-Z]:\' : '^/') ? item : join([currdir, item], (s:is_win ? '\\' : '/'))
+        call s:open(Cmd, abspath)
       endif
       if !has('patch-8.0.0177') && !has('nvim-0.2') && exists('#BufEnter')
             \ && isdirectory(item)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -244,8 +244,10 @@ function! s:common_sink(action, lines) abort
         execute 'e' s:escape(item)
         let empty = 0
       else
-        let abspath = item =~ (s:is_win ? '^[A-Z]:\' : '^/') ? item : join([cwd, item], (s:is_win ? '\' : '/'))
-        call s:open(Cmd, abspath)
+        if item[0] != '~' && item !~ (s:is_win ? '^[A-Z]:\' : '^/')
+          let item = join([cwd, item], (s:is_win ? '\' : '/'))
+        endif
+        call s:open(Cmd, item)
       endif
       if !has('patch-8.0.0177') && !has('nvim-0.2') && exists('#BufEnter')
             \ && isdirectory(item)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -238,12 +238,15 @@ function! s:common_sink(action, lines) abort
     let empty = empty(s:fzf_expand('%')) && line('$') == 1 && empty(getline(1)) && !&modified
     let autochdir = &autochdir
     set noautochdir
+    " preserve current directory in case current directory is changed by others
+    " after the call of s:open
+    let currdir = expand('%:p:h') . (s:is_win ? '\\' : '/')
     for item in a:lines
       if empty
         execute 'e' s:escape(item)
         let empty = 0
       else
-        call s:open(Cmd, item)
+        call s:open(Cmd, currdir . item)
       endif
       if !has('patch-8.0.0177') && !has('nvim-0.2') && exists('#BufEnter')
             \ && isdirectory(item)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -240,13 +240,13 @@ function! s:common_sink(action, lines) abort
     " during the execution
     let cwd = exists('w:fzf_pushd') ? w:fzf_pushd.dir : expand('%:p:h')
     for item in a:lines
+      if item[0] != '~' && item !~ (s:is_win ? '^[A-Z]:\' : '^/')
+        let item = join([cwd, item], (s:is_win ? '\' : '/'))
+      endif
       if empty
         execute 'e' s:escape(item)
         let empty = 0
       else
-        if item[0] != '~' && item !~ (s:is_win ? '^[A-Z]:\' : '^/')
-          let item = join([cwd, item], (s:is_win ? '\' : '/'))
-        endif
         call s:open(Cmd, item)
       endif
       if !has('patch-8.0.0177') && !has('nvim-0.2') && exists('#BufEnter')

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -236,21 +236,15 @@ function! s:common_sink(action, lines) abort
   endif
   try
     let empty = empty(s:fzf_expand('%')) && line('$') == 1 && empty(getline(1)) && !&modified
-    let autochdir = &autochdir
-    set noautochdir
-    " preserve current directory in case current directory is changed by others
-    " after the call of s:open
-    let currdir = expand('%:p:h') 
-    if exists('w:fzf_pushd')
-        let currdir = w:fzf_pushd.dir 
-    endif
-"    let currdir = currdir . (s:is_win ? '\\' : '/')
+    " Preserve current directory in case current working directory is changed
+    " during the execution
+    let cwd = exists('w:fzf_pushd') ? w:fzf_pushd.dir : expand('%:p:h')
     for item in a:lines
       if empty
         execute 'e' s:escape(item)
         let empty = 0
       else
-        let abspath = item =~ (s:is_win ? '^[A-Z]:\' : '^/') ? item : join([currdir, item], (s:is_win ? '\\' : '/'))
+        let abspath = item =~ (s:is_win ? '^[A-Z]:\' : '^/') ? item : join([cwd, item], (s:is_win ? '\' : '/'))
         call s:open(Cmd, abspath)
       endif
       if !has('patch-8.0.0177') && !has('nvim-0.2') && exists('#BufEnter')
@@ -260,7 +254,6 @@ function! s:common_sink(action, lines) abort
     endfor
   catch /^Vim:Interrupt$/
   finally
-    let &autochdir = autochdir
     silent! autocmd! fzf_swap
   endtry
 endfunction


### PR DESCRIPTION
I use ```autocmd BufEnter * silent! lcd %:p:h``` as suggested in this document <https://vim.fandom.com/wiki/Set_working_directory_to_the_current_file>.

When the '--multi' flag is set and I try to open multiple files, the current directory is changed after the first file is opened, which results in the following files failed to open because of the filenames are relative paths to "current directory".

I think this solution covers both 'autochdir' and 'BufEnter lcd' scenarios.

