### PR TITLE
Use FZF_DEFAULT_COMMAND in more places

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -14,10 +14,15 @@
 # Key bindings
 # ------------
 __fzf_select__() {
-  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
-    -o -type f -print \
-    -o -type d -print \
-    -o -type l -print 2> /dev/null | cut -b3-"}"
+  local cmd
+  if [ -n "${FZF_DEFAULT_COMMAND}" ]; then
+    cmd="${FZF_CTRL_T_COMMAND:-${FZF_DEFAULT_COMMAND}}"
+  else
+    cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+      -o -type f -print \
+      -o -type d -print \
+      -o -type l -print 2> /dev/null | cut -b3-"}"
+  fi
   eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS $FZF_CTRL_T_OPTS" $(__fzfcmd) -m "$@" | while read -r item; do
     printf '%q ' "$item"
   done
@@ -39,8 +44,12 @@ fzf-file-widget() {
 
 __fzf_cd__() {
   local cmd dir
-  cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
-    -o -type d -print 2> /dev/null | cut -b3-"}"
+  if [ -n "${FZF_DEFAULT_COMMAND}" ]; then
+    cmd="${FZF_ALT_C_COMMAND:-${FZF_DEFAULT_COMMAND}}"
+  else
+    cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+      -o -type d -print 2> /dev/null | cut -b3-"}"
+  fi
   dir=$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m) && printf 'cd %q' "$dir"
 }
 


### PR DESCRIPTION
The CTRL-T and ALT-C bindings were ignoring the FZF_DEFAULT_COMMAND when it was set. This left users wondering why "ignored" files/directories were still showing up in searches with these bindings.