### PR TITLE
Fixed failure of w:fzf_pushd unlet depending on timing

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -517,7 +517,7 @@ function! s:dopopd()
   if s:fzf_getcwd() ==# w:fzf_pushd.dir && (!&autochdir || w:fzf_pushd.bufname ==# bufname(''))
     execute w:fzf_pushd.command s:escape(w:fzf_pushd.origin)
   endif
-  unlet w:fzf_pushd
+  unlet! w:fzf_pushd
 endfunction
 
 function! s:xterm_launcher()


### PR DESCRIPTION
When restarting fzf from the fzf sink function, depending on the timing, w:fzf_pushd unlet fails and an error occurs.

I changed `unlet` to `unlet!` and the problem was solved.

Error message:
```
Error detected while processing function 140[30]..<SNR>23_callback[28]..<SNR>23_dopopd:
line   24:
E108: No such variable: "w:fzf_pushd"
```

OS: macOS Catalina 10.15.5
Shell: zsh
Editor: neovim (NVIM v0.5.0-nightly-348-g1ca67a73c)

![Kapture 2020-07-24 at 18 21 02](https://user-images.githubusercontent.com/5423775/88378691-748b3200-cddc-11ea-8f7c-d668839e77f7.gif)
