### PR TITLE
ssh completion - remove values where hostname starts with '%' (from s…

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -286,7 +286,7 @@ _fzf_host_completion() {
     command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?]') \
         <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
         <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
-        awk '{if (length($2) > 0) {print $2}}' | sort -u
+        awk '{if (length($2) > 0) {print $2}}' | grep -v '^%' | sort -u
   )
 }
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -283,10 +283,10 @@ _fzf_proc_completion_post() {
 
 _fzf_host_completion() {
   _fzf_complete +m -- "$@" < <(
-    command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?]') \
+    command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
         <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
         <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
-        awk '{if (length($2) > 0) {print $2}}' | grep -v '^%' | sort -u
+        awk '{if (length($2) > 0) {print $2}}' | sort -u
   )
 }
 

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -227,7 +227,7 @@ _fzf_complete_ssh() {
     command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?]') \
         <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
         <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
-        awk '{if (length($2) > 0) {print $2}}' | sort -u
+        awk '{if (length($2) > 0) {print $2}}' | grep -v '^%' | sort -u
   )
 }
 

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -224,10 +224,10 @@ _fzf_complete_telnet() {
 _fzf_complete_ssh() {
   _fzf_complete +m -- "$@" < <(
     setopt localoptions nonomatch
-    command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?]') \
+    command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
         <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
         <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
-        awk '{if (length($2) > 0) {print $2}}' | grep -v '^%' | sort -u
+        awk '{if (length($2) > 0) {print $2}}' | sort -u
   )
 }
 


### PR DESCRIPTION
…sh/config)

in the ssh/config file, in case hosts are defined such as:
```
Host *-aws
  Hostname %h-test.org.au
```
the ```_fzf_complete_ssh``` function will output the value ```%h-test.org.au``` which is not a valid argument for ssh. the proposed PR simply removes those hosts