### PR TITLE
[vim] Make `winblend` for popup window configurable

### DIFF
--- a/README-VIM.md
+++ b/README-VIM.md
@@ -412,6 +412,7 @@ The latest versions of Vim and Neovim include builtin terminal emulator
 " - yoffset [float default 0.5 range [0 ~ 1]]
 " - border [string default 'rounded']: Border style
 "   - 'rounded' / 'sharp' / 'horizontal' / 'vertical' / 'top' / 'bottom' / 'left' / 'right'
+" - winblend [int default 0 range[0 ~ 100]]: Transparency of floating window  (Neovim only)
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
 ```
 

--- a/doc/fzf.txt
+++ b/doc/fzf.txt
@@ -425,6 +425,7 @@ Starting fzf in a popup window~
     " - yoffset [float default 0.5 range [0 ~ 1]]
     " - border [string default 'rounded']: Border style
     "   - 'rounded' / 'sharp' / 'horizontal' / 'vertical' / 'top' / 'bottom' / 'left' / 'right'
+    " - winblend [int default 0 range[0 ~ 100]]: Transparency of floating window  (Neovim only)
     let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
 <
 Alternatively, you can make fzf open in a tmux popup window (requires tmux 3.2

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -915,13 +915,11 @@ if has('nvim')
   function s:create_popup(hl, opts) abort
     let buf = nvim_create_buf(v:false, v:true)
     let opts = extend({'relative': 'editor', 'style': 'minimal'}, a:opts)
-    let border = has_key(opts, 'border') ? remove(opts, 'border') : []
+    let winblend = has_key(opts, 'winblend') ? remove(opts, 'winblend') : 0
     let win = nvim_open_win(buf, v:true, opts)
     call setwinvar(win, '&winhighlight', 'NormalFloat:'..a:hl)
     call setwinvar(win, '&colorcolumn', '')
-    if !empty(border)
-      call nvim_buf_set_lines(buf, 0, -1, v:true, border)
-    endif
+    call nvim_win_set_option(win, "winblend", winblend)
     return buf
   endfunction
 else
@@ -952,8 +950,11 @@ function! s:popup(opts) abort
   let row += !has('nvim')
   let col += !has('nvim')
 
+  " Clamp the winblend (nvim only)
+  let winblend = has('nvim') ? min([max([0, get(a:opts, 'winblend', 0)]), 100]) : 0
+
   call s:create_popup('Normal', {
-    \ 'row': row, 'col': col, 'width': width, 'height': height
+    \ 'row': row, 'col': col, 'width': width, 'height': height, 'winblend': winblend
   \ })
 endfunction
 


### PR DESCRIPTION
## Make Neovim floating window's transparency configurable

```vim
let g:fzf_layout = {
  \ 'window': {
    \ 'width': 0.9,
    \ 'height': 0.95,
    \ 'border': 'rounded',
    \ 'winblend': 30,
  \ },
\ }
```

![image](https://user-images.githubusercontent.com/6816040/109027091-c776f000-7703-11eb-8353-5bdc446219e8.png)

I personally think `winblend` is one of factors that make Neovim UI components rich,
so this PR just makes that property configurable via `g:fzf_layout`.

## Other minor fix

I noticed that some `border` related sources codes have been left in Neovim's `create_popup` function.
I think that from [this commit](https://github.com/junegunn/fzf/commit/2e8e63fb0b3b62e89472eebe9e86578598e1a541), `border` had been fully controlled by `fzf` binary itself, and script-local `s:create_popup` function is never been called against `opts` with `border` property.