### PR TITLE
[bash-completion] Optimize startup + two minor fixes

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -53,7 +53,7 @@ __fzf_orig_completion() {
       comp="${BASH_REMATCH[1]}"
       f="${BASH_REMATCH[2]}"
       cmd="${BASH_REMATCH[3]}"
-      export "_fzf_orig_completion_${cmd//[^A-Za-z0-9_]/_}=${comp} %s ${cmd} #${f}"
+      printf -v "_fzf_orig_completion_${cmd//[^A-Za-z0-9_]/_}" "%s" "${comp} %s ${cmd} #${f}"
       if [[ "$l" = *" -o nospace "* ]] && [[ ! "$__fzf_nospace_commands" = *" $cmd "* ]]; then
         __fzf_nospace_commands="$__fzf_nospace_commands $cmd "
       fi

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -353,7 +353,7 @@ _fzf_setup_completion() {
     return 1
   fi
   shift
-  eval "$(complete -p "$@" 2> /dev/null | grep -v "$fn" | __fzf_orig_completion_filter)"
+  eval "$(complete -p "$@" 2> /dev/null | sed '/-F/!d; / _fzf/d' | __fzf_orig_completion_filter)"
   for cmd in "$@"; do
     case "$kind" in
       dir)   __fzf_defc "$cmd" "$fn" "-o nospace -o dirnames" ;;

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -47,7 +47,7 @@ __fzf_comprun() {
 }
 
 __fzf_orig_completion_filter() {
-  sed 's/^\(.*-F\) *\([^ ]*\).* \([^ ]*\)$/export _fzf_orig_completion_\3="\1 %s \3 #\2"; [[ "\1" = *" -o nospace "* ]] \&\& [[ ! "$__fzf_nospace_commands" = *" \3 "* ]] \&\& __fzf_nospace_commands="$__fzf_nospace_commands \3 ";/' |
+  sed '/ -F/!d; / _fzf/d; s/^\(.*-F\) *\([^ ]*\).* \([^ ]*\)$/export _fzf_orig_completion_\3="\1 %s \3 #\2"; [[ "\1" = *" -o nospace "* ]] \&\& [[ ! "$__fzf_nospace_commands" = *" \3 "* ]] \&\& __fzf_nospace_commands="$__fzf_nospace_commands \3 ";/' |
   awk -F= '{OFS = FS} {gsub(/[^A-Za-z0-9_= ;]/, "_", $1);}1'
 }
 
@@ -307,7 +307,7 @@ a_cmds="
 
 # Preserve existing completion
 eval "$(complete |
-  sed -E '/-F/!d; / _fzf/d; '"/ ($(echo $d_cmds $a_cmds | sed 's/ /|/g; s/+/\\+/g'))$/"'!d' |
+  sed -E "/ ($(echo $d_cmds $a_cmds | sed 's/ /|/g; s/+/\\+/g'))$/"'!d' |
   __fzf_orig_completion_filter)"
 
 if type _completion_loader > /dev/null 2>&1; then
@@ -353,7 +353,7 @@ _fzf_setup_completion() {
     return 1
   fi
   shift
-  eval "$(complete -p "$@" 2> /dev/null | sed '/-F/!d; / _fzf/d' | __fzf_orig_completion_filter)"
+  eval "$(complete -p "$@" 2> /dev/null | __fzf_orig_completion_filter)"
   for cmd in "$@"; do
     case "$kind" in
       dir)   __fzf_defc "$cmd" "$fn" "-o nospace -o dirnames" ;;


### PR DESCRIPTION
Commit d4ad4a25 slowed loading of completion.bash significantly (on my
laptop from 10 ms to 30 ms), then 54891d11 improved that (to 20 ms) but
it still stands out as the heavy part of my .bashrc. Furthermore, an
omission in d4ad4a25 caused meaningless "complete _a" and "complete _v"
completions to be defined.

This pull request fixes that mistake, refactors the code to prevent
making it again, and most importantly optimizes
__fzf_orig_completion_filter so that loading completion.bash is as fast
as it was before d4ad4a25, that is under 10 ms on my laptop.

(I tried not to use any features not present in bash 3.2, but I didn't
test it with bash 3.2. Can someone try this on MacOS please?)