### PR TITLE
Implement streaming preview window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.24.0
+------
+- fzf can render preview window before the command completes
+  ```sh
+  fzf --preview 'sleep 1; for i in $(seq 100); do echo $i; sleep 0.01; done'
+  ```
+
 0.23.1
 ------
 - Added `--preview-window` options for disabling flags

--- a/README.md
+++ b/README.md
@@ -582,9 +582,9 @@ and fzf will warn you about it. To suppress the warning message, we added
 
 ### Preview window
 
-When the `--preview` option is set, fzf automatically starts an external process 
-with the current line as the argument and shows the result in the split window. 
-Your `$SHELL` is used to execute the command with `$SHELL -c COMMAND`. 
+When the `--preview` option is set, fzf automatically starts an external process
+with the current line as the argument and shows the result in the split window.
+Your `$SHELL` is used to execute the command with `$SHELL -c COMMAND`.
 The window can be scrolled using the mouse or custom key bindings.
 
 ```bash
@@ -592,16 +592,8 @@ The window can be scrolled using the mouse or custom key bindings.
 fzf --preview 'cat {}'
 ```
 
-Since the preview window is updated only after the process is complete, it's
-important that the command finishes quickly.
-
-```bash
-# Use head instead of cat so that the command doesn't take too long to finish
-fzf --preview 'head -100 {}'
-```
-
 Preview window supports ANSI colors, so you can use any program that
-syntax-highlights the content of a file, such as 
+syntax-highlights the content of a file, such as
 [Bat](https://github.com/sharkdp/bat) or
 [Highlight](http://www.andre-simon.de/doku/highlight/en/highlight.php):
 

--- a/src/constants.go
+++ b/src/constants.go
@@ -27,6 +27,8 @@ const (
 	initialDelayTac   = 100 * time.Millisecond
 	spinnerDuration   = 100 * time.Millisecond
 	previewCancelWait = 500 * time.Millisecond
+	previewChunkDelay = 100 * time.Millisecond
+	previewDelayed    = 500 * time.Millisecond
 	maxPatternLength  = 300
 	maxMulti          = math.MaxInt32
 

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -704,7 +704,8 @@ func (t *Terminal) resizeWindows() {
 	if t.pwindow != nil {
 		t.pwindow.Close()
 	}
-	t.previewed.filled = false
+	// Reset preview version so that full redraw occurs
+	t.previewed.version = 0
 
 	width := screenWidth - marginInt[1] - marginInt[3]
 	height := screenHeight - marginInt[0] - marginInt[2]

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1219,7 +1219,11 @@ func (t *Terminal) printPreview() {
 		t.pwindow.FinishFill()
 	}
 	if !t.previewer.final || t.previewer.scrollable {
-		offsetRunes, _ := t.trimRight([]rune(fmt.Sprintf("%s%d/%d", t.previewer.spinner, t.previewer.offset+1, numLines)), t.pwindow.Width())
+		offsetString := strings.TrimSpace(t.previewer.spinner)
+		if t.previewer.scrollable {
+			offsetString = fmt.Sprintf("%s%d/%d", t.previewer.spinner, t.previewer.offset+1, numLines)
+		}
+		offsetRunes, _ := t.trimRight([]rune(offsetString), t.pwindow.Width())
 		pos := t.pwindow.Width() - t.displayWidth(offsetRunes)
 		if t.tui.DoesAutoWrap() {
 			pos--

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1790,7 +1790,7 @@ func (t *Terminal) Loop() {
 						go func() {
 							lines := []string{}
 							spinner := makeSpinner(t.unicode)
-							spinnerIndex := 0
+							spinnerIndex := -1 // Delay initial rendering by an extra tick
 							ticker := time.NewTicker(previewChunkDelay)
 							offset := initialOffset
 						Loop:
@@ -1798,10 +1798,12 @@ func (t *Terminal) Loop() {
 								select {
 								case <-ticker.C:
 									if len(lines) > 0 && len(lines) >= initialOffset {
-										spin := spinner[spinnerIndex%len(spinner)]
-										t.reqBox.Set(reqPreviewDisplay, previewResult{version, lines, offset, false, spin + " "})
+										if spinnerIndex >= 0 {
+											spin := spinner[spinnerIndex%len(spinner)]
+											t.reqBox.Set(reqPreviewDisplay, previewResult{version, lines, offset, false, spin + " "})
+											offset = -1
+										}
 										spinnerIndex++
-										offset = -1
 									}
 								case eachLine := <-lineChan:
 									line := eachLine.line

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1208,7 +1208,6 @@ func (t *Terminal) printPreview() {
 				break
 			}
 			if unchanged && lineNo == 0 {
-				t.previewed.filled = true
 				break
 			}
 		}

--- a/src/tui/dummy.go
+++ b/src/tui/dummy.go
@@ -32,10 +32,9 @@ func (r *FullscreenRenderer) Clear()            {}
 func (r *FullscreenRenderer) Refresh()          {}
 func (r *FullscreenRenderer) Close()            {}
 
-func (r *FullscreenRenderer) DoesAutoWrap() bool { return false }
-func (r *FullscreenRenderer) GetChar() Event     { return Event{} }
-func (r *FullscreenRenderer) MaxX() int          { return 0 }
-func (r *FullscreenRenderer) MaxY() int          { return 0 }
+func (r *FullscreenRenderer) GetChar() Event { return Event{} }
+func (r *FullscreenRenderer) MaxX() int      { return 0 }
+func (r *FullscreenRenderer) MaxY() int      { return 0 }
 
 func (r *FullscreenRenderer) RefreshWindows(windows []Window) {}
 

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -624,10 +624,6 @@ func (r *LightRenderer) MaxY() int {
 	return r.height
 }
 
-func (r *LightRenderer) DoesAutoWrap() bool {
-	return false
-}
-
 func (r *LightRenderer) NewWindow(top int, left int, width int, height int, preview bool, borderStyle BorderStyle) Window {
 	w := &LightWindow{
 		renderer: r,

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -166,10 +166,6 @@ func (w *TcellWindow) Y() int {
 	return w.lastY
 }
 
-func (r *FullscreenRenderer) DoesAutoWrap() bool {
-	return false
-}
-
 func (r *FullscreenRenderer) Clear() {
 	_screen.Sync()
 	_screen.Clear()

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -286,7 +286,6 @@ type Renderer interface {
 
 	MaxX() int
 	MaxY() int
-	DoesAutoWrap() bool
 
 	NewWindow(top int, left int, width int, height int, preview bool, borderStyle BorderStyle) Window
 }


### PR DESCRIPTION
Preliminary implementation of the streaming preview window. Please test and report any bugs. Fix #2212.

```sh
# Will start rendering after 200ms, update every 100ms
fzf --preview 'for i in $(seq 100); do echo $i; sleep 0.01; done'

# Should print "Loading preview" message after 500ms
fzf --preview 'sleep 1; for i in $(seq 100); do echo $i; sleep 0.01; done'

# The first line should appear after 200ms
fzf --preview 'date; sleep 2; date'

# Should not render before enough lines for the scroll offset are ready
rg --line-number --no-heading --color=always ^ |
  fzf --delimiter : --ansi --preview-window '+{2}-/2' \
      --preview 'sleep 1; bat --style=numbers --color=always --pager=never --highlight-line={2} {1}'
```

/ping @p-kolacz @edi9999 