### PR TITLE
Add deselect-last option

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -800,6 +800,7 @@ A key or an event can be bound to one or more of the following actions.
     \fBdelete-char/eof\fR           \fIctrl-d\fR (same as \fBdelete-char\fR except aborts fzf if query is empty)
     \fBdeselect\fR
     \fBdeselect-all\fR              (deselect all matches)
+    \fBdeselect-last\fR             (deselect the last match)
     \fBdisable-search\fR            (disable search functionality)
     \fBdown\fR                      \fIctrl-j  ctrl-n  down\fR
     \fBenable-search\fR             (enable search functionality)

--- a/src/options.go
+++ b/src/options.go
@@ -842,6 +842,8 @@ func parseKeymap(keymap map[tui.Event][]action, str string) {
 				appendAction(actDeleteCharEOF)
 			case "deselect":
 				appendAction(actDeselect)
+			case "deselect-last":
+				appendAction(actDeselectLast)
 			case "end-of-line":
 				appendAction(actEndOfLine)
 			case "cancel":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -282,6 +282,7 @@ const (
 	actEnableSearch
 	actSelect
 	actDeselect
+	actDeselectLast
 )
 
 type placeholderFlags struct {
@@ -2393,6 +2394,14 @@ func (t *Terminal) Loop() {
 			case actDeselect:
 				current := t.currentItem()
 				if t.multi > 0 && current != nil && t.deselectItemChanged(current) {
+					req(reqList, reqInfo)
+				}
+			case actDeselectLast:
+				if t.multi > 0 {
+					len_selected := int32(len(t.selected))
+					if len_selected > 0 {
+						t.deselectItem(t.sortSelected()[len_selected-1].item)
+					}
 					req(reqList, reqInfo)
 				}
 			case actToggle:

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -1912,6 +1912,29 @@ class TestGoFZF < TestBase
     tmux.until { |lines| assert_equal 2, lines.select_count }
   end
 
+  def test_deselect_last
+    tmux.send_keys "seq 3 | #{FZF} --multi --bind ctrl-k:deselect-last", :Enter
+    tmux.until { |lines| assert_equal 3, lines.match_count }
+    tmux.send_keys :Tab
+    tmux.until { |lines| assert_equal 1, lines.select_count }
+    tmux.send_keys :Up
+    tmux.until { |lines| assert_equal 1, lines.select_count }
+    tmux.send_keys :Tab
+    tmux.until { |lines| assert_equal 2, lines.select_count }
+    tmux.send_keys 'C-k'
+    tmux.until { |lines| assert_equal 1, lines.select_count }
+    tmux.send_keys 'C-k'
+    tmux.until { |lines| assert_equal 0, lines.select_count }
+    tmux.send_keys 'C-k'
+    tmux.until { |lines| assert_equal 0, lines.select_count }
+    tmux.send_keys 'C-k'
+    tmux.until { |lines| assert_equal 0, lines.select_count }
+    tmux.send_keys :Tab
+    tmux.until { |lines| assert_equal 1, lines.select_count }
+    tmux.send_keys 'C-k'
+    tmux.until { |lines| assert_equal 0, lines.select_count }
+  end
+
   def test_interrupt_execute
     tmux.send_keys "seq 100 | #{FZF} --bind 'ctrl-l:execute:echo executing {}; sleep 100'", :Enter
     tmux.until { |lines| assert_equal 100, lines.item_count }


### PR DESCRIPTION
I found myself really wanting a way to deselect the last-selected selection even if the query has been cleared/changed, and couldn't for the life of me come up with any way to hack it together given the commands in place. 

`deselect-last` simply deselects the last-selected selection, and repeated uses will pop back through the selections until there are none left, at which point it's a no-op.

Added the command, updated the docs, and added a test. Please just let me know if there's anything else I need to change here, or if anything doesn't look idiomatic (new to Go).

Local test run:
```[Sat 21/04/03 21:39 CST][pts/11]
<glenn@ronnie:~/MrAwesome/fzf>
$ make
GOARCH=amd64 go build -a -ldflags "-s -w -X main.version=0.26.0 -X main.revision=3318bae" -tags "" -o target/fzf-linux_amd64
[Sat 21/04/03 21:39 CST][pts/11]
<glenn@ronnie:~/MrAwesome/fzf>
$ cp target/fzf-linux_amd64 bin/fzf
[Sat 21/04/03 21:39 CST][pts/11]
<glenn@ronnie:~/MrAwesome/fzf>
$ ruby test/test_go.rb --name test_deselect_last
Run options: --name test_deselect_last --seed 31866
<snip>
Finished in 0.172537s, 5.7959 runs/s, 63.7544 assertions/s.

1 runs, 11 assertions, 0 failures, 0 errors, 0 skips
```