### PR TITLE
Fix feedkeys() side effects

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -803,6 +803,8 @@ function! s:execute_term(dict, command, temps) abort
         " We use close instead of bd! since Vim does not close the split when
         " there's no other listed buffer (nvim +'set nobuflisted')
         close
+        " avoids side effects caused by previous feedkeys()
+        call feedkeys('', 'x')
       endif
       silent! execute 'tabnext' self.ppos.tab
       silent! execute self.ppos.win.'wincmd w'


### PR DESCRIPTION
See #2352
See https://github.com/junegunn/fzf.vim/issues/1216

Fixes side effects cleanely.

All of those work after this fix:

- ```:Buffers```
- ```fzf#run()``` calling ```fzf#run()```
- RPC calls in the sink function 