### PR TITLE
[bash-completion] Fix endless loop when completion.bash sourced twice

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -53,6 +53,7 @@ __fzf_orig_completion() {
       comp="${BASH_REMATCH[1]}"
       f="${BASH_REMATCH[2]}"
       cmd="${BASH_REMATCH[3]}"
+      [[ "$f" = _fzf_* ]] && continue
       printf -v "_fzf_orig_completion_${cmd//[^A-Za-z0-9_]/_}" "%s" "${comp} %s ${cmd} #${f}"
       if [[ "$l" = *" -o nospace "* ]] && [[ ! "$__fzf_nospace_commands" = *" $cmd "* ]]; then
         __fzf_nospace_commands="$__fzf_nospace_commands $cmd "


### PR DESCRIPTION
I forgot to add the "not _fzf" check into __fzf_orig_completion, so
invoking it twice would rewrite the _fzf_orig_completion_xxx variables
and then cause an endless loop when completion is requested.

Fixes: https://github.com/junegunn/fzf/pull/2246
Reported-by: @wingpin6