### PR TITLE
Add truecolor support for Windows, if available

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/junegunn/fzf
 
 require (
-	github.com/gdamore/tcell v1.3.0
+	github.com/gdamore/tcell v1.4.0
 	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-runewidth v0.0.8

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
-github.com/gdamore/tcell v1.3.0 h1:r35w0JBADPZCVQijYebl6YMWWtHRqVEGt7kL2eBADRM=
-github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
 github.com/gdamore/tcell v1.4.0 h1:vUnHwJRvcPQa3tzi+0QI4U9JINXYJlOz9yiaiPQ2wMU=
 github.com/gdamore/tcell v1.4.0/go.mod h1:vxEiSDZdW3L+Uhjii9c3375IlDmR05bzxY404ZVSMo0=
 github.com/lucasb-eyer/go-colorful v1.0.2 h1:mCMFu6PgSozg9tDNMMK3g18oJBX7oYGrC09mS6CXfO4=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdk
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell v1.3.0 h1:r35w0JBADPZCVQijYebl6YMWWtHRqVEGt7kL2eBADRM=
 github.com/gdamore/tcell v1.3.0/go.mod h1:Hjvr+Ofd+gLglo7RYKxxnzCBmev3BzsS67MebKS4zMM=
+github.com/gdamore/tcell v1.4.0 h1:vUnHwJRvcPQa3tzi+0QI4U9JINXYJlOz9yiaiPQ2wMU=
+github.com/gdamore/tcell v1.4.0/go.mod h1:vxEiSDZdW3L+Uhjii9c3375IlDmR05bzxY404ZVSMo0=
 github.com/lucasb-eyer/go-colorful v1.0.2 h1:mCMFu6PgSozg9tDNMMK3g18oJBX7oYGrC09mS6CXfO4=
 github.com/lucasb-eyer/go-colorful v1.0.2/go.mod h1:0MS4r+7BZKSJ5mw4/S5MPN+qHFF1fYclkSPilDOKW0s=
 github.com/lucasb-eyer/go-colorful v1.0.3 h1:QIbQXiugsb+q10B+MI+7DI1oQLdmnep86tWFlaaUAac=
@@ -11,6 +13,7 @@ github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHX
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.8 h1:3tS41NlGYSmhhe/8fhGRzc+z3AYCw1Fe1WAyLuujKs0=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-shellwords v1.0.9 h1:eaB5JspOwiKKcHdqcjbfe5lA9cNn/4NRRtddXJCimqk=

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -3,7 +3,6 @@ package tui
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
@@ -124,17 +123,6 @@ func NewLightRenderer(theme *ColorTheme, forceBlack bool, mouse bool, tabstop in
 		upOneLine:     false,
 		maxHeightFunc: maxHeightFunc}
 	return &r
-}
-
-func (r *LightRenderer) defaultTheme() *ColorTheme {
-	if strings.Contains(os.Getenv("TERM"), "256") {
-		return Dark256
-	}
-	colors, err := exec.Command("tput", "colors").Output()
-	if err == nil && atoi(strings.TrimSpace(string(colors)), 16) > 16 {
-		return Dark256
-	}
-	return Default16
 }
 
 func repeat(r rune, times int) string {

--- a/src/tui/light_unix.go
+++ b/src/tui/light_unix.go
@@ -5,6 +5,8 @@ package tui
 import (
 	"fmt"
 	"os"
+	"os/exec"
+	"strings"
 	"syscall"
 
 	"github.com/junegunn/fzf/src/util"
@@ -13,6 +15,17 @@ import (
 
 func IsLightRendererSupported() bool {
 	return true
+}
+
+func (r *LightRenderer) defaultTheme() *ColorTheme {
+	if strings.Contains(os.Getenv("TERM"), "256") {
+		return Dark256
+	}
+	colors, err := exec.Command("tput", "colors").Output()
+	if err == nil && atoi(strings.TrimSpace(string(colors)), 16) > 16 {
+		return Dark256
+	}
+	return Default16
 }
 
 func (r *LightRenderer) fd() int {

--- a/src/tui/light_windows.go
+++ b/src/tui/light_windows.go
@@ -34,6 +34,14 @@ func IsLightRendererSupported() bool {
 	return canSetVt100
 }
 
+func (r *LightRenderer) defaultTheme() *ColorTheme {
+	// the getenv check is borrowed from here: https://github.com/gdamore/tcell/commit/0c473b86d82f68226a142e96cc5a34c5a29b3690#diff-b008fcd5e6934bf31bc3d33bf49f47d8R178:
+	if !IsLightRendererSupported() || os.Getenv("ConEmuPID") != "" {
+		return Default16
+	}
+	return Dark256
+}
+
 func (r *LightRenderer) initPlatform() error {
 	//outHandle := windows.Stdout
 	outHandle, _ := syscall.Open("CONOUT$", syscall.O_RDWR, 0)

--- a/src/tui/light_windows.go
+++ b/src/tui/light_windows.go
@@ -36,7 +36,7 @@ func IsLightRendererSupported() bool {
 
 func (r *LightRenderer) defaultTheme() *ColorTheme {
 	// the getenv check is borrowed from here: https://github.com/gdamore/tcell/commit/0c473b86d82f68226a142e96cc5a34c5a29b3690#diff-b008fcd5e6934bf31bc3d33bf49f47d8R178:
-	if !IsLightRendererSupported() || os.Getenv("ConEmuPID") != "" {
+	if !IsLightRendererSupported() || os.Getenv("ConEmuPID") != "" || os.Getenv("TCELL_TRUECOLOR") == "disable" {
 		return Default16
 	}
 	return Dark256


### PR DESCRIPTION
- Update to latest tcell (1.4.0) which added 24 bit color Windows support
- light renderer under Windows defaults to Dark256, if possible
- Turns off Windows truecolor support if TCELL_TRUECOLOR is set to 'disable'