### PR TITLE
Add instructions on command for installing fzf with Guix and Guix System

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,18 +104,19 @@ git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 
 ### Using Linux package managers
 
-| Package Manager | Linux Distribution      | Command                            |
-| ---             | ---                     | ---                                |
-| APK             | Alpine Linux            | `sudo apk add fzf`                 |
-| APT             | Debian 9+/Ubuntu 19.10+ | `sudo apt-get install fzf`         |
-| Conda           |                         | `conda install -c conda-forge fzf` |
-| DNF             | Fedora                  | `sudo dnf install fzf`             |
-| Nix             | NixOS, etc.             | `nix-env -iA nixpkgs.fzf`          |
-| Pacman          | Arch Linux              | `sudo pacman -S fzf`               |
-| pkg             | FreeBSD                 | `pkg install fzf`                  |
-| pkg_add         | OpenBSD                 | `pkg_add fzf`                      |
-| XBPS            | Void Linux              | `sudo xbps-install -S fzf`         |
-| Zypper          | openSUSE                | `sudo zypper install fzf`          |
+| Package Manager | Linux Distribution      | Command                                   |
+| ---             | ---                     | ---                                       |
+| APK             | Alpine Linux            | `sudo apk add fzf`                        |
+| APT             | Debian 9+/Ubuntu 19.10+ | `sudo apt-get install fzf`                |
+| Conda           |                         | `conda install -c conda-forge fzf`        |
+| DNF             | Fedora                  | `sudo dnf install fzf`                    |
+| Guix            | Guix System             | `guix install go-github-com-junegunn-fzf` |
+| Nix             | NixOS, etc.             | `nix-env -iA nixpkgs.fzf`                 |
+| Pacman          | Arch Linux              | `sudo pacman -S fzf`                      |
+| pkg             | FreeBSD                 | `pkg install fzf`                         |
+| pkg_add         | OpenBSD                 | `pkg_add fzf`                             |
+| XBPS            | Void Linux              | `sudo xbps-install -S fzf`                |
+| Zypper          | openSUSE                | `sudo zypper install fzf`                 |
 
 Shell extensions (key bindings and fuzzy auto-completion) and Vim/Neovim
 plugin may or may not be enabled by default depending on the package manager.


### PR DESCRIPTION
See [here](https://hpc.guix.info/package/go-github-com-junegunn-fzf) for the guix package description.

Here is the [source code](https://github.com/guix-mirror/guix/blob/277ac1f242084a7a5048cd07390c04cf277f80c3/gnu/packages/terminals.scm#L731) of the guix package definition.