### PR TITLE
Leading double-quote for exact match + case sensitive search

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -619,6 +619,11 @@ A term that is prefixed by a single-quote character (\fB'\fR) is interpreted as
 an "exact-match" (or "non-fuzzy") term. fzf will search for the exact
 occurrences of the string.
 
+.SS Exact-match + Case-sensitive (double-quoted)
+A term that is prefixed by a double-quote character (\fB"\fR) is interpreted as
+an "exact-match" (or "non-fuzzy") term, including case. fzf will search for the
+exact case-sensitive occurrences of the string.
+
 .SS Anchored-match
 A term can be prefixed by \fB^\fR, or suffixed by \fB$\fR to become an
 anchored-match term. Then fzf will search for the lines that start with or end

--- a/src/pattern.go
+++ b/src/pattern.go
@@ -11,6 +11,7 @@ import (
 
 // fuzzy
 // 'exact
+// "exact+caseSensitive
 // ^prefix-exact
 // suffix-exact$
 // !inverse-exact
@@ -212,6 +213,24 @@ func parseTerms(fuzzy bool, caseMode Case, normalize bool, str string) []termSet
 				typ = termFuzzy
 				text = text[1:]
 			}
+
+		} else if strings.HasPrefix(text, "\"") {
+			// Flip exactness
+			if fuzzy && !inv {
+				typ = termExact
+				// if caseSmart then also caseSensitive
+				if caseMode == CaseSmart {
+					caseSensitive = true
+				}
+				text = text[1:]
+			} else {
+				if caseMode == CaseRespect {
+					caseSensitive = false
+				}
+				typ = termFuzzy
+				text = text[1:]
+			}
+
 		} else if strings.HasPrefix(text, "^") {
 			if typ == termSuffix {
 				typ = termEqual


### PR DESCRIPTION
Thank you for fzf, it is awesome.
This add a leading double-quote for an exact + case sensitive search.
Much like a leading single-quote, but also this is case sensitive.
thx,
-m