### PR TITLE
Adds warning about lagging Aptitude packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 >
 > Refer to the package documentation for more information. (e.g. `apt-cache show fzf`)
 
+> :warning: If installing via Aptitude, the package may be an old version. If you are
+> getting runtime errors, try installing latest with git cloning instructions.
+
 ### Windows
 
 Pre-built binaries for Windows can be downloaded [here][bin]. fzf is also


### PR DESCRIPTION
Hi all! Thanks for the great project. I was getting similar issues as described in https://github.com/junegunn/fzf/issues/2072, and they were easily remedied by uninstalling the aptitude package and installing the latest version via cloning the repo.

This PR adds a warning regarding https://github.com/junegunn/fzf/issues/2072#issuecomment-778745037.

See https://github.com/junegunn/fzf/issues/2072.

Thanks!