### PR TITLE
Action accept-1 to accept a single match

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -684,6 +684,7 @@ A key or an event can be bound to one or more of the following actions.
     \fBabort\fR                     \fIctrl-c  ctrl-g  ctrl-q  esc\fR
     \fBaccept\fR                    \fIenter   double-click\fR
     \fBaccept-non-empty\fR          (same as \fBaccept\fR except that it prevents fzf from exiting without selection)
+    \fBaccept-1\fR                  (accepts if there is a single match)
     \fBbackward-char\fR             \fIctrl-b  left\fR
     \fBbackward-delete-char\fR      \fIctrl-h  bspace\fR
     \fBbackward-delete-char/eof\fR  (same as \fBbackward-delete-char\fR except aborts fzf if query is empty)

--- a/src/options.go
+++ b/src/options.go
@@ -758,6 +758,8 @@ func parseKeymap(keymap map[int][]action, str string) {
 				appendAction(actAccept)
 			case "accept-non-empty":
 				appendAction(actAcceptNonEmpty)
+			case "accept-1":
+				appendAction(actAcceptOne)
 			case "print-query":
 				appendAction(actPrintQuery)
 			case "refresh-preview":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -190,6 +190,7 @@ const (
 	actAbort
 	actAccept
 	actAcceptNonEmpty
+	actAcceptOne
 	actBackwardChar
 	actBackwardDeleteChar
 	actBackwardDeleteCharEOF
@@ -2077,6 +2078,11 @@ func (t *Terminal) Loop() {
 				req(reqClose)
 			case actAcceptNonEmpty:
 				if len(t.selected) > 0 || t.merger.Length() > 0 || !t.reading && t.count == 0 {
+					req(reqClose)
+				}
+			case actAcceptOne:
+				if t.merger.Length() == 1 && t.cy < t.merger.Length() {
+					t.selectItem(t.merger.Get(t.cy).item)
 					req(reqClose)
 				}
 			case actClearScreen:


### PR DESCRIPTION
An action **accept-1** to accept the item if it is the last remaining match. I have used this in conjunction with movement actions like this:

`fzf --cycle --bind=tab:accept-1+down --bind=btab:accept-1+up` 

so that I can jump around the results if I need to, but if I narrow in on a single item I can just press tab again to select.

I can't see how you would want to use this with mult-select mode, but I added selectItem in case the user has selected multiple items and has gone on to successfully call this action.

Edit: failing on test_ctrl_t, sorry but I can't figure out why.