### PR TITLE
Shellcheck fzf-tmux

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -143,7 +143,7 @@ if [[ ! "$opt" =~ "-K -E" ]] && tmux list-panes -F '#F' | grep -q Z; then
   zoomed_without_popup=1
   original_window=$(tmux display-message -p "#{window_id}")
   tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - '\\;' do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
-  tmux swap-pane -t $tmp_window \; select-window -t $tmp_window
+  tmux swap-pane -t "$tmp_window" \; select-window -t "$tmp_window"
 fi
 
 set -e
@@ -156,7 +156,7 @@ fifo2="${TMPDIR:-/tmp}/fzf-fifo2-$id"
 fifo3="${TMPDIR:-/tmp}/fzf-fifo3-$id"
 tmux_win_opts=( $(tmux show-window-options remain-on-exit \; show-window-options synchronize-panes | sed '/ off/d; s/^/set-window-option /; s/$/ \\;/') )
 cleanup() {
-  \rm -f $argsf $fifo1 $fifo2 $fifo3
+  \rm -f "$argsf" "$fifo1" "$fifo2" "$fifo3"
 
   # Restore tmux window options
   if [[ "${#tmux_win_opts[@]}" -gt 0 ]]; then
@@ -166,9 +166,9 @@ cleanup() {
   # Remove temp window if we were zoomed without popup options
   if [[ -n "$zoomed_without_popup" ]]; then
     tmux display-message -p "#{window_id}" > /dev/null
-    tmux swap-pane -t $original_window \; \
-      select-window -t $original_window \; \
-      kill-window -t $tmp_window \; \
+    tmux swap-pane -t "$original_window" \; \
+      select-window -t "$original_window" \; \
+      kill-window -t "$tmp_window" \; \
       resize-pane -Z
   fi
 
@@ -190,36 +190,36 @@ echo "$envs;" > "$argsf"
 opts=$(printf "%q " "${args[@]}")
 
 pppid=$$
-echo -n "trap 'kill -SIGUSR1 -$pppid' EXIT SIGINT SIGTERM;" >> $argsf
+echo -n "trap 'kill -SIGUSR1 -$pppid' EXIT SIGINT SIGTERM;" >> "$argsf"
 close="; trap - EXIT SIGINT SIGTERM $close"
 
 export TMUX
 TMUX=$(cut -d , -f 1,2 <<< "$TMUX")
-mkfifo -m o+w $fifo2
+mkfifo -m o+w "$fifo2"
 if [[ "$opt" =~ "-K -E" ]]; then
-  cat $fifo2 &
+  cat "$fifo2" &
   if [[ -n "$term" ]] || [[ -t 0 ]]; then
-    cat <<< "\"$fzf\" $opts > $fifo2; out=\$? $close; exit \$out" >> $argsf
+    cat <<< "\"$fzf\" $opts > $fifo2; out=\$? $close; exit \$out" >> "$argsf"
   else
-    mkfifo $fifo1
-    cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; out=\$? $close; exit \$out" >> $argsf
-    cat <&0 > $fifo1 &
+    mkfifo "$fifo1"
+    cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; out=\$? $close; exit \$out" >> "$argsf"
+    cat <&0 > "$fifo1" &
   fi
-  tmux popup -d "$PWD" "${tmux_args[@]}" $opt -R "bash $argsf" > /dev/null 2>&1
+  tmux popup -d "$PWD" "${tmux_args[@]}" "$opt" -R "bash $argsf" > /dev/null 2>&1
   exit $?
 fi
 
-mkfifo -m o+w $fifo3
+mkfifo -m o+w "$fifo3"
 if [[ -n "$term" ]] || [[ -t 0 ]]; then
-  cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf
+  cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> "$argsf"
 else
-  mkfifo $fifo1
-  cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" >> $argsf
-  cat <&0 > $fifo1 &
+  mkfifo "$fifo1"
+  cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" >> "$argsf"
+  cat <&0 > "$fifo1" &
 fi
 tmux set-window-option synchronize-panes off \;\
   set-window-option remain-on-exit off \;\
-  split-window -c "$PWD" $opt "${tmux_args[@]}" "bash -c 'exec -a fzf bash $argsf'" $swap \
+  split-window -c "$PWD" "$opt" "${tmux_args[@]}" "bash -c 'exec -a fzf bash $argsf'" "$swap" \
   > /dev/null 2>&1 || { "$fzf" "${args[@]}"; exit $?; }
-cat $fifo2
-exit "$(cat $fifo3)"
+cat "$fifo2"
+exit "$(cat "$fifo3")"

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -193,7 +193,8 @@ pppid=$$
 echo -n "trap 'kill -SIGUSR1 -$pppid' EXIT SIGINT SIGTERM;" >> $argsf
 close="; trap - EXIT SIGINT SIGTERM $close"
 
-export TMUX=$(cut -d , -f 1,2 <<< "$TMUX")
+export TMUX
+TMUX=$(cut -d , -f 1,2 <<< "$TMUX")
 mkfifo -m o+w $fifo2
 if [[ "$opt" =~ "-K -E" ]]; then
   cat $fifo2 &


### PR DESCRIPTION
Use shellcheck on the `fzf-tmux` bash script.

I left one [warning _(Prefer mapfile or read -a to split command output (or quote to avoid splitting).)_](https://github.com/koalaman/shellcheck/wiki/SC2207) because I don’t know what would be the correct fix.
https://github.com/junegunn/fzf/blob/298342677107f19f2ef7035afcf5302fdf26aa51/bin/fzf-tmux#L157