### PR TITLE
Exit terminal mode before closing FZF window in Vim/Neovim

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -792,6 +792,8 @@ function! s:execute_term(dict, command, temps) abort
       call self.switch_back(1)
     else
       if bufnr('') == self.buf
+        " Exit terminal mode first (see neovim#13769)
+        call feedkeys("\<C-\>\<C-n>", 'n')
         " We use close instead of bd! since Vim does not close the split when
         " there's no other listed buffer (nvim +'set nobuflisted')
         close


### PR DESCRIPTION
Mode is global, therefore if we close the FZF window without quitting terminal mode (the current behavior), we enter the next buffer in terminal mode. If the next buffer happens to be a terminal, we are unexpectedly in terminal mode even if we left it in normal mode. This is especially annoying when using the `:Buffers` command of fzf.vim to switch to a terminal buffer.

This behavior is explained in [neovim#13769](https://github.com/neovim/neovim/issues/13769) and this PR fixes [fzf.vim#1216](https://github.com/junegunn/fzf.vim/issues/1216).

This affects only Neovim since it seems that Vim always exits terminal mode (but it's Vim that is not consistent in that case).