### PR TITLE
[zsh] Fix regular expression in history search function

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -100,7 +100,7 @@ bindkey '\ec' fzf-cd-widget
 fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
-  selected=( $(fc -rl 1 | perl -ne 'print if !$seen{(/^\s*[0-9]+\s+(.*)/, $1)}++' |
+  selected=( $(fc -rl 1 | perl -ne 'print if !$seen{(/^\s*[0-9]+\**\s+(.*)/, $1)}++' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then


### PR DESCRIPTION
# Summary

Fix the regular expression to capture the command containing asterisk.

# Details

After [this commit](https://github.com/junegunn/fzf/commit/e6d33f77da8cc36786c814f499f6cb3405e8c4c1#diff-961174188263ff616f70beae85ee0763), CTRL-R command history search has failed to display some commands in zsh.

The new method to cut the history number from the each line can't capture the command containing an asterisk(*) mark followed by the number.

If you have command history like an example below, CTRL-R only displays `ls`, `vi`, `man`, `git` and `ssh`... .

`$ fc -rl 1` output example
```shell
123* ls
122* cd
121* date
120 vi
119 man
118* git
117* which
116* emacs
115 ssh
...
```

I have little knowledge about perl, but I guess when it processes the `123* ls` line, capturing failure makes `'undef'` hash key. So the next commands(`cd` and `date`) including asterisks aren't be displayed because perl recognize them as the same commands.

While I don't know why `git` is displayed, my assumption is `undef`s that are not produced in the continuous block are treated differently by perl internals.