### PR TITLE
Fixed the issue of "Failed to run fzf --version: [<be><f8><b7><c3><ce>?<a3>^M]"

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -43,7 +43,11 @@ function download {
   $url="https://github.com/junegunn/fzf/releases/download/$version/$file"
   $temp=$env:TMP + "\fzf.zip"
   [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-  (New-Object Net.WebClient).DownloadFile($url, $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$temp"))
+  if ($PSVersionTable.PSVersion.Major -ge 3) {
+    Invoke-WebRequest -Uri $url -OutFile $temp
+  } else {
+    (New-Object Net.WebClient).DownloadFile($url, $ExecutionContext.SessionState.Path.GetUnresolvedProviderPathFromPSPath("$temp"))
+  }
   if ($?) {
     (Microsoft.PowerShell.Archive\Expand-Archive -Path $temp -DestinationPath .); (Remove-Item $temp)
   } else {
@@ -53,7 +57,7 @@ function download {
     $binary_error="Failed to download $file"
     return
   }
-  check_binary >$null
+  echo y | icacls $fzf_base\bin\fzf.exe /grant Administrator:F ; check_binary >$null
 }
 
 download "fzf-$version-windows_amd64.zip"


### PR DESCRIPTION
The first version of install.ps1 was created by me on last pull request on last year. But the original implement of it was missing the feature to set the access right of fzf.exe. It may cause the following issue:
1. Failed to run "fzf --version": ['<be><f8><b7><c3><ce>?<a3>^M']",  Please see issue #2256.
2. Failed to download fzf.exe because it will delete fzf.exe if the return result of "fzf --version" is wrong, see point 1.
Also,  the download progress hasn't been showed at previous implmentation. Ths pull request also fixed this.