### PR TITLE
fzf-tmux: Fix escaping of environment variables

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -179,10 +179,10 @@ cleanup() {
 trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
-envs="env TERM=$TERM "
+envs="env - TERM=$TERM"
 [[ "$opt" =~ "-K -E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 $FZF_DEFAULT_OPTS"
-[[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS")"
-[[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs FZF_DEFAULT_COMMAND=$(printf %q "$FZF_DEFAULT_COMMAND")"
+[[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs \"FZF_DEFAULT_OPTS=$FZF_DEFAULT_OPTS\""
+[[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs \"FZF_DEFAULT_COMMAND=$FZF_DEFAULT_COMMAND\""
 
 mkfifo -m o+w $fifo2
 mkfifo -m o+w $fifo3

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -179,7 +179,7 @@ cleanup() {
 trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
-envs="env - TERM=$TERM"
+envs="env - TERM=$TERM PATH=$PATH"
 [[ "$opt" =~ "-K -E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 $FZF_DEFAULT_OPTS"
 [[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs \"FZF_DEFAULT_OPTS=$FZF_DEFAULT_OPTS\""
 [[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs \"FZF_DEFAULT_COMMAND=$FZF_DEFAULT_COMMAND\""


### PR DESCRIPTION
This fixes `fzf-tmux` failing if `FZF_DEFAULT_OPTS` or `FZF_DEFAULT_COMMAND` contain multiple arguments. Example of failing setup:
```
$ export FZF_DEFAULT_OPTS="--tiebreak=index --ansi --border"
$ export FZF_DEFAULT_COMMAND="fd --color always"
$ fzf-tmux
```
This also adds `PATH` to the fzf's environment to help it find the `fd` executable in the above example.