### PR TITLE
Update build dep **Go**

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -6,7 +6,7 @@ Build instructions
 
 ### Prerequisites
 
-- Go 1.11 or above
+- Go 1.13 or above
 
 ### Using Makefile
 


### PR DESCRIPTION
Latest Go 1.11 not working

```sh
$ make
src/options.go:463:9: undefined: strings.ReplaceAll
note: module requires Go 1.13make: *** [Makefile:122: target/fzf-linux_amd64] Erro 2
```

