### PR TITLE
Fix offset of relatively positioned windows

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -983,8 +983,8 @@ function! s:popup(opts) abort
   " Size and position
   let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(columns * a:opts.width)]), columns])
   let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(lines * a:opts.height)]), lines - has('nvim')])
-  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] : 0)
-  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] : 0)
+  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] - 1 : 0)
+  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] - 1 : 0)
 
   " Managing the differences
   let row = min([max([0, row]), &lines - has('nvim') - height])

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -983,8 +983,8 @@ function! s:popup(opts) abort
   " Size and position
   let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(columns * a:opts.width)]), columns])
   let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(lines * a:opts.height)]), lines - has('nvim')])
-  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] - 1 : 0)
-  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] - 1 : 0)
+  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] - has('nvim') : 0)
+  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] - has('nvim') : 0)
 
   " Managing the differences
   let row = min([max([0, row]), &lines - has('nvim') - height])


### PR DESCRIPTION
Coordinates returned by `win_screenpos` start at `[1, 1]` whereas floating windows are positioned relative to `[0, 0]`, so occasionally the rounding logic results in floating windows being offset by one:

<img width="928" alt="image" src="https://user-images.githubusercontent.com/12588098/115903323-493f7d00-a418-11eb-92c7-eb34a10ddac0.png">

