### PR TITLE
Draft: Introduce --print-selected-count

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -208,6 +208,7 @@ type Options struct {
 	Keymap      map[int][]action
 	Preview     previewOpts
 	PrintQuery  bool
+	PrintSelectedCount  bool
 	ReadZero    bool
 	Printer     func(string)
 	PrintSep    string
@@ -264,6 +265,7 @@ func defaultOptions() *Options {
 		Keymap:      make(map[int][]action),
 		Preview:     previewOpts{"", posRight, sizeSpec{50, true}, "", false, false, tui.BorderRounded},
 		PrintQuery:  false,
+		PrintSelectedCount:  false,
 		ReadZero:    false,
 		Printer:     func(str string) { fmt.Println(str) },
 		PrintSep:    "\n",
@@ -1242,6 +1244,10 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.PrintQuery = true
 		case "--no-print-query":
 			opts.PrintQuery = false
+		case "--print-selected-count":
+			opts.PrintSelectedCount = true
+		case "--no-print-selected-count":
+			opts.PrintSelectedCount = false
 		case "--prompt":
 			opts.Prompt = nextString(allArgs, &i, "prompt string required")
 		case "--pointer":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -96,6 +96,7 @@ type Terminal struct {
 	keymap       map[int][]action
 	pressed      string
 	printQuery   bool
+	printSelectedCount   bool
 	history      *History
 	cycle        bool
 	header       []string
@@ -444,6 +445,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		keymap:      opts.Keymap,
 		pressed:     "",
 		printQuery:  opts.PrintQuery,
+		printSelectedCount:  opts.PrintSelectedCount,
 		history:     opts.History,
 		margin:      opts.Margin,
 		unicode:     opts.Unicode,
@@ -573,7 +575,11 @@ func (t *Terminal) output() bool {
 	if len(t.expect) > 0 {
 		t.printer(t.pressed)
 	}
-	found := len(t.selected) > 0
+  selectedCount := len(t.selected)
+  if t.printSelectedCount {
+    t.printer(strconv.Itoa(selectedCount))
+  }
+	found := selectedCount > 0
 	if !found {
 		current := t.currentItem()
 		if current != nil {


### PR DESCRIPTION
Disclaimer: I know this is missing tests, documentation, indentation, etc... which is why I'm opening this as a Draft first. I'd like to know if you are willing to accept this solution before going further with the rest.

#### Problem

Since FZF falls back to the current item even if nothing is selected, there's no way to differentiate between the two situations:

- In multi-mode, one item was selected and FZF exited with it
- No item was selected, but the item under the cursor was chosen as a fallback

https://github.com/junegunn/fzf/blob/0db65c22d369026a0a9af079bfa7e8110e850ec9/src/terminal.go#L577-L578

#### Solution

This MR would introduce a `print-selected-count` option, which is useful to disambiguate, in multi selection mode, if an "expected" binding has exited with an **explicit** multi-selection instead of the aforementioned fallback behavior.

At the same time, this would also be useful for some other use-case which would like to have the result count without extra post-processing.