### PR TITLE
Add " like ' to be exact + case-sensitive search

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -517,6 +517,11 @@ A term that is prefixed by a single-quote character (\fB'\fR) is interpreted as
 an "exact-match" (or "non-fuzzy") term. fzf will search for the exact
 occurrences of the string.
 
+.SS Exact-match + Case-sensitive (double-quoted)
+A term that is prefixed by a double-quote character (\fB"\fR) is interpreted as
+an "exact-match" (or "non-fuzzy") term, including case. fzf will search for the
+exact case-sensitive occurrences of the string.
+
 .SS Anchored-match
 A term can be prefixed by \fB^\fR, or suffixed by \fB$\fR to become an
 anchored-match term. Then fzf will search for the lines that start with or end

--- a/src/pattern.go
+++ b/src/pattern.go
@@ -11,6 +11,7 @@ import (
 
 // fuzzy
 // 'exact
+// "exact+caseSensitive
 // ^prefix-exact
 // suffix-exact$
 // !inverse-exact
@@ -207,6 +208,24 @@ func parseTerms(fuzzy bool, caseMode Case, normalize bool, str string) []termSet
 				typ = termFuzzy
 				text = text[1:]
 			}
+
+		} else if strings.HasPrefix(text, "\"") {
+			// Flip exactness
+			if fuzzy && !inv {
+				typ = termExact
+				// if caseSmart then also caseSensitive
+				if caseMode == CaseSmart {
+					caseSensitive = true
+				}
+				text = text[1:]
+			} else {
+				if caseMode == CaseRespect {
+					caseSensitive = false
+				}
+				typ = termFuzzy
+				text = text[1:]
+			}
+
 		} else if strings.HasPrefix(text, "^") {
 			if typ == termSuffix {
 				typ = termEqual


### PR DESCRIPTION
@junegunn what do you think ?
I use smart case all the time, but sometimes within that I want an exact + case-sensitive search.
This is issue: https://github.com/junegunn/fzf/issues/1960