### PR TITLE
[vim] Remove unnecessary `border` management in nvim floating window

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -915,13 +915,9 @@ if has('nvim')
   function s:create_popup(hl, opts) abort
     let buf = nvim_create_buf(v:false, v:true)
     let opts = extend({'relative': 'editor', 'style': 'minimal'}, a:opts)
-    let border = has_key(opts, 'border') ? remove(opts, 'border') : []
     let win = nvim_open_win(buf, v:true, opts)
     call setwinvar(win, '&winhighlight', 'NormalFloat:'..a:hl)
     call setwinvar(win, '&colorcolumn', '')
-    if !empty(border)
-      call nvim_buf_set_lines(buf, 0, -1, v:true, border)
-    endif
     return buf
   endfunction
 else


### PR DESCRIPTION
I noticed that some `border` related sources codes have been left in Neovim's `create_popup` function.
I think that from [this commit](https://github.com/junegunn/fzf/commit/2e8e63fb0b3b62e89472eebe9e86578598e1a541), `border` had been fully controlled by `fzf` binary itself, and script-local `s:create_popup` function is never been called against `opts` with `border` property.