### PR TITLE
Record cd execution in history

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -87,7 +87,7 @@ fzf-cd-widget() {
     zle redisplay
     return 0
   fi
-  BUFFER=$(printf "cd %q" "$dir")
+  BUFFER="cd ${(q)dir}"
   unset dir # ensure this doesn't end up appearing in prompt expansion
   zle accept-line
   local ret=$?

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -87,7 +87,9 @@ fzf-cd-widget() {
     zle redisplay
     return 0
   fi
-  cd "$dir"
+  BUFFER="cd \"$dir\""
+  zle reset-prompt
+  zle accept-line
   unset dir # ensure this doesn't end up appearing in prompt expansion
   local ret=$?
   zle fzf-redraw-prompt

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -87,7 +87,8 @@ fzf-cd-widget() {
     zle redisplay
     return 0
   fi
-  BUFFER="cd \"$dir\""
+  # cd
+  BUFFER=`printf "cd %q" $dir`
   zle reset-prompt
   zle accept-line
   unset dir # ensure this doesn't end up appearing in prompt expansion

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -87,11 +87,9 @@ fzf-cd-widget() {
     zle redisplay
     return 0
   fi
-  # cd
-  BUFFER=`printf "cd %q" $dir`
-  zle reset-prompt
-  zle accept-line
+  BUFFER=$(printf "cd %q" "$dir")
   unset dir # ensure this doesn't end up appearing in prompt expansion
+  zle accept-line
   local ret=$?
   zle fzf-redraw-prompt
   return $ret


### PR DESCRIPTION
We need directory movement history to look back at work history while reading zsh_history.
This keeps history by accepting the line where 'cd "$dir"' is written.