### PR TITLE
fix - install --no-update-rc

### DIFF
--- a/install
+++ b/install
@@ -318,7 +318,7 @@ append_line() {
   if [ -n "$lno" ]; then
     echo "    - Already exists: line #$lno"
   else
-    if [ $update -eq 1 ]; then
+    if [ $update = "1" ]; then
       [ -f "$file" ] && echo >> "$file"
       echo "$line" >> "$file"
       echo "    + Added"


### PR DESCRIPTION
I found that the `--no-update-rc` argument on the install script did not skip the update of the rc file.  In further inspection, I found that the `append_line` function converts its arguments to string, so we must use a string comparison for the `$update` variable.