### PR TITLE
[zsh] Reload shared history before searching

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -106,6 +106,9 @@ bindkey '\ec' fzf-cd-widget
 fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
+  if [[ -o sharehistory && -z "$BUFFER" ]]; then
+      fc -R "$HISTFILE"
+  fi
   selected=( $(fc -rl 1 | perl -ne 'print if !$seen{(/^\s*[0-9]+\**\s+(.*)/, $1)}++' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -107,7 +107,7 @@ fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
   if [[ -o sharehistory && -z "$BUFFER" ]]; then
-      fc -R "$HISTFILE"
+    fc -R "$HISTFILE"
   fi
   selected=( $(fc -rl 1 | perl -ne 'print if !$seen{(/^\s*[0-9]+\**\s+(.*)/, $1)}++' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -106,9 +106,7 @@ bindkey '\ec' fzf-cd-widget
 fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
-  if [[ -o sharehistory && -z "$BUFFER" ]]; then
-    fc -RI "$HISTFILE"
-  fi
+  [[ -o sharehistory ]] && fc -RI
   selected=( $(fc -rl 1 | perl -ne 'print if !$seen{(/^\s*[0-9]+\**\s+(.*)/, $1)}++' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -107,7 +107,7 @@ fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
   if [[ -o sharehistory && -z "$BUFFER" ]]; then
-    fc -R "$HISTFILE"
+    fc -RI "$HISTFILE"
   fi
   selected=( $(fc -rl 1 | perl -ne 'print if !$seen{(/^\s*[0-9]+\**\s+(.*)/, $1)}++' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )


### PR DESCRIPTION
When history sharing across shells is enabled (`setopt SHARE_HISTORY`), history written by shell A won't be available in shell B until re-rendering the prompt in B (e.g. by pressing Enter at the prompt).

With this change, C-r will always reload the history file if history sharing is enabled, making the latest history searchable immediately.