### PR TITLE
Add alt->, alt-< bindings and "bottom" action.

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -497,6 +497,10 @@ func parseKeyChords(str string, message string) map[int]string {
 			chord = tui.AltSpace
 		case "alt-/":
 			chord = tui.AltSlash
+		case "alt->":
+			chord = tui.AltMore
+		case "alt-<":
+			chord = tui.AltLess
 		case "alt-bs", "alt-bspace":
 			chord = tui.AltBS
 		case "alt-up":
@@ -881,6 +885,8 @@ func parseKeymap(keymap map[int][]action, str string) {
 				appendAction(actUp)
 			case "top":
 				appendAction(actTop)
+			case "bottom":
+				appendAction(actBottom)
 			case "page-up":
 				appendAction(actPageUp)
 			case "page-down":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -266,6 +266,7 @@ const (
 	actExecuteMulti // Deprecated
 	actSigStop
 	actTop
+	actBottom
 	actReload
 )
 
@@ -2366,6 +2367,9 @@ func (t *Terminal) Loop() {
 				}
 			case actTop:
 				t.vset(0)
+				req(reqList)
+			case actBottom:
+				t.vset(t.merger.Length())
 				req(reqList)
 			case actUnixLineDiscard:
 				beof = len(t.input) == 0

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -345,6 +345,10 @@ func (r *LightRenderer) escSequence(sz *int) Event {
 		return Event{AltSpace, 0, nil}
 	case '/':
 		return Event{AltSlash, 0, nil}
+	case '>':
+		return Event{AltMore, 0, nil}
+	case '<':
+		return Event{AltLess, 0, nil}
 	case 'b':
 		return Event{AltB, 0, nil}
 	case 'd':

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -394,6 +394,10 @@ func (r *FullscreenRenderer) GetChar() Event {
 					return Event{AltSpace, 0, nil}
 				case '/':
 					return Event{AltSlash, 0, nil}
+				case '>':
+					return Event{AltMore, 0, nil}
+				case '<':
+					return Event{AltLess, 0, nil}
 				}
 				if r >= 'a' && r <= 'z' {
 					return Event{AltA + int(r) - 'a', 0, nil}

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -91,6 +91,8 @@ const (
 
 	AltSpace
 	AltSlash
+	AltMore
+	AltLess
 	AltBS
 
 	AltUp


### PR DESCRIPTION
I'd like to have emacs-like "go last" and "go to first", which is bound on "alt->" and "alt-<", but as handling for these keys and for "bottom" action, there is PR with it.