### PR TITLE
Use more explicit int-to-string conversion.

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -449,7 +449,7 @@ func parseKeyChords(str string, message string) map[tui.Event]string {
 		errorExit(message)
 	}
 
-	str = regexp.MustCompile("(?i)(alt-),").ReplaceAllString(str, "$1"+string(escapedComma))
+	str = regexp.MustCompile("(?i)(alt-),").ReplaceAllString(str, "$1"+string([]rune{escapedComma}))
 	tokens := strings.Split(str, ",")
 	if str == "," || strings.HasPrefix(str, ",,") || strings.HasSuffix(str, ",,") || strings.Contains(str, ",,,") {
 		tokens = append(tokens, ",")
@@ -460,7 +460,7 @@ func parseKeyChords(str string, message string) map[tui.Event]string {
 		if len(key) == 0 {
 			continue // ignore
 		}
-		key = strings.ReplaceAll(key, string(escapedComma), ",")
+		key = strings.ReplaceAll(key, string([]rune{escapedComma}), ",")
 		lkey := strings.ToLower(key)
 		add := func(e tui.EventType) {
 			chords[e.AsEvent()] = key


### PR DESCRIPTION
This fixes the following errors with Go 1.15:
```
src/options.go:452:69: conversion from untyped int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
src/options.go:463:33: conversion from untyped int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
```