### PR TITLE
Update README to upgrade using brew upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ while. Please follow the instruction below depending on the installation
 method used.
 
 - git: `cd ~/.fzf && git pull && ./install`
-- brew: `brew update; brew upgrade`
+- brew: `brew update; brew upgrade fzf`
 - macports: `sudo port upgrade fzf`
 - chocolatey: `choco upgrade fzf`
 - vim-plug: `:PlugUpdate fzf`

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ while. Please follow the instruction below depending on the installation
 method used.
 
 - git: `cd ~/.fzf && git pull && ./install`
-- brew: `brew update; brew reinstall fzf`
+- brew: `brew update; brew upgrade`
 - macports: `sudo port upgrade fzf`
 - chocolatey: `choco upgrade fzf`
 - vim-plug: `:PlugUpdate fzf`


### PR DESCRIPTION
Unless there is some specific reason that FZF needs to be reinstalled, running brew update and then brew upgrade will upgrade all formula, including FZF. Reinstalling does not seem necessary for this use case and makes it seem as if users need to go to the additional step of reinstalling FZF when the usual brew upgrade and then brew install workflow will work correctly to upgrade FZF. However, if I have missed some specific reason why FZF needs to be reinstalled, I'll close this PR accordingly. Open to comments!