### PR TITLE
Feature: Add action preview-half-page-down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ CHANGELOG
 - Added `--preview-window` option for sharp edges (`--preview-window sharp`)
 - Reduced vertical padding around the preview window when `--preview-window
   noborder` is used
+- Added actions for preview window
+    - `preview-half-page-up`
+    - `preview-half-page-down`
 - Vim
     - Popup width and height can be given in absolute integer values
     - Added `fzf#exec()` function for getting the path of fzf executable
@@ -21,9 +24,6 @@ CHANGELOG
 
 0.22.0
 ------
-- Preview window half page movements
-    - `preview-half-page-up`
-    - `preview-half-page-down`
 - Added more options for `--bind`
     - `backward-eof` event
       ```sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ CHANGELOG
 
 0.22.0
 ------
+- Preview window half page movements
+    - `preview-half-page-up`
+    - `preview-half-page-down`
 - Added more options for `--bind`
     - `backward-eof` event
       ```sh

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -718,6 +718,8 @@ A key or an event can be bound to one or more of the following actions.
     \fBpreview-up\fR                \fIshift-up\fR
     \fBpreview-page-down\fR
     \fBpreview-page-up\fR
+    \fBpreview-half-page-down\fR
+    \fBpreview-half-page-up\fR
     \fBprevious-history\fR          (\fIctrl-p\fR on \fB--history\fR)
     \fBprint-query\fR               (print query and exit)
     \fBrefresh-preview\fR

--- a/src/options.go
+++ b/src/options.go
@@ -854,6 +854,10 @@ func parseKeymap(keymap map[int][]action, str string) {
 				appendAction(actPreviewPageUp)
 			case "preview-page-down":
 				appendAction(actPreviewPageDown)
+			case "preview-half-page-up":
+				appendAction(actPreviewHalfPageUp)
+			case "preview-half-page-down":
+				appendAction(actPreviewHalfPageDown)
 			default:
 				t := isExecuteAction(specLower)
 				if t == actIgnore {

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -236,6 +236,8 @@ const (
 	actPreviewDown
 	actPreviewPageUp
 	actPreviewPageDown
+	actPreviewHalfPageUp
+	actPreviewHalfPageDown
 	actPreviousHistory
 	actNextHistory
 	actExecute
@@ -1952,6 +1954,14 @@ func (t *Terminal) Loop() {
 			case actPreviewPageDown:
 				if t.hasPreviewWindow() {
 					scrollPreview(t.pwindow.Height())
+				}
+			case actPreviewHalfPageUp:
+				if t.hasPreviewWindow() {
+					scrollPreview(-t.pwindow.Height()/2)
+				}
+			case actPreviewHalfPageDown:
+				if t.hasPreviewWindow() {
+					scrollPreview(t.pwindow.Height()/2)
 				}
 			case actBeginningOfLine:
 				t.cx = 0


### PR DESCRIPTION
Hi @junegunn,
Awesome command. It took me one week-end to learn but I can jump anywhere.

I would personally like to jump half screen in the preview window (like ctrl-d in vim), actually I map it to  alt-d.
__This PR does not change the default behavior.__

-----

Well it's just like jumping a full screen divided by two but to follow french courtesy, I join a screencast where I 1/2 press alt-d and then ald-u

![fzf_cut1](https://user-images.githubusercontent.com/6123962/90346625-a7e66880-dff8-11ea-98bc-b8ac803f4feb.gif)
