### PR TITLE
Add argument specifying root directory for built-in file search

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -541,6 +541,9 @@ Exit immediately when there's no match
 Filter mode. Do not start interactive finder. When used with \fB--no-sort\fR,
 fzf becomes a fuzzy-version of grep.
 .TP
+.BI "-r, --root=" "STR"
+Root directory for listing files. Defaults to current directory.
+.TP
 .B "--print-query"
 Print query as the first line
 .TP

--- a/src/constants.go
+++ b/src/constants.go
@@ -57,10 +57,11 @@ const (
 var defaultCommand string
 
 func init() {
+	// The %s and %d get replaced with root directory and cut position
 	if !util.IsWindows() {
-		defaultCommand = `set -o pipefail; command find -L . -mindepth 1 \( -path '*/\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-`
+		defaultCommand = `set -o pipefail; command find -L %s -mindepth 1 \( -path '*/\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b%d-`
 	} else if os.Getenv("TERM") == "cygwin" {
-		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
+		defaultCommand = `sh -c "command find -L %s -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b%d-"`
 	}
 }
 

--- a/src/core.go
+++ b/src/core.go
@@ -141,7 +141,7 @@ func Run(opts *Options, version string, revision string) {
 		reader = NewReader(func(data []byte) bool {
 			return chunkList.Push(data)
 		}, eventBox, opts.ReadZero, opts.Filter == nil)
-		go reader.ReadSource()
+		go reader.ReadSource(opts.RootDir)
 	}
 
 	// Matcher
@@ -185,7 +185,7 @@ func Run(opts *Options, version string, revision string) {
 					}
 					return false
 				}, eventBox, opts.ReadZero, false)
-			reader.ReadSource()
+			reader.ReadSource(opts.RootDir)
 		} else {
 			eventBox.Unwatch(EvtReadNew)
 			eventBox.WaitFor(EvtReadFin)

--- a/src/options.go
+++ b/src/options.go
@@ -92,6 +92,7 @@ const usage = `usage: fzf [options]
     -1, --select-1        Automatically select the only match
     -0, --exit-0          Exit immediately when there's no match
     -f, --filter=STR      Filter mode. Do not start interactive finder.
+    -r, --root=STR        Root directory for built-in file search.
     --print-query         Print query as the first line
     --expect=KEYS         Comma-separated list of keys to complete fzf
     --read0               Read input delimited by ASCII NUL characters
@@ -210,6 +211,7 @@ type Options struct {
 	Select1     bool
 	Exit0       bool
 	Filter      *string
+	RootDir     string
 	ToggleSort  bool
 	Expect      map[tui.Event]string
 	Keymap      map[tui.Event][]action
@@ -271,6 +273,7 @@ func defaultOptions() *Options {
 		Select1:     false,
 		Exit0:       false,
 		Filter:      nil,
+		RootDir:     ".",
 		ToggleSort:  false,
 		Expect:      make(map[tui.Event]string),
 		Keymap:      make(map[tui.Event][]action),
@@ -1220,6 +1223,8 @@ func parseOptions(opts *Options, allArgs []string) {
 		case "-f", "--filter":
 			filter := nextString(allArgs, &i, "query string required")
 			opts.Filter = &filter
+		case "-r", "--root":
+			opts.RootDir = nextString(allArgs, &i, "root string required")
 		case "--literal":
 			opts.Normalize = false
 		case "--no-literal":


### PR DESCRIPTION
I often (like, multiple times a day) find myself in directory A but wanting to select files with fzf in directory B. In those cases as far as I'm aware one either has to go to that directory or else construct a command similar to the default one and feed that into fzf. Moreover the default implementation for Windows with saracen's walker and it is way faster than anything readily available. Meaning that a custom command to list files outside of the current directory is either relatively slow, or requires a specialized tool or custom code. All this while the default way fzf uses to list files works fine in most cases (anecdotal only of course) so just adding the ability to select the root directory seems worth it. 