### PR TITLE
[completion] Default behaviour to use fd if present else use find.

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,19 +413,6 @@ export FZF_COMPLETION_TRIGGER='~~'
 # Options to fzf command
 export FZF_COMPLETION_OPTS='+c -x'
 
-# Use fd (https://github.com/sharkdp/fd) instead of the default find
-# command for listing path candidates.
-# - The first argument to the function ($1) is the base path to start traversal
-# - See the source code (completion.{bash,zsh}) for the details.
-_fzf_compgen_path() {
-  fd --hidden --follow --exclude ".git" . "$1"
-}
-
-# Use fd to generate the list for directory completion
-_fzf_compgen_dir() {
-  fd --type d --hidden --follow --exclude ".git" . "$1"
-}
-
 # (EXPERIMENTAL) Advanced customization of fzf options via _fzf_comprun function
 # - The first argument to the function is the name of the command.
 # - You should make sure to pass the rest of the arguments to fzf.

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -80,17 +80,23 @@ fi
 if ! declare -f _fzf_compgen_path > /dev/null; then
   _fzf_compgen_path() {
     echo "$1"
-    command find -L "$1" \
-      -name .git -prune -o -name .hg -prune -o -name .svn -prune -o \( -type d -o -type f -o -type l \) \
-      -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    command fd --hidden --follow --exclude ".git" . "$1" 2>/dev/null ||
+    {
+      command find -L "$1" \
+        -name .git -prune -o -name .hg -prune -o -name .svn -prune -o \( -type d -o -type f -o -type l \) \
+        -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    }
   }
 fi
 
 if ! declare -f _fzf_compgen_dir > /dev/null; then
   _fzf_compgen_dir() {
-    command find -L "$1" \
-      -name .git -prune -o -name .hg -prune -o -name .svn -prune -o -type d \
-      -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    command   fd --type d --hidden --follow --exclude ".git" . "$1" 2>/dev/null ||
+    {
+      command find -L "$1" \
+        -name .git -prune -o -name .hg -prune -o -name .svn -prune -o -type d \
+        -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    }
   }
 fi
 


### PR DESCRIPTION
Since using `fd` along with `fzf` is very common choice,  checking in `completion.{ba, z}sh` if `fd` is present. If yes then use it by default or else use the default `find` command.