### PR TITLE
Fix zsh completion

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -211,7 +211,6 @@ _fzf_complete() {
   if [ -n "$matches" ]; then
     LBUFFER="$lbuf$matches"
   fi
-  zle reset-prompt
   command rm -f "$fifo"
 }
 
@@ -302,6 +301,7 @@ fzf-completion() {
 
     if eval "type _fzf_complete_${cmd} > /dev/null"; then
       prefix="$prefix" eval _fzf_complete_${cmd} ${(q)lbuf}
+      zle reset-prompt
     elif [ ${d_cmds[(i)$cmd]} -le ${#d_cmds} ]; then
       _fzf_dir_completion "$prefix" "$lbuf"
     else


### PR DESCRIPTION
Fixes #2317.
It seems `zle reset-prompt` doesn't work correctly inside `eval`.