### PR TITLE
add bind action

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -780,7 +780,7 @@ func init() {
 	// Backreferences are not supported.
 	// "~!@#$%^&*;/|".each_char.map { |c| Regexp.escape(c) }.map { |c| "#{c}[^#{c}]*#{c}" }.join('|')
 	executeRegexp = regexp.MustCompile(
-		`(?si)[:+](execute(?:-multi|-silent)?|reload|preview|change-prompt|unbind):.+|[:+](execute(?:-multi|-silent)?|reload|preview|change-prompt|unbind)(\([^)]*\)|\[[^\]]*\]|~[^~]*~|![^!]*!|@[^@]*@|\#[^\#]*\#|\$[^\$]*\$|%[^%]*%|\^[^\^]*\^|&[^&]*&|\*[^\*]*\*|;[^;]*;|/[^/]*/|\|[^\|]*\|)`)
+		`(?si)[:+](execute(?:-multi|-silent)?|reload|preview|change-prompt|unbind|bind):.+|[:+](execute(?:-multi|-silent)?|reload|preview|change-prompt|unbind|bind)(\([^)]*\)|\[[^\]]*\]|~[^~]*~|![^!]*!|@[^@]*@|\#[^\#]*\#|\$[^\$]*\$|%[^%]*%|\^[^\^]*\^|&[^&]*&|\*[^\*]*\*|;[^;]*;|/[^/]*/|\|[^\|]*\|)`)
 }
 
 func parseKeymap(keymap map[tui.Event][]action, str string) {
@@ -796,6 +796,8 @@ func parseKeymap(keymap map[tui.Event][]action, str string) {
 			prefix = symbol + "preview"
 		} else if strings.HasPrefix(src[1:], "unbind") {
 			prefix = symbol + "unbind"
+		} else if strings.HasPrefix(src[1:], "bind") {
+			prefix = symbol + "bind"
 		} else if strings.HasPrefix(src[1:], "change-prompt") {
 			prefix = symbol + "change-prompt"
 		} else if src[len(prefix)] == '-' {
@@ -993,6 +995,8 @@ func parseKeymap(keymap map[tui.Event][]action, str string) {
 						offset = len("change-prompt")
 					case actUnbind:
 						offset = len("unbind")
+					case actBind:
+						offset = len("bind")
 					case actExecuteSilent:
 						offset = len("execute-silent")
 					case actExecuteMulti:
@@ -1015,6 +1019,11 @@ func parseKeymap(keymap map[tui.Event][]action, str string) {
 					}
 					if t == actUnbind {
 						parseKeyChords(actionArg, "unbind target required")
+					} else if t == actBind {
+						bindSepIndex := strings.Index(actionArg, ":")
+						if bindSepIndex == -1 {
+							errorExit("bind action requires an action")
+						}
 					}
 				}
 			}
@@ -1038,6 +1047,8 @@ func isExecuteAction(str string) actionType {
 		return actReload
 	case "unbind":
 		return actUnbind
+	case "bind":
+		return actBind
 	case "preview":
 		return actPreview
 	case "change-prompt":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -285,6 +285,7 @@ const (
 	actSelect
 	actDeselect
 	actUnbind
+	actBind
 )
 
 type placeholderFlags struct {
@@ -2664,6 +2665,8 @@ func (t *Terminal) Loop() {
 				for key := range keys {
 					delete(t.keymap, key)
 				}
+			case actBind:
+				parseKeymap(t.keymap, a.a)
 			}
 			return true
 		}


### PR DESCRIPTION
This is a proof of concept `bind` action, which as an example, can be used to rebind the `change` event.

Building on your third advanced [ripgrep](https://github.com/christian-schulze/fzf/blob/master/ADVANCED.md#switching-to-fzf-only-search-mode) example, this allows switching back and forth between `ripgrep` and `fzf` search modes:
```bash
#!/usr/bin/env bash

# Two-phase filtering with Ripgrep and fzf
#
# 1. Search for text in files using Ripgrep
# 2. Interactively restart Ripgrep with reload action
#    * Press ctrl-f to switch to fzf-only filtering
#    * Press ctrl-r to switch back to ripgrep
# 3. Open the file in Vim
RG_PREFIX="rg --column --line-number --no-heading --color=always --smart-case "
INITIAL_QUERY="${*:-}"
IFS=: read -ra selected < <(
  FZF_DEFAULT_COMMAND="$RG_PREFIX $(printf %q "$INITIAL_QUERY")" \
  fzf --ansi \
      --color "hl:-1:underline,hl+:-1:underline:reverse" \
      --disabled \
      --query "$INITIAL_QUERY" \
      --bind "change:reload:sleep 0.1; $RG_PREFIX {q} || true" \
      --bind "ctrl-f:unbind(change)+change-prompt(2. fzf> )+enable-search+clear-query" \
      --bind "ctrl-r:change-prompt(1. ripgrep> )+disable-search+clear-query+bind(change:reload:sleep 0.1; $RG_PREFIX {q} || true)" \
      --prompt "1. ripgrep> " \
      --delimiter : \
      --preview "bat --color=always {1} --highlight-line {2}" \
      --preview-window "up,60%,border-bottom,+{2}+3/3,~3"
)
[ -n "${selected[0]}" ] && vim "${selected[0]}" "+${selected[1]}"
```

What do you think, is this something you would consider adding?