### PR TITLE
[fish] Fix parser handling of option-like args

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -127,12 +127,12 @@ function fzf_key_bindings
     else
       set dir (__fzf_get_dir $commandline)
 
-      if [ "$dir" = "." -a (string sub -l 1 $commandline) != '.' ]
+      if [ "$dir" = "." -a (string sub -l 1 -- $commandline) != '.' ]
         # if $dir is "." but commandline is not a relative path, this means no file path found
         set fzf_query $commandline
       else
         # Also remove trailing slash after dir, to "split" input properly
-        set fzf_query (string replace -r "^$dir/?" '' "$commandline")
+        set fzf_query (string replace -r "^$dir/?" -- '' "$commandline")
       end
     end
 
@@ -144,15 +144,15 @@ function fzf_key_bindings
     set dir $argv
 
     # Strip all trailing slashes. Ignore if $dir is root dir (/)
-    if [ (string length $dir) -gt 1 ]
-      set dir (string replace -r '/*$' '' $dir)
+    if [ (string length -- $dir) -gt 1 ]
+      set dir (string replace -r '/*$' -- '' $dir)
     end
 
     # Iteratively check if dir exists and strip tail end of path
     while [ ! -d "$dir" ]
       # If path is absolute, this can keep going until ends up at /
       # If path is relative, this can keep going until entire input is consumed, dirname returns "."
-      set dir (dirname "$dir")
+      set dir (dirname -- "$dir")
     end
 
     echo $dir


### PR DESCRIPTION
Fixes error when option-like args are parsed (e.g. "-1", followed by `c-t` to trigger fzf).