### PR TITLE
Support relatively positioned windows in Neovim

### DIFF
--- a/README-VIM.md
+++ b/README-VIM.md
@@ -127,11 +127,14 @@ let g:fzf_action = {
   \ 'ctrl-v': 'vsplit' }
 
 " Default fzf layout
-" - Popup window (centered in editor)
+" - Popup window (center of the screen)
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
 
-" - Popup window (centered in current window)
+" - Popup window (center of the current window)
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true } }
+
+" - Popup window (anchored to the bottom of the current window)
+let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true, 'yoffset': 1.0 } }
 
 " - down / up / left / right
 let g:fzf_layout = { 'down': '40%' }
@@ -305,6 +308,7 @@ following options are allowed:
 - Optional:
     - `yoffset` [float default 0.5 range [0 ~ 1]]
     - `xoffset` [float default 0.5 range [0 ~ 1]]
+    - `relative` [boolean default v:false]
     - `border` [string default `rounded`]: Border style
         - `rounded` / `sharp` / `horizontal` / `vertical` / `top` / `bottom` / `left` / `right` / `no[ne]`
 
@@ -413,6 +417,7 @@ The latest versions of Vim and Neovim include builtin terminal emulator
 " Optional:
 " - xoffset [float default 0.5 range [0 ~ 1]]
 " - yoffset [float default 0.5 range [0 ~ 1]]
+" - relative [boolean default v:false]
 " - border [string default 'rounded']: Border style
 "   - 'rounded' / 'sharp' / 'horizontal' / 'vertical' / 'top' / 'bottom' / 'left' / 'right'
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }

--- a/README-VIM.md
+++ b/README-VIM.md
@@ -131,7 +131,7 @@ let g:fzf_action = {
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
 
 " - Popup window (centered in current window)
-let g:fzf_layout = { 'window': { 'relative': 'win', 'width': 0.9, 'height': 0.6 } }
+let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true } }
 
 " - down / up / left / right
 let g:fzf_layout = { 'down': '40%' }

--- a/README-VIM.md
+++ b/README-VIM.md
@@ -127,8 +127,11 @@ let g:fzf_action = {
   \ 'ctrl-v': 'vsplit' }
 
 " Default fzf layout
-" - Popup window
+" - Popup window (centered in editor)
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
+
+" - Popup window (centered in current window)
+let g:fzf_layout = { 'window': { 'relative': 'win', 'width': 0.9, 'height': 0.6 } }
 
 " - down / up / left / right
 let g:fzf_layout = { 'down': '40%' }

--- a/doc/fzf.txt
+++ b/doc/fzf.txt
@@ -1,4 +1,4 @@
-fzf.txt	fzf	Last change: January 3 2021
+fzf.txt	fzf	Last change: April 17 2021
 FZF - TABLE OF CONTENTS                                            *fzf* *fzf-toc*
 ==============================================================================
 
@@ -155,8 +155,14 @@ Examples~
       \ 'ctrl-v': 'vsplit' }
 
     " Default fzf layout
-    " - Popup window
+    " - Popup window (center of the screen)
     let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
+
+    " - Popup window (center of the current window)
+    let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true } }
+
+    " - Popup window (anchored to the bottom of the current window)
+    let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true, 'yoffset': 1.0 } }
 
     " - down / up / left / right
     let g:fzf_layout = { 'down': '40%' }
@@ -318,6 +324,7 @@ following options are allowed:
  - Optional:
    - `yoffset` [float default 0.5 range [0 ~ 1]]
    - `xoffset` [float default 0.5 range [0 ~ 1]]
+   - `relative` [boolean default v:false]
    - `border` [string default `rounded`]: Border style
      - `rounded` / `sharp` / `horizontal` / `vertical` / `top` / `bottom` / `left` / `right` / `no[ne]`
 
@@ -372,7 +379,7 @@ last `fullscreen` argument of `fzf#wrap` (see :help <bang>).
 Our `:LS` command will be much more useful if we can pass a directory argument
 to it, so that something like `:LS /tmp` is possible.
 >
-    command! -bang -complete=dir -nargs=* LS
+    command! -bang -complete=dir -nargs=? LS
         \ call fzf#run(fzf#wrap({'source': 'ls', 'dir': <q-args>}, <bang>0))
 <
 Lastly, if you have enabled `g:fzf_history_dir`, you might want to assign a
@@ -380,7 +387,7 @@ unique name to our command and pass it as the first argument to `fzf#wrap`.
 >
     " The query history for this command will be stored as 'ls' inside g:fzf_history_dir.
     " The name is ignored if g:fzf_history_dir is not defined.
-    command! -bang -complete=dir -nargs=* LS
+    command! -bang -complete=dir -nargs=? LS
         \ call fzf#run(fzf#wrap('ls', {'source': 'ls', 'dir': <q-args>}, <bang>0))
 <
 
@@ -423,6 +430,7 @@ Starting fzf in a popup window~
     " Optional:
     " - xoffset [float default 0.5 range [0 ~ 1]]
     " - yoffset [float default 0.5 range [0 ~ 1]]
+    " - relative [boolean default v:false]
     " - border [string default 'rounded']: Border style
     "   - 'rounded' / 'sharp' / 'horizontal' / 'vertical' / 'top' / 'bottom' / 'left' / 'right'
     let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -972,21 +972,24 @@ else
 endif
 
 function! s:popup(opts) abort
+  let columns = has_key(a:opts, 'relative') ? winwidth(0) : &columns
+  let lines = has_key(a:opts, 'relative') ? winheight(0) : &lines
+
   " Size and position
-  let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(&columns * a:opts.width)]), &columns])
-  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(&lines * a:opts.height)]), &lines - has('nvim')])
-  let row = float2nr(get(a:opts, 'yoffset', 0.5) * (&lines - height))
-  let col = float2nr(get(a:opts, 'xoffset', 0.5) * (&columns - width))
+  let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(&columns * a:opts.width)]), columns])
+  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(&lines * a:opts.height)]), lines - has('nvim')])
+  let row = float2nr(get(a:opts, 'yoffset', 0.5) * (lines - height))
+  let col = float2nr(get(a:opts, 'xoffset', 0.5) * (columns - width))
 
   " Managing the differences
-  let row = min([max([0, row]), &lines - has('nvim') - height])
-  let col = min([max([0, col]), &columns - width])
+  let row = min([max([0, row]), lines - has('nvim') - height])
+  let col = min([max([0, col]), columns - width])
   let row += !has('nvim')
   let col += !has('nvim')
 
-  call s:create_popup('Normal', {
+  call s:create_popup('Normal', extend(a:opts, {
     \ 'row': row, 'col': col, 'width': width, 'height': height
-  \ })
+  \ }))
 endfunction
 
 let s:default_action = {

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -987,7 +987,7 @@ function! s:popup(opts) abort
   let row += !has('nvim')
   let col += !has('nvim')
 
-  call s:create_popup('Normal', extend(a:opts, {
+  call s:create_popup('Normal', extend(copy(a:opts), {
     \ 'row': row, 'col': col, 'width': width, 'height': height
   \ }))
 endfunction

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -977,16 +977,21 @@ function! s:popup(opts) abort
   " Remove known FZF options
   let xoffset = get(a:opts, 'xoffset', 0.5)
   let yoffset = get(a:opts, 'yoffset', 0.5)
+  let relative = index([1, 'win'], get(a:opts, 'relative', '')) >= 0
 
-  for key in ['xoffset', 'yoffset', 'border', 'highlight']
+  for key in ['xoffset', 'yoffset', 'border', 'highlight', 'relative']
     if has_key(a:opts, key)
       call remove(create_opts, key)
     endif
   endfor
 
+  if relative && has('nvim')
+    let create_opts.relative = 'win'
+  endif
+
   " Use current window size for positioning relatively positioned popups
-  let columns = has_key(a:opts, 'relative') ? winwidth(0) : &columns
-  let lines = has_key(a:opts, 'relative') ? winheight(0) : &lines
+  let columns = relative ? winwidth(0) : &columns
+  let lines = relative ? winheight(0) : &lines
 
   " Size and position
   let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(columns * a:opts.width)]), columns])

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -972,14 +972,35 @@ else
 endif
 
 function! s:popup(opts) abort
+  let create_opts = copy(a:opts)
+
+  " Remove known FZF options
+  let xoffset = 0.5
+  let yoffset = 0.5
+
+  if has_key(a:opts, 'xoffset')
+    let xoffset = a:opts.xoffset
+    call remove(create_opts, 'xoffset')
+  endif
+
+  if has_key(a:opts, 'yoffset')
+    let yoffset = a:opts.yoffset
+    call remove(create_opts, 'yoffset')
+  endif
+
+  if has_key(a:opts, 'border')
+    call remove(create_opts, 'border')
+  endif
+
+  " Use current window size for positioning relatively positioned popups
   let columns = has_key(a:opts, 'relative') ? winwidth(0) : &columns
   let lines = has_key(a:opts, 'relative') ? winheight(0) : &lines
 
   " Size and position
   let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(&columns * a:opts.width)]), columns])
   let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(&lines * a:opts.height)]), lines - has('nvim')])
-  let row = float2nr(get(a:opts, 'yoffset', 0.5) * (lines - height))
-  let col = float2nr(get(a:opts, 'xoffset', 0.5) * (columns - width))
+  let row = float2nr(yoffset * (lines - height))
+  let col = float2nr(xoffset * (columns - width))
 
   " Managing the differences
   let row = min([max([0, row]), lines - has('nvim') - height])
@@ -987,9 +1008,11 @@ function! s:popup(opts) abort
   let row += !has('nvim')
   let col += !has('nvim')
 
-  call s:create_popup('Normal', extend(copy(a:opts), {
+  call extend(create_opts, {
     \ 'row': row, 'col': col, 'width': width, 'height': height
-  \ }))
+  \ })
+
+  call s:create_popup('Normal', create_opts)
 endfunction
 
 let s:default_action = {

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -975,30 +975,22 @@ function! s:popup(opts) abort
   let create_opts = copy(a:opts)
 
   " Remove known FZF options
-  let xoffset = 0.5
-  let yoffset = 0.5
+  let xoffset = get(a:opts, 'xoffset', 0.5)
+  let yoffset = get(a:opts, 'yoffset', 0.5)
 
-  if has_key(a:opts, 'xoffset')
-    let xoffset = a:opts.xoffset
-    call remove(create_opts, 'xoffset')
-  endif
-
-  if has_key(a:opts, 'yoffset')
-    let yoffset = a:opts.yoffset
-    call remove(create_opts, 'yoffset')
-  endif
-
-  if has_key(a:opts, 'border')
-    call remove(create_opts, 'border')
-  endif
+  for key in ['xoffset', 'yoffset', 'border', 'highlight']
+    if has_key(a:opts, key)
+      call remove(create_opts, key)
+    endif
+  endfor
 
   " Use current window size for positioning relatively positioned popups
   let columns = has_key(a:opts, 'relative') ? winwidth(0) : &columns
   let lines = has_key(a:opts, 'relative') ? winheight(0) : &lines
 
   " Size and position
-  let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(&columns * a:opts.width)]), columns])
-  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(&lines * a:opts.height)]), lines - has('nvim')])
+  let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(columns * a:opts.width)]), columns])
+  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(lines * a:opts.height)]), lines - has('nvim')])
   let row = float2nr(yoffset * (lines - height))
   let col = float2nr(xoffset * (columns - width))
 

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -972,22 +972,9 @@ else
 endif
 
 function! s:popup(opts) abort
-  let create_opts = copy(a:opts)
-
-  " Remove known FZF options
   let xoffset = get(a:opts, 'xoffset', 0.5)
   let yoffset = get(a:opts, 'yoffset', 0.5)
-  let relative = index([1, 'win'], get(a:opts, 'relative', '')) >= 0
-
-  for key in ['xoffset', 'yoffset', 'border', 'highlight', 'relative']
-    if has_key(a:opts, key)
-      call remove(create_opts, key)
-    endif
-  endfor
-
-  if relative && has('nvim')
-    let create_opts.relative = 'win'
-  endif
+  let relative = get(a:opts, 'relative', 0)
 
   " Use current window size for positioning relatively positioned popups
   let columns = relative ? winwidth(0) : &columns
@@ -996,20 +983,18 @@ function! s:popup(opts) abort
   " Size and position
   let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(columns * a:opts.width)]), columns])
   let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(lines * a:opts.height)]), lines - has('nvim')])
-  let row = float2nr(yoffset * (lines - height))
-  let col = float2nr(xoffset * (columns - width))
+  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] : 0)
+  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] : 0)
 
   " Managing the differences
-  let row = min([max([0, row]), lines - has('nvim') - height])
-  let col = min([max([0, col]), columns - width])
+  let row = min([max([0, row]), &lines - has('nvim') - height])
+  let col = min([max([0, col]), &columns - width])
   let row += !has('nvim')
   let col += !has('nvim')
 
-  call extend(create_opts, {
+  call s:create_popup('Normal', {
     \ 'row': row, 'col': col, 'width': width, 'height': height
   \ })
-
-  call s:create_popup('Normal', create_opts)
 endfunction
 
 let s:default_action = {


### PR DESCRIPTION
Neovim supports a `relative` option in `nvim_open_win()` that allows you to position windows relative to the current window or the cursor (as opposed to the entirety of the editor).

This PR:
- passes all options from `s:popup` to `s:create_popup` so that it can receive `relative` (plus other options like `anchor`)
- uses window width/height instead of `&columns`/`&lines` if the `relative` option is present

A configuration of `let g:fzf_layout = { 'window': { 'relative': 'win', 'width': 1.0, 'height': 0.4 }}]` looks like this:

<img width="912" alt="image" src="https://user-images.githubusercontent.com/12588098/114946526-34ebf680-9e00-11eb-936f-9e82d46a42c8.png">
