### PR TITLE
Clarify installation of fuzzy shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,29 @@ More tips can be found on [the wiki page](https://github.com/junegunn/fzf/wiki/C
 Fuzzy completion for bash and zsh
 ---------------------------------
 
+Hook script to enable fuzzy completion by fzf for bash, zsh, and fish are
+included in this source under `shell/` and may be installed to the system under
+`/usr/share/doc/fzf/examples/` by the distribution (for Debian/Ubuntu/..).
+
+For bash, you should enable fuzzy completion by adding followings at the end of
+'~/.bashrc`.
+
+```sh
+FZF_KEYBINDINGS_PATH=/usr/share/doc/fzf/examples/key-bindings.bash
+if [ -f $FZF_KEYBINDINGS_PATH ]; then
+  . $FZF_KEYBINDINGS_PATH
+fi
+FZF_COMPLETION_PATH=/usr/share/doc/fzf/examples/completion.bash
+if [ -f $FZF_COMPLETION_PATH ]; then
+  . $FZF_COMPLETION_PATH
+fi
+```
+
+Please note this must be sourced after sourcing the bash-completion package
+scripts. Otherwise, setting from bash-completion package will override the fzf
+settings.
+
+
 #### Files and directories
 
 Fuzzy completion for files and directories can be triggered if the word before


### PR DESCRIPTION
Since current complete setting may be overridden by bash-completion
scripts, it should be good idea to remind people on this facts.

(Yes, it is obvious after checking how this was implemented.  But
README.md lacks documenting this first step tutorial information while
mentioning all sorts of corner case customization tricks.)

Signed-off-by: Osamu Aoki <osamu@debian.org>