### PR TITLE
zsh: declare variable as local before assignment

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -45,6 +45,7 @@ __fsel() {
     -o -type d -print \
     -o -type l -print 2> /dev/null | cut -b3-"}"
   setopt localoptions pipefail no_aliases 2> /dev/null
+  local item
   eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse $FZF_DEFAULT_OPTS $FZF_CTRL_T_OPTS" $(__fzfcmd) -m "$@" | while read item; do
     echo -n "${(q)item} "
   done


### PR DESCRIPTION
Zsh with option `WARN_CREATE_GLOBAL` helps find bugs like this. Basically, builtin `read` assigns to whatever variable it is given, and by default when variable does not exists — it will be created in global scope, but in my case (with option turned on) it produces a warning:

```
__fsel:6: scalar parameter item created globally in function __fsel
```