### PR TITLE
fzf.1 clarify that $SHELL is used to run commands

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -570,7 +570,8 @@ Note that most options have the opposite versions with \fB--no-\fR prefix.
 .TP
 .B FZF_DEFAULT_COMMAND
 Default command to use when input is tty. On *nix systems, fzf runs the command
-with \fBsh -c\fR, so make sure that it's POSIX-compliant.
+with \fB$SHELL -c\fR if \fBSHELL\fR is set, otherwise with \fBsh -c\fR, so in
+this case make sure that the command is POSIX-compliant.
 .TP
 .B FZF_DEFAULT_OPTS
 Default options. e.g. \fBexport FZF_DEFAULT_OPTS="--extended --cycle"\fR
@@ -889,6 +890,10 @@ output, you might want to use \fBexecute-silent\fR instead, which silently
 executes the command without the switching. Note that fzf will not be
 responsive until the command is complete. For asynchronous execution, start
 your command as a background process (i.e. appending \fB&\fR).
+
+On *nix systems, fzf runs the command with \fB$SHELL -c\fR if \fBSHELL\fR is
+set, otherwise with \fBsh -c\fR, so in this case make sure that the command is
+POSIX-compliant.
 
 .SS RELOAD INPUT
 


### PR DESCRIPTION
On my GNU/Linux system `$SHELL` --if set-- is used for fzf's `execute` action and preview and default commands.

Consider the following example of a script portability issue due to using `SHELL`:
```sh
SHELL=/usr/bin/fish FZF_DEFAULT_COMMAND="foo() { ls; }; foo" fzf
```

_More typically, `SHELL` is set in a user's shell profile file`._

`$FZF_DEFAULT` will fail because `foo() { ls; }; foo` is invalid fish syntax although it is valid for a POSIX shell.
Setting `SHELL=` above or using `env -u SHELL` will fix the problem.
Deleting `SHELL=...` altogether will leave fzf's command executor undefined--either `$SHELL` or `/bin/sh`.  This is the portability issue I mentioned.  It's unlikely to happen but it can happen.

The portability issue depends on the environment in which a script will run.  Unsetting `SHELL` in fzf's environment is a possible work-around to ensure that fzf will run commands with `/bin/sh`.  However, such work-around prevents propagating `SHELL` to any command started by fzf, which might not be desirable for some scripts.  