### PR TITLE
[vim] Use keepjump (again)

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -782,7 +782,7 @@ function! s:execute_term(dict, command, temps) abort
   function! fzf.switch_back(inplace)
     if a:inplace && bufnr('') == self.buf
       if bufexists(self.pbuf)
-        execute 'keepalt b' self.pbuf
+        execute 'keepalt keepjump b' self.pbuf
       endif
       " No other listed buffer
       if bufnr('') == self.buf

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -782,7 +782,7 @@ function! s:execute_term(dict, command, temps) abort
   function! fzf.switch_back(inplace)
     if a:inplace && bufnr('') == self.buf
       if bufexists(self.pbuf)
-        execute 'keepalt keepjump b' self.pbuf
+        execute 'keepalt keepjumps b' self.pbuf
       endif
       " No other listed buffer
       if bufnr('') == self.buf


### PR DESCRIPTION
Note that this is an exact duplicate of #1621, I ran into the issue again but couldn't reopen as I've since deleted the fork.

This time I have reliable steps to reproduce:

1. Create a directory containing three files, `a`, `b` and `c`.
2. Run `vim -Nu <(curl https://gist.githubusercontent.com/junegunn/6936bf79fedd3a079aeb1dd2f3c81ef5/raw)`.
3. Execute `let g:fzf_layout = { 'window': 'enew' }`.
4. Execute `clearjumps`. Output of `jumps` is now an empty jump list. This is correct.
5. Execute `FZF` and select file `b`. Output of `jumps` now contains one entry, the position in `a`. This is still correct.
6. Execute `FZF` and select file `c`. Output of `jumps` now contains two entries, the position in `a` and the position in `b`. However, the entry in `a` has index `3`, and the entry in `b` has index 1 -- entry `2` is missing (it is presumably inside the now hidden FZF buffer).
 
```
:jumps
 jump line  col file/text
   3     1    0 a
   1     1    0 b
>
```

If you now start navigating the jump list, it gets really messed up once you try to jump to index 2.

Adding `keepjump` to the switch back function fixes this issue.