### PR TITLE
Use the first FZF found in the path

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -169,10 +169,10 @@ endfunction
 let s:checked = {}
 function! fzf#exec(...)
   if !exists('s:exec')
-    if executable(s:fzf_go)
-      let s:exec = s:fzf_go
-    elseif executable('fzf')
+    if executable('fzf')
       let s:exec = 'fzf'
+    elseif executable(s:fzf_go)
+      let s:exec = s:fzf_go
     elseif input('fzf executable not found. Download binary? (y/n) ') =~? '^y'
       redraw
       call fzf#install()


### PR DESCRIPTION
I think it makes more sense to respect the user's path rather than look at a
hardcoded path first. This causes issues, for example, on ubuntu if you have
fzf installed with `apt` and a newer version of fzf installed in your path (I
used the install script provided by fzf).

This changes the order so the first fzf found in the path is used for the
command.
