### PR TITLE
fish key bindings: make fzf-file-widget work with -option= prefix

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -123,7 +123,7 @@ function fzf_key_bindings
 
     # strip -option= from token if present
     set -l prefix (string match -r -- '^-[^\s=]+=' $commandline)
-    set commandline (string replace -r -- "^$prefix" '' $commandline)
+    set commandline (string replace -- "$prefix" '' $commandline)
 
     # eval is used to do shell expansion on paths
     eval set commandline $commandline

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -76,6 +76,7 @@ function fzf_key_bindings
     set -l commandline (__fzf_parse_commandline)
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
+    set -l prefix $commandline[3]
 
     test -n "$FZF_ALT_C_COMMAND"; or set -l FZF_ALT_C_COMMAND "
     command find -L \$dir -mindepth 1 \\( -path \$dir'*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' \\) -prune \
@@ -90,6 +91,7 @@ function fzf_key_bindings
 
         # Remove last token from commandline.
         commandline -t ""
+        commandline -it -- $prefix
       end
     end
 

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -20,6 +20,7 @@ function fzf_key_bindings
     set -l commandline (__fzf_parse_commandline)
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
+    set -l prefix $commandline[3]
 
     # "-path \$dir'*/\\.*'" matches hidden files/folders inside $dir but not
     # $dir itself, even if hidden.
@@ -42,6 +43,7 @@ function fzf_key_bindings
       commandline -t ""
     end
     for i in $result
+      commandline -it -- $prefix
       commandline -it -- (string escape $i)
       commandline -it -- ' '
     end
@@ -116,9 +118,15 @@ function fzf_key_bindings
     bind -M insert \ec fzf-cd-widget
   end
 
-  function __fzf_parse_commandline -d 'Parse the current command line token and return split of existing filepath and rest of token'
+  function __fzf_parse_commandline -d 'Parse the current command line token and return split of existing filepath, fzf query, and optional -option= prefix'
+    set -l commandline (commandline -t)
+
+    # strip -option= from token if present
+    set -l prefix (string match -r -- '^-[^\s=]+=' $commandline)
+    set commandline (string replace -r -- "^$prefix" '' $commandline)
+
     # eval is used to do shell expansion on paths
-    set -l commandline (eval "printf '%s' "(commandline -t))
+    eval set commandline $commandline
 
     if [ -z $commandline ]
       # Default to current directory with no --query
@@ -138,6 +146,7 @@ function fzf_key_bindings
 
     echo $dir
     echo $fzf_query
+    echo $prefix
   end
 
   function __fzf_get_dir -d 'Find the longest existing filepath from input string'


### PR DESCRIPTION
Currently, when having a commandline like `grep --exclude-from=~/Desktop`  using the `fzf-file-widget` does not work since it takes `--exclude-from=` as part of the path.

This PR makes the widget under fish shell work even when the path is prefixed with an option.