### PR TITLE
Support `**` completion for `fc`

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -260,6 +260,14 @@ _fzf_complete_kill_post() {
   awk '{print $2}'
 }
 
+_fzf_complete_fc() {
+    _fzf_complete --tac --cycle --prompt='fc> ' -- "$@" < <(fc -l -1000)
+}
+
+_fzf_complete_fc_post() {
+    awk '{print $1}'
+}
+
 fzf-completion() {
   local tokens cmd prefix trigger tail matches lbuf d_cmds
   setopt localoptions noshwordsplit noksh_arrays noposixbuiltins


### PR DESCRIPTION
This adds support for quick selecting, editing, and re-running history
commands via `fc`:

    $ fc **<TAB>
    fc>
     1000/1000
      3645  git st
      3644  vim .
      3643  ls -l
      ...

Upon selecting, e.g., "3644 vim.", the command becomes:

    $ fc 3644

Pressing <ENTER> then allows user's $EDITOR being open to edit that
history command, and re-run the editted command.