### PR TITLE
Allow Fzf to be embedded into any go project

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,25 @@ builds:
       - amd64
     ldflags:
       - "-s -w -X main.version={{ .Version }} -X main.revision={{ .ShortCommit }}"
+    hooks:
+      post: |
+        sh -c '
+        cat > /tmp/fzf-gon-amd64.hcl << EOF
+        source = ["./dist/fzf-macos_darwin_amd64/fzf"]
+        bundle_id = "kr.junegunn.fzf"
+        apple_id {
+          username = "junegunn.c@gmail.com"
+          password = "@env:AC_PASSWORD"
+        }
+        sign {
+          application_identity = "Developer ID Application: Junegunn Choi (Y254DRW44Z)"
+        }
+        zip {
+          output_path = "./dist/fzf-{{ .Version }}-darwin_amd64.zip"
+        }
+        EOF
+        gon /tmp/fzf-gon-amd64.hcl
+        '
 
   - id: fzf-macos-arm
     binary: fzf
@@ -23,6 +42,25 @@ builds:
       - arm64
     ldflags:
       - "-s -w -X main.version={{ .Version }} -X main.revision={{ .ShortCommit }}"
+    hooks:
+      post: |
+        sh -c '
+        cat > /tmp/fzf-gon-arm64.hcl << EOF
+        source = ["./dist/fzf-macos-arm_darwin_arm64/fzf"]
+        bundle_id = "kr.junegunn.fzf"
+        apple_id {
+          username = "junegunn.c@gmail.com"
+          password = "@env:AC_PASSWORD"
+        }
+        sign {
+          application_identity = "Developer ID Application: Junegunn Choi (Y254DRW44Z)"
+        }
+        zip {
+          output_path = "./dist/fzf-{{ .Version }}-darwin_arm64.zip"
+        }
+        EOF
+        gon /tmp/fzf-gon-arm64.hcl
+        '
 
   - id: fzf
     goos:
@@ -60,53 +98,6 @@ archives:
         format: zip
     files:
       - non-existent*
-
-signs:
-  - id: fzf-macos-sign
-    ids: [fzf-macos]
-    artifacts: all
-    cmd: sh
-    args:
-      - "-c"
-      - |-
-        cat > /tmp/fzf-gon-amd64.hcl << EOF
-        source = ["./dist/fzf-macos_darwin_amd64/fzf"]
-        bundle_id = "kr.junegunn.fzf"
-        apple_id {
-          username = "junegunn.c@gmail.com"
-          password = "@env:AC_PASSWORD"
-        }
-        sign {
-          application_identity = "Developer ID Application: Junegunn Choi (Y254DRW44Z)"
-        }
-        zip {
-          output_path = "./dist/fzf-{{ .Version }}-darwin_amd64.zip"
-        }
-        EOF
-        gon /tmp/fzf-gon-amd64.hcl
-
-  - id: fzf-macos-arm-sign
-    ids: [fzf-macos-arm]
-    artifacts: all
-    cmd: sh
-    args:
-      - "-c"
-      - |-
-        cat > /tmp/fzf-gon-arm64.hcl << EOF
-        source = ["./dist/fzf-macos-arm_darwin_arm64/fzf"]
-        bundle_id = "kr.junegunn.fzf"
-        apple_id {
-          username = "junegunn.c@gmail.com"
-          password = "@env:AC_PASSWORD"
-        }
-        sign {
-          application_identity = "Developer ID Application: Junegunn Choi (Y254DRW44Z)"
-        }
-        zip {
-          output_path = "./dist/fzf-{{ .Version }}-darwin_arm64.zip"
-        }
-        EOF
-        gon /tmp/fzf-gon-arm64.hcl
 
 release:
   github:

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -132,10 +132,9 @@ fzf-tmux -u30%
 
 #### Popup window support
 
-But here's the really cool part; tmux 3.2 (stable version is not yet released
-as of now) supports popup windows. So if you have tmux built from the latest
-source, you can open fzf in a popup window, which is quite useful if you
-frequently use split panes.
+But here's the really cool part; tmux 3.2 added support for popup windows. So
+you can open fzf in a popup window, which is quite useful if you frequently
+use split panes.
 
 ```sh
 # Open tmux in a tmux popup window (default size: 50% of the screen)

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -16,6 +16,7 @@ Advanced fzf examples
 * [Ripgrep integration](#ripgrep-integration)
   * [Using fzf as the secondary filter](#using-fzf-as-the-secondary-filter)
   * [Using fzf as interative Ripgrep launcher](#using-fzf-as-interative-ripgrep-launcher)
+  * [Switching to fzf-only search mode](#switching-to-fzf-only-search-mode)
 * [Log tailing](#log-tailing)
 * [Key bindings for git objects](#key-bindings-for-git-objects)
   * [Files listed in `git status`](#files-listed-in-git-status)
@@ -353,6 +354,56 @@ IFS=: read -ra selected < <(
 - `sleep 0.1` in the reload command is for "debouncing". This small delay will
   reduce the number of intermediate Ripgrep processes while we're typing in
   a query.
+
+### Switching to fzf-only search mode
+
+*(Requires fzf 0.27.1 or above)*
+
+In the previous example, we lost fuzzy matching capability as we completely
+delegated search functionality to Ripgrep. But we can dynamically switch to
+fzf-only search mode by *"unbinding"* `reload` action from `change` event.
+
+```sh
+#!/usr/bin/env bash
+
+# Two-phase filtering with Ripgrep and fzf
+#
+# 1. Search for text in files using Ripgrep
+# 2. Interactively restart Ripgrep with reload action
+#    * Press alt-enter to switch to fzf-only filtering
+# 3. Open the file in Vim
+RG_PREFIX="rg --column --line-number --no-heading --color=always --smart-case "
+INITIAL_QUERY="${*:-}"
+IFS=: read -ra selected < <(
+  FZF_DEFAULT_COMMAND="$RG_PREFIX $(printf %q "$INITIAL_QUERY")" \
+  fzf --ansi \
+      --color "hl:-1:underline,hl+:-1:underline:reverse" \
+      --disabled --query "$INITIAL_QUERY" \
+      --bind "change:reload:sleep 0.1; $RG_PREFIX {q} || true" \
+      --bind "alt-enter:unbind(change,alt-enter)+change-prompt(2. fzf> )+enable-search+clear-query" \
+      --prompt '1. ripgrep> ' \
+      --delimiter : \
+      --preview 'bat --color=always {1} --highlight-line {2}' \
+      --preview-window 'up,60%,border-bottom,+{2}+3/3,~3'
+)
+[ -n "${selected[0]}" ] && vim "${selected[0]}" "+${selected[1]}"
+```
+
+* Phase 1. Filtering with Ripgrep
+![image](https://user-images.githubusercontent.com/700826/119213880-735e8a80-bafd-11eb-8493-123e4be24fbc.png)
+* Phase 2. Filtering with fzf
+![image](https://user-images.githubusercontent.com/700826/119213887-7e191f80-bafd-11eb-98c9-71a1af9d7aab.png)
+
+- We added `--prompt` option to show that fzf is initially running in "Ripgrep
+  launcher mode".
+- We added `alt-enter` binding that
+    1. unbinds `change` event, so Ripgrep is no longer restarted on key press
+    2. changes the prompt to `2. fzf>`
+    3. enables search functionality of fzf
+    4. clears the current query string that was used to start Ripgrep process
+    5. and unbinds `alt-enter` itself as this is a one-off event
+- We reverted `--color` option for customizing how the matching chunks are
+  displayed in the second phase
 
 Log tailing
 -----------

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -338,6 +338,7 @@ IFS=: read -ra selected < <(
   Otherwise, the initial Ripgrep process will keep consuming system resources
   even after `reload` is triggered.
 - Filtering is no longer a responsibitiliy of fzf; hence `--disabled`
+- `{q}` in the reload command evaluates to the query string on fzf prompt.
 - `sleep 0.1` in the reload command is for "debouncing". This small delay will
   reduce the number of intermediate Ripgrep processes while we're typing in
   a query.

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,7 +1,7 @@
 Advanced fzf examples
 ======================
 
-*(Last update: 2021/04/09)*
+*(Last update: 2021/05/22)*
 
 <!-- vim-markdown-toc GFM -->
 

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,0 +1,502 @@
+Advanced fzf examples
+======================
+
+*(Last update: 2021/04/06)*
+
+<!-- vim-markdown-toc GFM -->
+
+* [Introduction](#introduction)
+* [Screen Layout](#screen-layout)
+  * [`--height`](#--height)
+  * [`fzf-tmux`](#fzf-tmux)
+    * [Popup window support](#popup-window-support)
+* [Dynamic reloading of the list](#dynamic-reloading-of-the-list)
+  * [Updating the list of processes by pressing CTRL-R](#updating-the-list-of-processes-by-pressing-ctrl-r)
+  * [Toggling between data sources](#toggling-between-data-sources)
+* [Ripgrep integration](#ripgrep-integration)
+  * [Using fzf as the secondary filter](#using-fzf-as-the-secondary-filter)
+  * [Using fzf as interative Ripgrep launcher](#using-fzf-as-interative-ripgrep-launcher)
+* [Log tailing](#log-tailing)
+* [Key bindings for git objects](#key-bindings-for-git-objects)
+  * [Files listed in `git status`](#files-listed-in-git-status)
+  * [Branches](#branches)
+  * [Commit hashes](#commit-hashes)
+* [Color themes](#color-themes)
+  * [Generating fzf color theme from Vim color schemes](#generating-fzf-color-theme-from-vim-color-schemes)
+
+<!-- vim-markdown-toc -->
+
+Introduction
+------------
+
+fzf is an interactive [Unix filter][filter] program that is designed to be
+used with other Unix tools. It reads a list of items from the standard input,
+allows you to select a subset of the items, and prints the selected ones to
+the standard output. You can think of it as an interactive version of *grep*,
+and it's already useful even if you don't know any of its options.
+
+```sh
+# 1. ps:   Feed the list of processes to fzf
+# 2. fzf:  Interactively select a process using fuzzy matching algorithm
+# 3. awk:  Take the PID from the selected line
+# 3. kill: Kill the process with the PID
+ps -ef | fzf | awk '{print $2}' | xargs kill -9
+```
+
+[filter]: https://en.wikipedia.org/wiki/Filter_(software)
+
+While the above example succinctly summarizes the fundamental concept of fzf,
+you can build much more sophisticated interactive workflows using fzf once you
+learn its wide variety of features.
+
+- To see the full list of options and features, see `man fzf`
+- To see the latest additions, see [CHANGELOG.md](CHANGELOG.md)
+
+This document will guide you through some examples that will familiarize you
+with the advanced features of fzf.
+
+Screen Layout
+-------------
+
+### `--height`
+
+fzf by default opens in fullscreen mode, but it's not always desirable.
+Oftentimes, you want to see the current context of the terminal while using
+fzf. `--height` is an option for opening fzf below the cursor in
+non-fullscreen mode so you can still see the previous commands and their
+results above it.
+
+```sh
+fzf --height=40%
+```
+
+![image](https://user-images.githubusercontent.com/700826/113379893-c184c680-93b5-11eb-9676-c7c0a2f01748.png)
+
+You might also want to experiment with other layout options such as
+`--layout=reverse`, `--info=inline`, `--border`, `--margin`, etc.
+
+```sh
+fzf --height=40% --layout=reverse
+fzf --height=40% --layout=reverse --info=inline
+fzf --height=40% --layout=reverse --info=inline --border
+fzf --height=40% --layout=reverse --info=inline --border --margin=1
+fzf --height=40% --layout=reverse --info=inline --border --margin=1 --padding=1
+```
+
+![image](https://user-images.githubusercontent.com/700826/113379932-dfeac200-93b5-11eb-9e28-df1a2ee71f90.png)
+
+*(See `Layout` section of the man page to see the full list of options)*
+
+But you definitely don't want to repeat `--height=40% --layout=reverse
+--info=inline --border --margin=1 --padding=1` every time you use fzf. You
+could write a wrapper script or shell alise, but there is an easier option.
+Define `$FZF_DEFAULT_OPTS` like so:
+
+```sh
+export FZF_DEFAULT_OPTS="--height=40% --layout=reverse --info=inline --border --margin=1 --padding=1"
+```
+
+### `fzf-tmux`
+
+Before fzf had `--height` option, we would open fzf in a tmux split pane not
+to take up the whole screen. This is done using `fzf-tmux` script.
+
+```sh
+# Open fzf on a tmux split pane below the current pane.
+# Takes the same set of options.
+fzf-tmux --layout=reverse
+```
+
+![image](https://user-images.githubusercontent.com/700826/113379973-f1cc6500-93b5-11eb-8860-c9bc4498aadf.png)
+
+The limitation of `fzf-tmux` is that it only works when you're on tmux unlike
+`--height` option. But the advantage of it is that it's more flexible.
+
+```sh
+# On the right (50%)
+fzf-tmux -r
+
+# On the left (30%)
+fzf-tmux -l30%
+
+# Above the cursor
+fzf-tmux -u30%
+```
+
+![image](https://user-images.githubusercontent.com/700826/113379983-fa24a000-93b5-11eb-93eb-8a3d39b2f163.png)
+
+![image](https://user-images.githubusercontent.com/700826/113380001-0577cb80-93b6-11eb-95d0-2ba453866882.png)
+
+![image](https://user-images.githubusercontent.com/700826/113380040-1d4f4f80-93b6-11eb-9bef-737fb120aafe.png)
+
+#### Popup window support
+
+But here's the really cool part; tmux 3.2 (stable version is not yet released
+as of now) supports popup windows. So if you have tmux built from the latest
+source, you can open fzf in a popup window, which is quite useful when you're
+working on split panes.
+
+```sh
+# Open tmux in a tmux popup window (default size: 50% of the screen)
+fzf-tmux -p
+
+# 80% width, 60% height
+fzf-tmux -p 80%,60%
+```
+
+![image](https://user-images.githubusercontent.com/700826/113380106-4a9bfd80-93b6-11eb-8cee-aeb1c4ce1a1f.png)
+
+Dynamic reloading of the list
+-----------------------------
+
+fzf can dynamically update the candidate list using an arbitrary program with
+`reload` bindings (The design document for `reload` can be found
+[here][reload]).
+
+[reload]: https://github.com/junegunn/fzf/issues/1750
+
+### Updating the list of processes by pressing CTRL-R
+
+This example shows how you can set up a binding for dynamically updating the
+list without restarting fzf.
+
+```sh
+(date; ps -ef) |
+  fzf --bind='ctrl-r:reload(date; ps -ef)' \
+      --header=$'Press CTRL-R to reload\n\n' --header-lines=2 \
+      --preview='echo {}' --preview-window=down,3,wrap \
+      --layout=reverse --height=80% | awk '{print $2}' | xargs kill -9
+```
+
+![image](https://user-images.githubusercontent.com/700826/113465047-200c7c00-946c-11eb-918c-268f37a900c8.png)
+
+- The initial command is `(date; ps -ef)`. It prints the current date and
+  time, and the list of the processes.
+- With `--header` option, you can show any message as the fixed header.
+- To disallow selecting the first two lines (`date` and `ps` header), we use
+  `--header-lines=2` option.
+- `--bind='ctrl-r:reload(date; ps -ef)'` binds CTRL-R to `reload` action that
+  runs `date; ps -ef`, so we can update the list of the processes by pressing
+  CTRL-R.
+- We use simple `echo {}` preview option, so we can see the entire line on the
+  preview window below even if it's too long
+
+### Toggling between data sources
+
+You're not limiited to just one reload binding. Set up multiple bindings so
+you can switch between data sources.
+
+```sh
+find * | fzf --prompt 'All> ' \
+             --header 'CTRL-D: Directories / CTRL-F: Files' \
+             --bind 'ctrl-d:change-prompt(Directories> )+reload(find * -type d)' \
+             --bind 'ctrl-f:change-prompt(Files> )+reload(find * -type f)'
+```
+
+![image](https://user-images.githubusercontent.com/700826/113465073-4af6d000-946c-11eb-858f-2372c0955f67.png)
+
+![image](https://user-images.githubusercontent.com/700826/113465072-46321c00-946c-11eb-9b6f-cda3951df579.png)
+
+Ripgrep integration
+-------------------
+
+### Using fzf as the secondary filter
+
+* Requires [bat][bat]
+* Requires [Ripgrep][rg]
+
+[bat]: https://github.com/sharkdp/bat
+[rg]: https://github.com/BurntSushi/ripgrep
+
+fzf is pretty fast for filtering a list that you will rarely have to think
+about its performance. But it is not the right tool for searching for text
+inside many large files, and in that case you should definitely use something
+like [Ripgrep][rg].
+
+In the next example, Ripgrep is the primary filter that searches for the given
+text in files, and fzf is used as the secondary fuzzy filter that adds
+interactivity to the workflow. And we use [bat][bat] to show the matching line in
+the preview window.
+
+This is a bash script and it will not run as expected on other non-compliant
+shells. To avoid the compatibility issue, let's save this snippet as a script
+file called `rfv`.
+
+```bash
+#!/usr/bin/env bash
+
+# 1. Search for text in files using Ripgrep
+# 2. Interactively narrow down the list using fzf
+# 3. Open the file in Vim
+IFS=: read -ra selected < <(
+  rg --color=always --line-number --no-heading --smart-case "${*:-}" |
+    fzf --ansi \
+        --color "hl:-1:underline,hl+:-1:underline:reverse" \
+        --delimiter : \
+        --preview 'bat --color=always {1} --highlight-line {2}' \
+        --preview-window 'up,60%,border-bottom,+{2}+3/3,~3'
+)
+[ -n "${selected[0]}" ] && vim "${selected[0]}" "+${selected[1]}"
+```
+
+And run it with an initial query string.
+
+```sh
+chmod +x rfv
+./rfv algo
+```
+
+![image](https://user-images.githubusercontent.com/700826/113683873-a42a6200-96ff-11eb-9666-26ce4091b0e4.png)
+
+I know it's a lot to digest, let's try to break down the code.
+
+- Ripgrep prints the matching lines in the following format
+  ```
+  man/man1/fzf.1:54:.BI "--algo=" TYPE
+  man/man1/fzf.1:55:Fuzzy matching algorithm (default: v2)
+  man/man1/fzf.1:58:.BR v2 "     Optimal scoring algorithm (quality)"
+  src/pattern_test.go:7:  "github.com/junegunn/fzf/src/algo"
+  ```
+  The first token delimited by `:` is the file path, and the second token is
+  the line number of the matching line. They respectively correspond to `{1}`
+  and `{2}` in the preview command.
+    - `--preview 'bat --color=always {1} --highlight-line {2}'`
+- As we run `rg` with `--color=always` option, we should tell fzf to parse
+  ANSI color codes in the input by setting `--ansi`.
+- We customize how fzf colors various text elements using `--color` option.
+  `-1` tells fzf to keep the original color from the input. See `man fzf` for
+  available color options.
+- The value of `--preview-window` options consists of 4 components delimited
+  by `,`
+    1. `up` — Position of the preview window
+    1. `60%` — Size of the preview window
+    1. `border-bottom` — Preview window border only on the bottom side
+    1. `+{2}+3/3` — Scroll offset of the preview contents
+    1. `~3` — Fixed header
+- Let's break down the latter two. We want to display the bat output in the
+  preview window with a certain scroll offset so that the matching line is
+  positioned near the center of the preview window.
+    - `+{2}` — The base offset is extracted from the second token
+    - `+3` — We add 3 lines to the base offset to compensate for the header
+      part of `bat` output
+        - ```
+          ───────┬──────────────────────────────────────────────────────────
+                 │ File: CHANGELOG.md
+          ───────┼──────────────────────────────────────────────────────────
+             1   │ CHANGELOG
+             2   │ =========
+             3   │
+             4   │ 0.26.0
+             5   │ ------
+          ```
+    - `/3` adjusts the offset so that the matching line is shown at a third
+      position in the window
+    - `~3` makes the top three lines fixed header so that they are always
+      visible regardless of the scroll offset
+- Once we selected a line, we open the file with `vim` (`vim
+  "${selected[0]}"`) and move the cursor to the line (`+${selected[1]}`).
+
+### Using fzf as interative Ripgrep launcher
+
+We have learned that we can bind `reload` action to a key (e.g.
+`--bind=ctrl-r:execute(ps -ef)`). In the next example, we are going to **bind
+`reload` action to `change` event** so that whenever the user *changes* the
+query string on fzf, `reload` action is triggered.
+
+Here is a variation of the above `rfv` script. fzf will restart Ripgrep every
+time the user updates the query string on fzf. Searching and filtering is
+completely done by Ripgrep, and fzf merely provides the interactive interface.
+So we lose the "fuzziness", but the performance will be better on larger
+projects, and it will free up memory as you narrow down the results.
+
+```bash
+#!/usr/bin/env bash
+
+# 1. Search for text in files using Ripgrep
+# 2. Interactively restart Ripgrep with reload action
+# 3. Open the file in Vim
+RG_PREFIX="rg --column --line-number --no-heading --color=always --smart-case "
+INITIAL_QUERY="${*:-}"
+IFS=: read -ra selected < <(
+  FZF_DEFAULT_COMMAND="$RG_PREFIX $(printf %q "$INITIAL_QUERY")" \
+  fzf --ansi \
+      --disabled --query "$INITIAL_QUERY" \
+      --bind "change:reload:sleep 0.1; $RG_PREFIX {q} || true" \
+      --color "hl:-1:underline,hl+:-1:underline:reverse" \
+      --delimiter : \
+      --preview 'bat --color=always {1} --highlight-line {2}' \
+      --preview-window 'up,60%,border-bottom,+{2}+3/3,~3'
+)
+[ -n "${selected[0]}" ] && vim "${selected[0]}" "+${selected[1]}"
+```
+
+![image](https://user-images.githubusercontent.com/700826/113684212-f9ff0a00-96ff-11eb-8737-7bb571d320cc.png)
+
+- Instead of starting fzf in `rg ... | fzf` form, we start fzf without an
+  explicit input, but with a custom `FZF_DEFAULT_COMMAND` variable. This way
+  fzf can kill the initial Ripgrep process it starts with the initial query.
+  Otherwise, the initial Ripgrep process will keep consuming system resources
+  even after `reload` is triggered.
+- Filtering is no longer a responsibitiliy of fzf; hence `--disabled`
+- `sleep 0.1` in the reload command is for "debouncing". This small delay will
+  reduce the number of intermediate Ripgrep processes while we're typing in
+  a query.
+
+Log tailing
+-----------
+
+fzf can run long-running preview commands and render partial results before
+completion. And when you specify `:follow` flag in `--preview-window` option,
+fzf will "`tail -f`" the result, automatically scrolling to the bottom.
+
+```bash
+# With "follow", preview window will automatically scroll to the bottom.
+# "\033[2J" is an ANSI escape sequence for clearing the screen.
+# When fzf reads this code it clears the previous preview contents.
+fzf --preview-window follow --preview 'for i in $(seq 100000); do
+  echo "$i"
+  sleep 0.01
+  (( i % 300 == 0 )) && printf "\033[2J"
+done'
+```
+
+![image](https://user-images.githubusercontent.com/700826/113473303-dd669600-94a3-11eb-88a9-1f61b996bb0e.png)
+
+Admittedly, that was a silly example. Here's a practical one for browsing
+Kubernetes pods.
+
+```bash
+#!/usr/bin/env bash
+
+read -ra tokens < <(
+  kubectl get pods --all-namespaces |
+    fzf --info=inline --layout=reverse --header-lines=1 --border \
+        --prompt "$(kubectl config current-context | sed 's/-context$//')> " \
+        --header $'Press CTRL-O to open log in editor\n\n' \
+        --bind ctrl-/:toggle-preview \
+        --bind 'ctrl-o:execute:${EDITOR:-vim} <(kubectl logs --namespace {1} {2}) > /dev/tty' \
+        --preview-window up,follow \
+        --preview 'kubectl logs --follow --tail=100000 --namespace {1} {2}' "$@"
+)
+[ ${#tokens} -gt 1 ] &&
+  kubectl exec -it --namespace "${tokens[0]}" "${tokens[1]}" -- bash
+```
+
+![image](https://user-images.githubusercontent.com/700826/113473547-1d7a4880-94a5-11eb-98ef-9aa6f0ed215a.png)
+
+- The preview window will *"log tail"* the pod
+    - Holding on to a large amount of log will consume a lot of memory. So we
+      limited the initial log amount with `--tail=100000`.
+- With `execute` binding, you can press CTRL-O to open the log in your editor
+  without leaving fzf
+- Select a pod (with an enter key) to `kubectl exec` into it
+
+Key bindings for git objects
+----------------------------
+
+I have [blogged](https://junegunn.kr/2016/07/fzf-git) about my fzf+git key
+bindings a few years ago. I'm going to show them here again, because they are
+seriously useful.
+
+### Files listed in `git status`
+
+<kbd>CTRL-G</kbd><kbd>CTRL-F</kbd>
+
+![image](https://user-images.githubusercontent.com/700826/113473779-a9d93b00-94a6-11eb-87b5-f62a8d0a0efc.png)
+
+### Branches
+
+<kbd>CTRL-G</kbd><kbd>CTRL-B</kbd>
+
+![image](https://user-images.githubusercontent.com/700826/113473758-87dfb880-94a6-11eb-82f4-9218103f10bd.png)
+
+### Commit hashes
+
+<kbd>CTRL-G</kbd><kbd>CTRL-H</kbd>
+
+![image](https://user-images.githubusercontent.com/700826/113473765-91692080-94a6-11eb-8d38-ed4d41f27ac1.png)
+
+
+The full source code can be found [here](https://gist.github.com/junegunn/8b572b8d4b5eddd8b85e5f4d40f17236).
+
+Color themes
+------------
+
+You can customize how fzf colors the text elements with `--color` option. Here
+are a few color themes. Note that you need a terminal emulator that can
+display 24-bit colors.
+
+```sh
+# junegunn/seoul256.vim (dark)
+export FZF_DEFAULT_OPTS='--color=bg+:#3F3F3F,bg:#4B4B4B,border:#6B6B6B,spinner:#98BC99,hl:#719872,fg:#D9D9D9,header:#719872,info:#BDBB72,pointer:#E12672,marker:#E17899,fg+:#D9D9D9,preview-bg:#3F3F3F,prompt:#98BEDE,hl+:#98BC99'
+```
+
+![seoul256](https://user-images.githubusercontent.com/700826/113475011-2c192d80-94ae-11eb-9d17-1e5867bae01f.png)
+
+```sh
+# junegunn/seoul256.vim (light)
+export FZF_DEFAULT_OPTS='--color=bg+:#D9D9D9,bg:#E1E1E1,border:#C8C8C8,spinner:#719899,hl:#719872,fg:#616161,header:#719872,info:#727100,pointer:#E12672,marker:#E17899,fg+:#616161,preview-bg:#D9D9D9,prompt:#0099BD,hl+:#719899'
+```
+
+![seoul256-light](https://user-images.githubusercontent.com/700826/113475022-389d8600-94ae-11eb-905f-0939dd535837.png)
+
+```sh
+# morhetz/gruvbox
+export FZF_DEFAULT_OPTS='--color=bg+:#3c3836,bg:#32302f,spinner:#fb4934,hl:#928374,fg:#ebdbb2,header:#928374,info:#8ec07c,pointer:#fb4934,marker:#fb4934,fg+:#ebdbb2,prompt:#fb4934,hl+:#fb4934'
+```
+
+![gruvbox](https://user-images.githubusercontent.com/700826/113475042-494dfc00-94ae-11eb-9322-cd03a027305a.png)
+
+```sh
+# arcticicestudio/nord-vim
+export FZF_DEFAULT_OPTS='--color=bg+:#3B4252,bg:#2E3440,spinner:#81A1C1,hl:#616E88,fg:#D8DEE9,header:#616E88,info:#81A1C1,pointer:#81A1C1,marker:#81A1C1,fg+:#D8DEE9,prompt:#81A1C1,hl+:#81A1C1'
+```
+
+![nord](https://user-images.githubusercontent.com/700826/113475063-67b3f780-94ae-11eb-9b24-5f0d22b63399.png)
+
+```sh
+# tomasr/molokai
+export FZF_DEFAULT_OPTS='--color=bg+:#293739,bg:#1B1D1E,border:#808080,spinner:#E6DB74,hl:#7E8E91,fg:#F8F8F2,header:#7E8E91,info:#A6E22E,pointer:#A6E22E,marker:#F92672,fg+:#F8F8F2,prompt:#F92672,hl+:#F92672'
+```
+
+![molokai](https://user-images.githubusercontent.com/700826/113475085-8619f300-94ae-11eb-85e4-2766fc3246bf.png)
+
+### Generating fzf color theme from Vim color schemes
+
+The Vim plugin of fzf can generate `--color` option from the current color
+scheme according to `g:fzf_colors` variable. You can find the detailed
+explanation [here](https://github.com/junegunn/fzf/blob/master/README-VIM.md#explanation-of-gfzf_colors).
+
+Here is an example. Add this to your Vim configuration file.
+
+```vim
+let g:fzf_colors =
+\ { 'fg':         ['fg', 'Normal'],
+  \ 'bg':         ['bg', 'Normal'],
+  \ 'preview-bg': ['bg', 'NormalFloat'],
+  \ 'hl':         ['fg', 'Comment'],
+  \ 'fg+':        ['fg', 'CursorLine', 'CursorColumn', 'Normal'],
+  \ 'bg+':        ['bg', 'CursorLine', 'CursorColumn'],
+  \ 'hl+':        ['fg', 'Statement'],
+  \ 'info':       ['fg', 'PreProc'],
+  \ 'border':     ['fg', 'Ignore'],
+  \ 'prompt':     ['fg', 'Conditional'],
+  \ 'pointer':    ['fg', 'Exception'],
+  \ 'marker':     ['fg', 'Keyword'],
+  \ 'spinner':    ['fg', 'Label'],
+  \ 'header':     ['fg', 'Comment'] }
+```
+
+Then you can see how the `--color` option is generated by printing the result
+of `fzf#wrap()`.
+
+```vim
+:echo fzf#wrap()
+```
+
+Use this command to append `export FZF_DEFAULT_OPTS="..."` line to the end of
+the current file.
+
+```vim
+:call append('$', printf('export FZF_DEFAULT_OPTS="%s"', matchstr(fzf#wrap().options, "--color[^']*")))
+```

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -1,7 +1,7 @@
 Advanced fzf examples
 ======================
 
-*(Last update: 2021/04/06)*
+*(Last update: 2021/04/09)*
 
 <!-- vim-markdown-toc GFM -->
 
@@ -242,9 +242,15 @@ IFS=: read -ra selected < <(
 And run it with an initial query string.
 
 ```sh
+# Make the script executable
 chmod +x rfv
+
+# Run it with the initial query "algo"
 ./rfv algo
 ```
+
+> Ripgrep will perform the initial search and list all the lines that contain
+`algo`. Then we further narrow down the list on fzf.
 
 ![image](https://user-images.githubusercontent.com/700826/113683873-a42a6200-96ff-11eb-9666-26ce4091b0e4.png)
 
@@ -266,7 +272,7 @@ I know it's a lot to digest, let's try to break down the code.
 - We customize how fzf colors various text elements using `--color` option.
   `-1` tells fzf to keep the original color from the input. See `man fzf` for
   available color options.
-- The value of `--preview-window` options consists of 5 components delimited
+- The value of `--preview-window` option consists of 5 components delimited
   by `,`
     1. `up` — Position of the preview window
     1. `60%` — Size of the preview window

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -266,7 +266,7 @@ I know it's a lot to digest, let's try to break down the code.
 - We customize how fzf colors various text elements using `--color` option.
   `-1` tells fzf to keep the original color from the input. See `man fzf` for
   available color options.
-- The value of `--preview-window` options consists of 4 components delimited
+- The value of `--preview-window` options consists of 5 components delimited
   by `,`
     1. `up` — Position of the preview window
     1. `60%` — Size of the preview window
@@ -347,7 +347,7 @@ Log tailing
 -----------
 
 fzf can run long-running preview commands and render partial results before
-completion. And when you specify `:follow` flag in `--preview-window` option,
+completion. And when you specify `follow` flag in `--preview-window` option,
 fzf will "`tail -f`" the result, automatically scrolling to the bottom.
 
 ```bash

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -335,7 +335,6 @@ IFS=: read -ra selected < <(
   fzf --ansi \
       --disabled --query "$INITIAL_QUERY" \
       --bind "change:reload:sleep 0.1; $RG_PREFIX {q} || true" \
-      --color "hl:-1:underline,hl+:-1:underline:reverse" \
       --delimiter : \
       --preview 'bat --color=always {1} --highlight-line {2}' \
       --preview-window 'up,60%,border-bottom,+{2}+3/3,~3'

--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -89,7 +89,7 @@ fzf --height=40% --layout=reverse --info=inline --border --margin=1 --padding=1
 
 But you definitely don't want to repeat `--height=40% --layout=reverse
 --info=inline --border --margin=1 --padding=1` every time you use fzf. You
-could write a wrapper script or shell alise, but there is an easier option.
+could write a wrapper script or shell alias, but there is an easier option.
 Define `$FZF_DEFAULT_OPTS` like so:
 
 ```sh
@@ -111,6 +111,7 @@ fzf-tmux --layout=reverse
 
 The limitation of `fzf-tmux` is that it only works when you're on tmux unlike
 `--height` option. But the advantage of it is that it's more flexible.
+(See `man fzf-tmux` for available options.)
 
 ```sh
 # On the right (50%)
@@ -133,8 +134,8 @@ fzf-tmux -u30%
 
 But here's the really cool part; tmux 3.2 (stable version is not yet released
 as of now) supports popup windows. So if you have tmux built from the latest
-source, you can open fzf in a popup window, which is quite useful when you're
-working on split panes.
+source, you can open fzf in a popup window, which is quite useful if you
+frequently use split panes.
 
 ```sh
 # Open tmux in a tmux popup window (default size: 50% of the screen)
@@ -145,6 +146,12 @@ fzf-tmux -p 80%,60%
 ```
 
 ![image](https://user-images.githubusercontent.com/700826/113380106-4a9bfd80-93b6-11eb-8cee-aeb1c4ce1a1f.png)
+
+> You might also want to check out my tmux plugins which support this popup
+> window layout.
+> 
+> - https://github.com/junegunn/tmux-fzf-url
+> - https://github.com/junegunn/tmux-fzf-maccy
 
 Dynamic reloading of the list
 -----------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
   fzf --color fg:3,fg+:11
   fzf --color fg:yellow,fg+:bright-yellow
   ```
+- Fix bug where `--read0` not properly displaying long lines
 
 0.27.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 CHANGELOG
 =========
 
+0.27.3
+------
+- Preview window is `hidden` by default when there are `preview` bindings but
+  `--preview` command is not given
+- Vim plugin
+    - `sinklist` is added as a synonym to `sink*` so that it's easier to add
+      a function to a spec dictionary
+      ```vim
+      let spec = { 'source': 'ls', 'options': ['--multi', '--preview', 'cat {}'] }
+      function spec.sinklist(matches)
+        echom string(a:matches)
+      endfunction
+
+      call fzf#run(fzf#wrap(spec))
+      ```
+
 0.27.2
 ------
 - 16 base ANSI colors can be specified by their names

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 CHANGELOG
 =========
 
+0.27.1
+------
+- Added `unbind` action. In the following Ripgrep launcher example, you can
+  use `unbind(reload)` to switch to fzf-only filtering mode.
+    - See https://github.com/junegunn/fzf/blob/master/ADVANCED.md#switching-to-fzf-only-search-mode
+- Vim plugin
+    - Vim plugin will stop immediately even when the source command hasn't finished
+      ```vim
+      " fzf will read the stream file while allowing other processes to append to it
+      call fzf#run({'source': 'cat /dev/null > /tmp/stream; tail -f /tmp/stream'})
+      ```
+    - It is now possible to open popup window relative to the currrent window
+      ```vim
+      let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true, 'yoffset': 1.0 } }
+      ```
+
 0.27.0
 ------
 - More border options for `--preview-window`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 CHANGELOG
 =========
 
+0.27.2
+------
+- 16 base ANSI colors can be specified by their names
+  ```sh
+  fzf --color fg:3,fg+:11
+  fzf --color fg:yellow,fg+:bright-yellow
+  ```
+
 0.27.1
 ------
 - Added `unbind` action. In the following Ripgrep launcher example, you can

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,21 @@ CHANGELOG
 - More border options for `--preview-window`
   ```sh
   fzf --preview 'cat {}' --preview-window border-left
+  fzf --preview 'cat {}' --preview-window border-left --border horizontal
   fzf --preview 'cat {}' --preview-window top:border-bottom
   fzf --preview 'cat {}' --preview-window top:border-horizontal
   ```
-- Signed and notarized macOS binaries (thanks to [BACKERS.md](https://github.com/junegunn/junegunn/blob/main/BACKERS.md))
+- Automatically set `/dev/tty` as STDIN on execute action
+  ```sh
+  # Redirect /dev/tty to suppress "Vim: Warning: Input is not from a terminal"
+  # ls | fzf --bind "enter:execute(vim {} < /dev/tty)"
+
+  # "< /dev/tty" part is no longer needed
+  ls | fzf --bind "enter:execute(vim {})"
+  ```
+- Bug fixes and improvements
+- Signed and notarized macOS binaries
+  (Huge thanks to [BACKERS.md](https://github.com/junegunn/junegunn/blob/main/BACKERS.md)!)
 
 0.26.0
 ------

--- a/README-VIM.md
+++ b/README-VIM.md
@@ -399,15 +399,41 @@ Tips
 
 ### fzf inside terminal buffer
 
-The latest versions of Vim and Neovim include builtin terminal emulator
-(`:terminal`) and fzf will start in a terminal buffer in the following cases:
+On the latest versions of Vim and Neovim, fzf will start in a terminal buffer.
+If you find the default ANSI colors to be different, consider configuring the
+colors using `g:terminal_ansi_colors` in regular Vim or `g:terminal_color_x`
+in Neovim.
 
-- On Neovim
-- On GVim
-- On Terminal Vim with a non-default layout
-    - `call fzf#run({'left': '30%'})` or `let g:fzf_layout = {'left': '30%'}`
+```vim
+" Terminal colors for seoul256 color scheme
+if has('nvim')
+  let g:terminal_color_0 = '#4e4e4e'
+  let g:terminal_color_1 = '#d68787'
+  let g:terminal_color_2 = '#5f865f'
+  let g:terminal_color_3 = '#d8af5f'
+  let g:terminal_color_4 = '#85add4'
+  let g:terminal_color_5 = '#d7afaf'
+  let g:terminal_color_6 = '#87afaf'
+  let g:terminal_color_7 = '#d0d0d0'
+  let g:terminal_color_8 = '#626262'
+  let g:terminal_color_9 = '#d75f87'
+  let g:terminal_color_10 = '#87af87'
+  let g:terminal_color_11 = '#ffd787'
+  let g:terminal_color_12 = '#add4fb'
+  let g:terminal_color_13 = '#ffafaf'
+  let g:terminal_color_14 = '#87d7d7'
+  let g:terminal_color_15 = '#e4e4e4'
+else
+  let g:terminal_ansi_colors = [
+    \ '#4e4e4e', '#d68787', '#5f865f', '#d8af5f',
+    \ '#85add4', '#d7afaf', '#87afaf', '#d0d0d0',
+    \ '#626262', '#d75f87', '#87af87', '#ffd787',
+    \ '#add4fb', '#ffafaf', '#87d7d7', '#e4e4e4'
+  \ ]
+endif
+```
 
-#### Starting fzf in a popup window
+### Starting fzf in a popup window
 
 ```vim
 " Required:
@@ -435,21 +461,21 @@ else
 endif
 ```
 
-#### Hide statusline
+### Hide statusline
 
 When fzf starts in a terminal buffer, the file type of the buffer is set to
 `fzf`. So you can set up `FileType fzf` autocmd to customize the settings of
 the window.
 
-For example, if you use a non-popup layout (e.g. `{'down': '40%'}`) on Neovim,
-you might want to temporarily disable the statusline for a cleaner look.
+For example, if you open fzf on the bottom on the screen (e.g. `{'down':
+'40%'}`), you might want to temporarily disable the statusline for a cleaner
+look.
 
 ```vim
-if has('nvim') && !exists('g:fzf_layout')
-  autocmd! FileType fzf
-  autocmd  FileType fzf set laststatus=0 noshowmode noruler
-    \| autocmd BufLeave <buffer> set laststatus=2 showmode ruler
-endif
+let g:fzf_layout = { 'down': '30%' }
+autocmd! FileType fzf
+autocmd  FileType fzf set laststatus=0 noshowmode noruler
+  \| autocmd BufLeave <buffer> set laststatus=2 showmode ruler
 ```
 
 [License](LICENSE)

--- a/README-VIM.md
+++ b/README-VIM.md
@@ -283,7 +283,7 @@ The following table summarizes the available options.
 | `source`                   | list          | Vim list as input to fzf                                              |
 | `sink`                     | string        | Vim command to handle the selected item (e.g. `e`, `tabe`)            |
 | `sink`                     | funcref       | Reference to function to process each selected item                   |
-| `sink*`                    | funcref       | Similar to `sink`, but takes the list of output lines at once         |
+| `sinklist` (or `sink*`)    | funcref       | Similar to `sink`, but takes the list of output lines at once         |
 | `options`                  | string/list   | Options to fzf                                                        |
 | `dir`                      | string        | Working directory                                                     |
 | `up`/`down`/`left`/`right` | number/string | (Layout) Window position and size (e.g. `20`, `50%`)                  |
@@ -387,7 +387,7 @@ command! -bang -complete=dir -nargs=? LS
 
 - `g:fzf_layout`
 - `g:fzf_action`
-    - **Works only when no custom `sink` (or `sink*`) is provided**
+    - **Works only when no custom `sink` (or `sinklist`) is provided**
         - Having custom sink usually means that each entry is not an ordinary
           file path (e.g. name of color scheme), so we can't blindly apply the
           same strategy (i.e. `tabedit some-color-scheme` doesn't make sense)

--- a/README-VIM.md
+++ b/README-VIM.md
@@ -127,8 +127,14 @@ let g:fzf_action = {
   \ 'ctrl-v': 'vsplit' }
 
 " Default fzf layout
-" - Popup window
+" - Popup window (center of the screen)
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
+
+" - Popup window (center of the current window)
+let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true } }
+
+" - Popup window (anchored to the bottom of the current window)
+let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true, 'yoffset': 1.0 } }
 
 " - down / up / left / right
 let g:fzf_layout = { 'down': '40%' }
@@ -302,6 +308,7 @@ following options are allowed:
 - Optional:
     - `yoffset` [float default 0.5 range [0 ~ 1]]
     - `xoffset` [float default 0.5 range [0 ~ 1]]
+    - `relative` [boolean default v:false]
     - `border` [string default `rounded`]: Border style
         - `rounded` / `sharp` / `horizontal` / `vertical` / `top` / `bottom` / `left` / `right` / `no[ne]`
 
@@ -410,6 +417,7 @@ The latest versions of Vim and Neovim include builtin terminal emulator
 " Optional:
 " - xoffset [float default 0.5 range [0 ~ 1]]
 " - yoffset [float default 0.5 range [0 ~ 1]]
+" - relative [boolean default v:false]
 " - border [string default 'rounded']: Border style
 "   - 'rounded' / 'sharp' / 'horizontal' / 'vertical' / 'top' / 'bottom' / 'left' / 'right'
 let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }

--- a/README.md
+++ b/README.md
@@ -289,9 +289,10 @@ If you learn by watching videos, check out this screencast by [@samoshkin](https
 Examples
 --------
 
-Many useful examples can be found on [the wiki
-page](https://github.com/junegunn/fzf/wiki/examples). Feel free to add your
-own as well.
+* [Wiki page of examples](https://github.com/junegunn/fzf/wiki/examples)
+    * *Disclaimer: The examples on this page are maintained by the community
+      and are not thoroughly tested*
+* [Advanced fzf examples](https://github.com/junegunn/fzf/blob/master/ADVANCED.md)
 
 `fzf-tmux` script
 -----------------

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 | Nix             | NixOS, etc.             | `nix-env -iA nixpkgs.fzf`          |
 | Pacman          | Arch Linux              | `sudo pacman -S fzf`               |
 | pkg             | FreeBSD                 | `pkg install fzf`                  |
+| pkgin           | NetBSD                  | `pkgin install fzf`                |
 | pkg_add         | OpenBSD                 | `pkg_add fzf`                      |
 | XBPS            | Void Linux              | `sudo xbps-install -S fzf`         |
 | Zypper          | openSUSE                | `sudo zypper install fzf`          |

--- a/README.md
+++ b/README.md
@@ -615,7 +615,7 @@ You can customize the size, position, and border of the preview window using
 
 ```bash
 fzf --height 40% --layout reverse --info inline --border \
-    --preview 'file {}' --preview-window down:1:noborder \
+    --preview 'file {}' --preview-window up,1,border-horizontal \
     --color 'fg:#bbccdd,fg+:#ddeeff,bg:#334455,preview-bg:#223344,border:#778899'
 ```
 

--- a/doc/fzf.txt
+++ b/doc/fzf.txt
@@ -1,4 +1,4 @@
-fzf.txt	fzf	Last change: April 17 2021
+fzf.txt	fzf	Last change: May 19 2021
 FZF - TABLE OF CONTENTS                                            *fzf* *fzf-toc*
 ==============================================================================
 
@@ -14,8 +14,8 @@ FZF - TABLE OF CONTENTS                                            *fzf* *fzf-to
       Global options supported by fzf#wrap  |fzf-global-options-supported-by-fzf#wrap|
     Tips                                    |fzf-tips|
       fzf inside terminal buffer            |fzf-inside-terminal-buffer|
-        Starting fzf in a popup window      |fzf-starting-fzf-in-a-popup-window|
-        Hide statusline                     |fzf-hide-statusline|
+      Starting fzf in a popup window        |fzf-starting-fzf-in-a-popup-window|
+      Hide statusline                       |fzf-hide-statusline|
     License                                 |fzf-license|
 
 FZF VIM INTEGRATION                                        *fzf-vim-integration*
@@ -419,8 +419,46 @@ The latest versions of Vim and Neovim include builtin terminal emulator
  - On Terminal Vim with a non-default layout
    - `call fzf#run({'left': '30%'})` or `let g:fzf_layout = {'left': '30%'}`
 
+On the latest versions of Vim and Neovim, fzf will start in a terminal buffer.
+If you find the default ANSI colors to be different, consider configuring the
+colors using `g:terminal_ansi_colors` in regular Vim or `g:terminal_color_x`
+in Neovim.
 
-Starting fzf in a popup window~
+                   *g:terminal_color_15* *g:terminal_color_14* *g:terminal_color_13*
+*g:terminal_color_12* *g:terminal_color_11* *g:terminal_color_10* *g:terminal_color_9*
+   *g:terminal_color_8* *g:terminal_color_7* *g:terminal_color_6* *g:terminal_color_5*
+   *g:terminal_color_4* *g:terminal_color_3* *g:terminal_color_2* *g:terminal_color_1*
+                                                            *g:terminal_color_0*
+>
+    " Terminal colors for seoul256 color scheme
+    if has('nvim')
+      let g:terminal_color_0 = '#4e4e4e'
+      let g:terminal_color_1 = '#d68787'
+      let g:terminal_color_2 = '#5f865f'
+      let g:terminal_color_3 = '#d8af5f'
+      let g:terminal_color_4 = '#85add4'
+      let g:terminal_color_5 = '#d7afaf'
+      let g:terminal_color_6 = '#87afaf'
+      let g:terminal_color_7 = '#d0d0d0'
+      let g:terminal_color_8 = '#626262'
+      let g:terminal_color_9 = '#d75f87'
+      let g:terminal_color_10 = '#87af87'
+      let g:terminal_color_11 = '#ffd787'
+      let g:terminal_color_12 = '#add4fb'
+      let g:terminal_color_13 = '#ffafaf'
+      let g:terminal_color_14 = '#87d7d7'
+      let g:terminal_color_15 = '#e4e4e4'
+    else
+      let g:terminal_ansi_colors = [
+        \ '#4e4e4e', '#d68787', '#5f865f', '#d8af5f',
+        \ '#85add4', '#d7afaf', '#87afaf', '#d0d0d0',
+        \ '#626262', '#d75f87', '#87af87', '#ffd787',
+        \ '#add4fb', '#ffafaf', '#87d7d7', '#e4e4e4'
+      \ ]
+    endif
+<
+
+< Starting fzf in a popup window >____________________________________________~
                                             *fzf-starting-fzf-in-a-popup-window*
 >
     " Required:
@@ -446,21 +484,21 @@ or above) by putting fzf-tmux options in `tmux` key.
     endif
 <
 
-Hide statusline~
+< Hide statusline >___________________________________________________________~
                                                            *fzf-hide-statusline*
 
 When fzf starts in a terminal buffer, the file type of the buffer is set to
 `fzf`. So you can set up `FileType fzf` autocmd to customize the settings of
 the window.
 
-For example, if you use a non-popup layout (e.g. `{'down': '40%'}`) on Neovim,
-you might want to temporarily disable the statusline for a cleaner look.
+For example, if you open fzf on the bottom on the screen (e.g. `{'down':
+'40%'}`), you might want to temporarily disable the statusline for a cleaner
+look.
 >
-    if has('nvim') && !exists('g:fzf_layout')
-      autocmd! FileType fzf
-      autocmd  FileType fzf set laststatus=0 noshowmode noruler
-        \| autocmd BufLeave <buffer> set laststatus=2 showmode ruler
-    endif
+    let g:fzf_layout = { 'down': '30%' }
+    autocmd! FileType fzf
+    autocmd  FileType fzf set laststatus=0 noshowmode noruler
+      \| autocmd BufLeave <buffer> set laststatus=2 showmode ruler
 <
 
 LICENSE                                                            *fzf-license*

--- a/doc/fzf.txt
+++ b/doc/fzf.txt
@@ -300,7 +300,7 @@ The following table summarizes the available options.
   `source`                    | list          | Vim list as input to fzf
   `sink`                      | string        | Vim command to handle the selected item (e.g.  `e` ,  `tabe` )
   `sink`                      | funcref       | Reference to function to process each selected item
-  `sink*`                     | funcref       | Similar to  `sink` , but takes the list of output lines at once
+  `sinklist`  (or  `sink*` )    | funcref       | Similar to  `sink` , but takes the list of output lines at once
   `options`                   | string/list   | Options to fzf
   `dir`                       | string        | Working directory
   `up` / `down` / `left` / `right`  | number/string | (Layout) Window position and size (e.g.  `20` ,  `50%` )

--- a/doc/fzf.txt
+++ b/doc/fzf.txt
@@ -1,4 +1,4 @@
-fzf.txt	fzf	Last change: January 3 2021
+fzf.txt	fzf	Last change: April 17 2021
 FZF - TABLE OF CONTENTS                                            *fzf* *fzf-toc*
 ==============================================================================
 
@@ -155,8 +155,14 @@ Examples~
       \ 'ctrl-v': 'vsplit' }
 
     " Default fzf layout
-    " - Popup window
+    " - Popup window (center of the screen)
     let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
+
+    " - Popup window (center of the current window)
+    let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true } }
+
+    " - Popup window (anchored to the bottom of the current window)
+    let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6, 'relative': v:true, 'yoffset': 1.0 } }
 
     " - down / up / left / right
     let g:fzf_layout = { 'down': '40%' }
@@ -318,6 +324,7 @@ following options are allowed:
  - Optional:
    - `yoffset` [float default 0.5 range [0 ~ 1]]
    - `xoffset` [float default 0.5 range [0 ~ 1]]
+   - `relative` [boolean default v:false]
    - `border` [string default `rounded`]: Border style
      - `rounded` / `sharp` / `horizontal` / `vertical` / `top` / `bottom` / `left` / `right` / `no[ne]`
 
@@ -372,7 +379,7 @@ last `fullscreen` argument of `fzf#wrap` (see :help <bang>).
 Our `:LS` command will be much more useful if we can pass a directory argument
 to it, so that something like `:LS /tmp` is possible.
 >
-    command! -bang -complete=dir -nargs=* LS
+    command! -bang -complete=dir -nargs=? LS
         \ call fzf#run(fzf#wrap({'source': 'ls', 'dir': <q-args>}, <bang>0))
 <
 Lastly, if you have enabled `g:fzf_history_dir`, you might want to assign a
@@ -380,7 +387,7 @@ unique name to our command and pass it as the first argument to `fzf#wrap`.
 >
     " The query history for this command will be stored as 'ls' inside g:fzf_history_dir.
     " The name is ignored if g:fzf_history_dir is not defined.
-    command! -bang -complete=dir -nargs=* LS
+    command! -bang -complete=dir -nargs=? LS
         \ call fzf#run(fzf#wrap('ls', {'source': 'ls', 'dir': <q-args>}, <bang>0))
 <
 
@@ -423,6 +430,7 @@ Starting fzf in a popup window~
     " Optional:
     " - xoffset [float default 0.5 range [0 ~ 1]]
     " - yoffset [float default 0.5 range [0 ~ 1]]
+    " - relative [boolean default v:false]
     " - border [string default 'rounded']: Border style
     "   - 'rounded' / 'sharp' / 'horizontal' / 'vertical' / 'top' / 'bottom' / 'left' / 'right'
     let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12
 	github.com/mattn/go-runewidth v0.0.12
 	github.com/mattn/go-shellwords v1.0.11
-	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/rivo/uniseg v0.2.0
 	github.com/saracen/walker v0.1.2
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57

--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 
 set -u
 
-version=0.27.1
+version=0.27.2
 auto_completion=
 key_bindings=
 update_config=2

--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 
 set -u
 
-version=0.26.0
+version=0.27.0
 auto_completion=
 key_bindings=
 update_config=2
@@ -168,8 +168,8 @@ archi=$(uname -sm)
 binary_available=1
 binary_error=""
 case "$archi" in
-  Darwin\ arm64)   download fzf-$version-darwin_arm64.tar.gz  ;;
-  Darwin\ x86_64)  download fzf-$version-darwin_amd64.tar.gz  ;;
+  Darwin\ arm64)   download fzf-$version-darwin_arm64.zip     ;;
+  Darwin\ x86_64)  download fzf-$version-darwin_amd64.zip     ;;
   Linux\ armv5*)   download fzf-$version-linux_armv5.tar.gz   ;;
   Linux\ armv6*)   download fzf-$version-linux_armv6.tar.gz   ;;
   Linux\ armv7*)   download fzf-$version-linux_armv7.tar.gz   ;;

--- a/install
+++ b/install
@@ -2,7 +2,7 @@
 
 set -u
 
-version=0.27.0
+version=0.27.1
 auto_completion=
 key_bindings=
 update_config=2

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-$version="0.26.0"
+$version="0.27.0"
 
 $fzf_base=Split-Path -Parent $MyInvocation.MyCommand.Definition
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-$version="0.27.1"
+$version="0.27.2"
 
 $fzf_base=Split-Path -Parent $MyInvocation.MyCommand.Definition
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,4 +1,4 @@
-$version="0.27.0"
+$version="0.27.1"
 
 $fzf_base=Split-Path -Parent $MyInvocation.MyCommand.Definition
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"github.com/junegunn/fzf/src/protector"
 )
 
-var version string = "0.26"
+var version string = "0.27"
 var revision string = "devel"
 
 func main() {

--- a/man/man1/fzf-tmux.1
+++ b/man/man1/fzf-tmux.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf-tmux 1 "May 2021" "fzf 0.27.1" "fzf-tmux - open fzf in tmux split pane"
+.TH fzf-tmux 1 "Jun 2021" "fzf 0.27.2" "fzf-tmux - open fzf in tmux split pane"
 
 .SH NAME
 fzf-tmux - open fzf in tmux split pane

--- a/man/man1/fzf-tmux.1
+++ b/man/man1/fzf-tmux.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf-tmux 1 "Apr 2021" "fzf 0.27.0" "fzf-tmux - open fzf in tmux split pane"
+.TH fzf-tmux 1 "May 2021" "fzf 0.27.1" "fzf-tmux - open fzf in tmux split pane"
 
 .SH NAME
 fzf-tmux - open fzf in tmux split pane

--- a/man/man1/fzf-tmux.1
+++ b/man/man1/fzf-tmux.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf-tmux 1 "Mar 2021" "fzf 0.26.0" "fzf-tmux - open fzf in tmux split pane"
+.TH fzf-tmux 1 "Apr 2021" "fzf 0.27.0" "fzf-tmux - open fzf in tmux split pane"
 
 .SH NAME
 fzf-tmux - open fzf in tmux split pane

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf 1 "May 2021" "fzf 0.27.2" "fzf - a command-line fuzzy finder"
+.TH fzf 1 "Jun 2021" "fzf 0.27.2" "fzf - a command-line fuzzy finder"
 
 .SH NAME
 fzf - a command-line fuzzy finder

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf 1 "Apr 2021" "fzf 0.27.0" "fzf - a command-line fuzzy finder"
+.TH fzf 1 "May 2021" "fzf 0.27.1" "fzf - a command-line fuzzy finder"
 
 .SH NAME
 fzf - a command-line fuzzy finder
@@ -852,6 +852,7 @@ A key or an event can be bound to one or more of the following actions.
     \fBtoggle-search\fR             (toggle search functionality)
     \fBtoggle-sort\fR
     \fBtoggle+up\fR                 \fIbtab    (shift-tab)\fR
+    \fBunbind(...)\fR               (unbind bindings)
     \fBunix-line-discard\fR         \fIctrl-u\fR
     \fBunix-word-rubout\fR          \fIctrl-w\fR
     \fBup\fR                        \fIctrl-k  ctrl-p  up\fR

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf 1 "May 2021" "fzf 0.27.1" "fzf - a command-line fuzzy finder"
+.TH fzf 1 "May 2021" "fzf 0.27.2" "fzf - a command-line fuzzy finder"
 
 .SH NAME
 fzf - a command-line fuzzy finder
@@ -340,6 +340,22 @@ color mappings.
     \fB-1         \fRDefault terminal foreground/background color
     \fB           \fR(or the original color of the text)
     \fB0 ~ 15     \fR16 base colors
+      \fBblack\fR
+      \fBred\fR
+      \fBgreen\fR
+      \fByellow\fR
+      \fBblue\fR
+      \fBmagenta\fR
+      \fBcyan\fR
+      \fBwhite\fR
+      \fBbright-black\fR (gray | grey)
+      \fBbright-red\fR
+      \fBbright-green\fR
+      \fBbright-yellow\fR
+      \fBbright-blue\fR
+      \fBbright-magenta\fR
+      \fBbright-cyan\fR
+      \fBbright-white\fR
     \fB16 ~ 255   \fRANSI 256 colors
     \fB#rrggbb    \fR24-bit colors
 

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -532,10 +532,12 @@ e.g.
 Start the finder with the given query
 .TP
 .B "-1, --select-1"
-Automatically select the only match
+If there is only one match for the initial query (\fB--query\fR), do not start
+interactive finder and automatically select the only match
 .TP
 .B "-0, --exit-0"
-Exit immediately when there's no match
+If there is no match for the initial query (\fB--query\fR), do not start
+interactive finder and exit immediately
 .TP
 .BI "-f, --filter=" "STR"
 Filter mode. Do not start interactive finder. When used with \fB--no-sort\fR,

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf 1 "Mar 2021" "fzf 0.26.0" "fzf - a command-line fuzzy finder"
+.TH fzf 1 "Apr 2021" "fzf 0.27.0" "fzf - a command-line fuzzy finder"
 
 .SH NAME
 fzf - a command-line fuzzy finder

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -978,13 +978,13 @@ function! s:popup(opts) abort
 
   " Use current window size for positioning relatively positioned popups
   let columns = relative ? winwidth(0) : &columns
-  let lines = relative ? winheight(0) : &lines
+  let lines = relative ? winheight(0) : (&lines - has('nvim'))
 
   " Size and position
   let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(columns * a:opts.width)]), columns])
-  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(lines * a:opts.height)]), lines - has('nvim')])
-  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] : 0)
-  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] : 0)
+  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(lines * a:opts.height)]), lines])
+  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] - 1 : 0)
+  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] - 1 : 0)
 
   " Managing the differences
   let row = min([max([0, row]), &lines - has('nvim') - height])

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -419,13 +419,13 @@ function! fzf#wrap(...)
   endif
 
   " Action: g:fzf_action
-  if !s:has_any(opts, ['sink', 'sink*'])
+  if !s:has_any(opts, ['sink', 'sinklist', 'sink*'])
     let opts._action = get(g:, 'fzf_action', s:default_action)
     let opts.options .= ' --expect='.join(keys(opts._action), ',')
-    function! opts.sink(lines) abort
+    function! opts.sinklist(lines) abort
       return s:common_sink(self._action, a:lines)
     endfunction
-    let opts['sink*'] = remove(opts, 'sink')
+    let opts['sink*'] = opts.sinklist " For backward compatibility
   endif
 
   return opts
@@ -943,6 +943,8 @@ function! s:callback(dict, lines) abort
     endif
     if has_key(a:dict, 'sink*')
       call a:dict['sink*'](a:lines)
+    elseif has_key(a:dict, 'sinklist')
+      call a:dict['sinklist'](a:lines)
     endif
   catch
     if stridx(v:exception, ':E325:') < 0

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -972,11 +972,19 @@ else
 endif
 
 function! s:popup(opts) abort
+  let xoffset = get(a:opts, 'xoffset', 0.5)
+  let yoffset = get(a:opts, 'yoffset', 0.5)
+  let relative = get(a:opts, 'relative', 0)
+
+  " Use current window size for positioning relatively positioned popups
+  let columns = relative ? winwidth(0) : &columns
+  let lines = relative ? winheight(0) : &lines
+
   " Size and position
-  let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(&columns * a:opts.width)]), &columns])
-  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(&lines * a:opts.height)]), &lines - has('nvim')])
-  let row = float2nr(get(a:opts, 'yoffset', 0.5) * (&lines - height))
-  let col = float2nr(get(a:opts, 'xoffset', 0.5) * (&columns - width))
+  let width = min([max([8, a:opts.width > 1 ? a:opts.width : float2nr(columns * a:opts.width)]), columns])
+  let height = min([max([4, a:opts.height > 1 ? a:opts.height : float2nr(lines * a:opts.height)]), lines - has('nvim')])
+  let row = float2nr(yoffset * (lines - height)) + (relative ? win_screenpos(0)[0] : 0)
+  let col = float2nr(xoffset * (columns - width)) + (relative ? win_screenpos(0)[1] : 0)
 
   " Managing the differences
   let row = min([max([0, row]), &lines - has('nvim') - height])

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -519,7 +519,7 @@ finally
     if len(prev_default_command)
       let $FZF_DEFAULT_COMMAND = prev_default_command
     else
-      unlet $FZF_DEFAULT_COMMAND
+      execute 'unlet $FZF_DEFAULT_COMMAND'
     endif
   endif
   let [&shell, &shellslash, &shellcmdflag, &shellxquote] = [shell, shellslash, shellcmdflag, shellxquote]

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -487,17 +487,17 @@ try
   let has_vim8_term = has('terminal') && has('patch-8.0.995')
   let has_nvim_term = has('nvim-0.2.1') || has('nvim') && !s:is_win
   let use_term = has_nvim_term ||
-    \ has_vim8_term && !has('win32unix') && (has('gui_running') || s:is_win || !use_height && s:present(dict, 'down', 'up', 'left', 'right', 'window'))
+    \ has_vim8_term && !has('win32unix') && (has('gui_running') || s:is_win || s:present(dict, 'down', 'up', 'left', 'right', 'window'))
   let use_tmux = (has_key(dict, 'tmux') || (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:splittable(dict)) && s:tmux_enabled()
   if prefer_tmux && use_tmux
     let use_height = 0
     let use_term = 0
   endif
-  if use_height
+  if use_term
+    let optstr .= ' --no-height'
+  elseif use_height
     let height = s:calc_size(&lines, dict.down, dict)
     let optstr .= ' --height='.height
-  elseif use_term
-    let optstr .= ' --no-height'
   endif
   let optstr .= s:border_opt(get(dict, 'window', 0))
   let prev_default_command = $FZF_DEFAULT_COMMAND

--- a/src/fzflib.go
+++ b/src/fzflib.go
@@ -1,0 +1,407 @@
+/*
+Package fzf implements fzf, a command-line fuzzy finder.
+
+The MIT License (MIT)
+
+Copyright (c) 2013-2021 Junegunn Choi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package fzf
+
+import (
+	"bytes"
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"github.com/junegunn/fzf/src/util"
+	"github.com/mattn/go-shellwords"
+)
+
+/*
+Reader   -> EvtReadFin
+Reader   -> EvtReadNew        -> Matcher  (restart)
+Terminal -> EvtSearchNew:bool -> Matcher  (restart)
+Matcher  -> EvtSearchProgress -> Terminal (update info)
+Matcher  -> EvtSearchFin      -> Terminal (update list)
+Matcher  -> EvtHeader         -> Terminal (update header)
+*/
+
+type Out struct {
+	out string
+	err error
+}
+
+// FzfFilter filters choices into the chosen strings.
+// options shoud be specified in the same manner as for fzf's cli (eg. "-m -e --extended").
+func FzfFilter(choices []string, options string) (chosen []string, err error) {
+	in, out := make(chan string), make(chan Out)
+	go Fzf(in, out, options)
+	go func() {
+		for _, c := range choices {
+			in <- c
+		}
+		close(in)
+	}()
+	for o := range out {
+		if o.err != nil {
+			err = o.err
+			return
+		}
+		chosen = append(chosen, o.out)
+	}
+	return
+}
+
+// Fzf filters the input channel into the output channel, which wraps both normal output and errors.
+// This should be launched either in a goroutine, or with large enough buffered channels.
+// FzfFilter is a good example of how to use Fzf.
+// options shoud be specified in the same manner as for fzf's cli (eg. "-m -e --extended").
+func Fzf(in <-chan string, out chan<- Out, options string) {
+	defer func() {
+		r := recover()
+		if r != nil {
+			out <- Out{err: fmt.Errorf("%v", r)}
+		}
+		close(out)
+	}()
+
+	// Taking environment variables into account here does not seem appropriate.
+	opts := defaultOptions()
+	words, _ := shellwords.Parse(options)
+	if len(words) > 0 {
+		parseOptions(opts, words)
+	}
+	postProcessOptions(opts)
+
+	opts.Printer = func(str string) { out <- Out{out: str} }
+
+	sort := opts.Sort > 0
+	sortCriteria = opts.Criteria
+
+	// the version switch should not have any use here
+	// if opts.Version {}
+
+	// Event channel
+	eventBox := util.NewEventBox()
+
+	// ANSI code processor
+	ansiProcessor := func(data []byte) (util.Chars, *[]ansiOffset) {
+		return util.ToChars(data), nil
+	}
+
+	var lineAnsiState, prevLineAnsiState *ansiState
+	if opts.Ansi {
+		if opts.Theme.Colored {
+			ansiProcessor = func(data []byte) (util.Chars, *[]ansiOffset) {
+				prevLineAnsiState = lineAnsiState
+				trimmed, offsets, newState := extractColor(string(data), lineAnsiState, nil)
+				lineAnsiState = newState
+				return util.ToChars([]byte(trimmed)), offsets
+			}
+		} else {
+			// When color is disabled but ansi option is given,
+			// we simply strip out ANSI codes from the input
+			ansiProcessor = func(data []byte) (util.Chars, *[]ansiOffset) {
+				trimmed, _, _ := extractColor(string(data), nil, nil)
+				return util.ToChars([]byte(trimmed)), nil
+			}
+		}
+	}
+
+	// Chunk list
+	var chunkList *ChunkList
+	var itemIndex int32
+	header := make([]string, 0, opts.HeaderLines)
+	if len(opts.WithNth) == 0 {
+		chunkList = NewChunkList(func(item *Item, data []byte) bool {
+			if len(header) < opts.HeaderLines {
+				header = append(header, string(data))
+				eventBox.Set(EvtHeader, header)
+				return false
+			}
+			item.text, item.colors = ansiProcessor(data)
+			item.text.Index = itemIndex
+			itemIndex++
+			return true
+		})
+	} else {
+		chunkList = NewChunkList(func(item *Item, data []byte) bool {
+			tokens := Tokenize(string(data), opts.Delimiter)
+			if opts.Ansi && opts.Theme.Colored && len(tokens) > 1 {
+				var ansiState *ansiState
+				if prevLineAnsiState != nil {
+					ansiStateDup := *prevLineAnsiState
+					ansiState = &ansiStateDup
+				}
+				for _, token := range tokens {
+					prevAnsiState := ansiState
+					_, _, ansiState = extractColor(token.text.ToString(), ansiState, nil)
+					if prevAnsiState != nil {
+						token.text.Prepend("\x1b[m" + prevAnsiState.ToString())
+					} else {
+						token.text.Prepend("\x1b[m")
+					}
+				}
+			}
+			trans := Transform(tokens, opts.WithNth)
+			transformed := joinTokens(trans)
+			if len(header) < opts.HeaderLines {
+				header = append(header, transformed)
+				eventBox.Set(EvtHeader, header)
+				return false
+			}
+			item.text, item.colors = ansiProcessor([]byte(transformed))
+			item.text.TrimTrailingWhitespaces()
+			item.text.Index = itemIndex
+			item.origText = &data
+			itemIndex++
+			return true
+		})
+	}
+
+	// Reader
+	streamingFilter := opts.Filter != nil && !sort && !opts.Tac && !opts.Sync
+	var reader *Reader
+	if !streamingFilter {
+		reader = NewReader(func(data []byte) bool {
+			return chunkList.Push(data)
+		}, eventBox, opts.ReadZero, opts.Filter == nil)
+		go reader.ReadInput(in)
+	}
+
+	// Matcher
+	forward := true
+	for _, cri := range opts.Criteria[1:] {
+		if cri == byEnd {
+			forward = false
+			break
+		}
+		if cri == byBegin {
+			break
+		}
+	}
+	patternBuilder := func(runes []rune) *Pattern {
+		return BuildPattern(
+			opts.Fuzzy, opts.FuzzyAlgo, opts.Extended, opts.Case, opts.Normalize, forward,
+			opts.Filter == nil, opts.Nth, opts.Delimiter, runes)
+	}
+	matcher := NewMatcher(patternBuilder, sort, opts.Tac, eventBox)
+
+	// Filtering mode
+	if opts.Filter != nil {
+		if opts.PrintQuery {
+			opts.Printer(*opts.Filter)
+		}
+
+		pattern := patternBuilder([]rune(*opts.Filter))
+		matcher.sort = pattern.sortable
+
+		found := false
+		if streamingFilter {
+			slab := util.MakeSlab(slab16Size, slab32Size)
+			reader := NewReader(
+				func(runes []byte) bool {
+					item := Item{}
+					if chunkList.trans(&item, runes) {
+						if result, _, _ := pattern.MatchItem(&item, false, slab); result != nil {
+							opts.Printer(item.text.ToString())
+							found = true
+						}
+					}
+					return false
+				}, eventBox, opts.ReadZero, false)
+			reader.ReadInput(in)
+		} else {
+			eventBox.Unwatch(EvtReadNew)
+			eventBox.WaitFor(EvtReadFin)
+
+			snapshot, _ := chunkList.Snapshot()
+			merger, _ := matcher.scan(MatchRequest{
+				chunks:  snapshot,
+				pattern: pattern})
+			for i := 0; i < merger.Length(); i++ {
+				opts.Printer(merger.Get(i).item.AsString(opts.Ansi))
+				found = true
+			}
+		}
+		if found {
+			// Barbaric but necessary to avoid to refactor everything.
+			panic(nil)
+		}
+		// Barbaric but necessary to avoid to refactor everything.
+		panic("no match")
+	}
+
+	// Synchronous search
+	if opts.Sync {
+		eventBox.Unwatch(EvtReadNew)
+		eventBox.WaitFor(EvtReadFin)
+	}
+
+	// Go interactive
+	go matcher.Loop()
+
+	// Terminal I/O
+	terminal := NewTerminal(opts, eventBox)
+	deferred := opts.Select1 || opts.Exit0
+	go terminal.Loop()
+	if !deferred {
+		terminal.startChan <- true
+	}
+
+	// Event coordination
+	reading := true
+	clearCache := util.Once(false)
+	clearSelection := util.Once(false)
+	ticks := 0
+	var nextCommand *string
+	restart := func(command string) {
+		reading = true
+		clearCache = util.Once(true)
+		clearSelection = util.Once(true)
+		chunkList.Clear()
+		header = make([]string, 0, opts.HeaderLines)
+		go reader.restart(command)
+	}
+	eventBox.Watch(EvtReadNew)
+	query := []rune{}
+	for {
+		delay := true
+		ticks++
+		input := func() []rune {
+			paused, input := terminal.Input()
+			if !paused {
+				query = input
+			}
+			return query
+		}
+		eventBox.Wait(func(events *util.Events) {
+			if _, fin := (*events)[EvtReadFin]; fin {
+				delete(*events, EvtReadNew)
+			}
+			for evt, value := range *events {
+				switch evt {
+				case EvtQuit:
+					if reading {
+						reader.terminate()
+					}
+					panic(nil)
+				case EvtReadNew, EvtReadFin:
+					if evt == EvtReadFin && nextCommand != nil {
+						restart(*nextCommand)
+						nextCommand = nil
+						break
+					} else {
+						reading = reading && evt == EvtReadNew
+					}
+					snapshot, count := chunkList.Snapshot()
+					terminal.UpdateCount(count, !reading, value.(*string))
+					if opts.Sync {
+						opts.Sync = false
+						terminal.UpdateList(PassMerger(&snapshot, opts.Tac), false)
+					}
+					matcher.Reset(snapshot, input(), false, !reading, sort, clearCache())
+
+				case EvtSearchNew:
+					var command *string
+					switch val := value.(type) {
+					case searchRequest:
+						sort = val.sort
+						command = val.command
+					}
+					if command != nil {
+						if reading {
+							reader.terminate()
+							nextCommand = command
+						} else {
+							restart(*command)
+						}
+						break
+					}
+					snapshot, _ := chunkList.Snapshot()
+					matcher.Reset(snapshot, input(), true, !reading, sort, clearCache())
+					delay = false
+
+				case EvtSearchProgress:
+					switch val := value.(type) {
+					case float32:
+						terminal.UpdateProgress(val)
+					}
+
+				case EvtHeader:
+					headerPadded := make([]string, opts.HeaderLines)
+					copy(headerPadded, value.([]string))
+					terminal.UpdateHeader(headerPadded)
+
+				case EvtSearchFin:
+					switch val := value.(type) {
+					case *Merger:
+						if deferred {
+							count := val.Length()
+							if opts.Select1 && count > 1 || opts.Exit0 && !opts.Select1 && count > 0 {
+								deferred = false
+								terminal.startChan <- true
+							} else if val.final {
+								if opts.Exit0 && count == 0 || opts.Select1 && count == 1 {
+									if opts.PrintQuery {
+										opts.Printer(opts.Query)
+									}
+									if len(opts.Expect) > 0 {
+										opts.Printer("")
+									}
+									for i := 0; i < count; i++ {
+										opts.Printer(val.Get(i).item.AsString(opts.Ansi))
+									}
+									if count > 0 {
+										// Barbaric but necessary to avoid to refactor everything.
+										panic(nil)
+									}
+									// Barbaric but necessary to avoid to refactor everything.
+									panic("no match")
+								}
+								deferred = false
+								terminal.startChan <- true
+							}
+						}
+						terminal.UpdateList(val, clearSelection())
+					}
+				}
+			}
+			events.Clear()
+		})
+		if delay && reading {
+			dur := util.DurWithin(
+				time.Duration(ticks)*coordinatorDelayStep,
+				0, coordinatorDelayMax)
+			time.Sleep(dur)
+		}
+	}
+}
+
+func (r *Reader) ReadInput(in <-chan string) {
+	r.startEventPoller()
+	for str := range in {
+		if r.pusher(bytes.NewBufferString(str).Bytes()) {
+			atomic.StoreInt32(&r.event, int32(EvtReadNew))
+		}
+	}
+	r.fin(true)
+}

--- a/src/fzflib.go
+++ b/src/fzflib.go
@@ -51,6 +51,9 @@ type Out struct {
 
 // FzfFilter filters choices into the chosen strings.
 // options shoud be specified in the same manner as for fzf's cli (eg. "-m -e --extended").
+// WARNING: Any problem while fzf is handling the TTY or parsing the options string will result in a call
+// to os.Exit(). There is no way to change this without refactoring a large portion of the code.
+// If you specify any options, you must be absolutely certain that they are valid.
 func FzfFilter(choices []string, options string) (chosen []string, err error) {
 	in, out := make(chan string), make(chan Out)
 	go Fzf(in, out, options)
@@ -74,6 +77,9 @@ func FzfFilter(choices []string, options string) (chosen []string, err error) {
 // This should be launched either in a goroutine, or with large enough buffered channels.
 // FzfFilter is a good example of how to use Fzf.
 // options shoud be specified in the same manner as for fzf's cli (eg. "-m -e --extended").
+// WARNING: Any problem while fzf is handling the TTY or parsing the options string will result in a call
+// to os.Exit(). There is no way to change this without refactoring a large portion of the code.
+// If you specify any options, you must be absolutely certain that they are valid.
 func Fzf(in <-chan string, out chan<- Out, options string) {
 	defer func() {
 		r := recover()

--- a/src/options.go
+++ b/src/options.go
@@ -670,6 +670,38 @@ func parseTheme(defaultTheme *tui.ColorTheme, str string) *tui.ColorTheme {
 						cattr.Attr |= tui.Blink
 					case "reverse":
 						cattr.Attr |= tui.Reverse
+					case "black":
+						cattr.Color = tui.Color(0)
+					case "red":
+						cattr.Color = tui.Color(1)
+					case "green":
+						cattr.Color = tui.Color(2)
+					case "yellow":
+						cattr.Color = tui.Color(3)
+					case "blue":
+						cattr.Color = tui.Color(4)
+					case "magenta":
+						cattr.Color = tui.Color(5)
+					case "cyan":
+						cattr.Color = tui.Color(6)
+					case "white":
+						cattr.Color = tui.Color(7)
+					case "bright-black", "gray", "grey":
+						cattr.Color = tui.Color(8)
+					case "bright-red":
+						cattr.Color = tui.Color(9)
+					case "bright-green":
+						cattr.Color = tui.Color(10)
+					case "bright-yellow":
+						cattr.Color = tui.Color(11)
+					case "bright-blue":
+						cattr.Color = tui.Color(12)
+					case "bright-magenta":
+						cattr.Color = tui.Color(13)
+					case "bright-cyan":
+						cattr.Color = tui.Color(14)
+					case "bright-white":
+						cattr.Color = tui.Color(15)
 					case "":
 					default:
 						if rrggbb.MatchString(component) {

--- a/src/options.go
+++ b/src/options.go
@@ -1536,15 +1536,13 @@ func validateSign(sign string, signOptName string) error {
 	if sign == "" {
 		return fmt.Errorf("%v cannot be empty", signOptName)
 	}
-	widthSum := 0
 	for _, r := range sign {
 		if !unicode.IsGraphic(r) {
 			return fmt.Errorf("invalid character in %v", signOptName)
 		}
-		widthSum += runewidth.RuneWidth(r)
-		if widthSum > 2 {
-			return fmt.Errorf("%v display width should be up to 2", signOptName)
-		}
+	}
+	if runewidth.StringWidth(sign) > 2 {
+		return fmt.Errorf("%v display width should be up to 2", signOptName)
 	}
 	return nil
 }

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -425,6 +425,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		delay = initialDelay
 	}
 	var previewBox *util.EventBox
+	showPreviewWindow := len(opts.Preview.command) > 0 && !opts.Preview.hidden
 	if len(opts.Preview.command) > 0 || hasPreviewAction(opts) {
 		previewBox = util.NewEventBox()
 	}
@@ -521,7 +522,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox) *Terminal {
 		selected:    make(map[int32]selectedItem),
 		reqBox:      util.NewEventBox(),
 		previewOpts: opts.Preview,
-		previewer:   previewer{0, []string{}, 0, previewBox != nil && !opts.Preview.hidden, false, true, false, ""},
+		previewer:   previewer{0, []string{}, 0, showPreviewWindow, false, true, false, ""},
 		previewed:   previewed{0, 0, 0, false},
 		previewBox:  previewBox,
 		eventBox:    eventBox,

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2,7 +2,6 @@ package fzf
 
 import (
 	"bufio"
-	"bytes"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -14,6 +13,9 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
 
 	"github.com/junegunn/fzf/src/tui"
 	"github.com/junegunn/fzf/src/util"
@@ -673,11 +675,8 @@ func (t *Terminal) sortSelected() []selectedItem {
 }
 
 func (t *Terminal) displayWidth(runes []rune) int {
-	l := 0
-	for _, r := range runes {
-		l += util.RuneWidth(r, l, t.tabstop)
-	}
-	return l
+	width, _ := util.RunesWidth(runes, 0, t.tabstop, 0)
+	return width
 }
 
 const (
@@ -1141,28 +1140,18 @@ func (t *Terminal) printItem(result Result, line int, i int, current bool) {
 	t.prevLines[i] = newLine
 }
 
-func (t *Terminal) trimRight(runes []rune, width int) ([]rune, int) {
+func (t *Terminal) trimRight(runes []rune, width int) ([]rune, bool) {
 	// We start from the beginning to handle tab characters
-	l := 0
-	for idx, r := range runes {
-		l += util.RuneWidth(r, l, t.tabstop)
-		if l > width {
-			return runes[:idx], len(runes) - idx
-		}
+	width, overflowIdx := util.RunesWidth(runes, 0, t.tabstop, width)
+	if overflowIdx >= 0 {
+		return runes[:overflowIdx], true
 	}
-	return runes, 0
+	return runes, false
 }
 
 func (t *Terminal) displayWidthWithLimit(runes []rune, prefixWidth int, limit int) int {
-	l := 0
-	for _, r := range runes {
-		l += util.RuneWidth(r, l+prefixWidth, t.tabstop)
-		if l > limit {
-			// Early exit
-			return l
-		}
-	}
-	return l
+	width, _ := util.RunesWidth(runes, prefixWidth, t.tabstop, limit)
+	return width
 }
 
 func (t *Terminal) trimLeft(runes []rune, width int) ([]rune, int32) {
@@ -1362,9 +1351,9 @@ func (t *Terminal) renderPreviewText(height int, lines []string, lineNo int, unc
 			prefixWidth := 0
 			_, _, ansi = extractColor(line, ansi, func(str string, ansi *ansiState) bool {
 				trimmed := []rune(str)
-				trimmedLen := 0
+				isTrimmed := false
 				if !t.previewOpts.wrap {
-					trimmed, trimmedLen = t.trimRight(trimmed, maxWidth-t.pwindow.X())
+					trimmed, isTrimmed = t.trimRight(trimmed, maxWidth-t.pwindow.X())
 				}
 				str, width := t.processTabs(trimmed, prefixWidth)
 				prefixWidth += width
@@ -1374,7 +1363,7 @@ func (t *Terminal) renderPreviewText(height int, lines []string, lineNo int, unc
 				} else {
 					fillRet = t.pwindow.CFill(tui.ColPreview.Fg(), tui.ColPreview.Bg(), tui.AttrRegular, str)
 				}
-				return trimmedLen == 0 &&
+				return !isTrimmed &&
 					(fillRet == tui.FillContinue || t.previewOpts.wrap && fillRet == tui.FillNextLine)
 			})
 			t.previewer.scrollable = t.previewer.scrollable || t.pwindow.Y() == height-1 && t.pwindow.X() == t.pwindow.Width()
@@ -1430,16 +1419,21 @@ func (t *Terminal) printPreviewDelayed() {
 }
 
 func (t *Terminal) processTabs(runes []rune, prefixWidth int) (string, int) {
-	var strbuf bytes.Buffer
+	var strbuf strings.Builder
 	l := prefixWidth
-	for _, r := range runes {
-		w := util.RuneWidth(r, l, t.tabstop)
-		l += w
-		if r == '\t' {
+	gr := uniseg.NewGraphemes(string(runes))
+	for gr.Next() {
+		rs := gr.Runes()
+		str := string(rs)
+		var w int
+		if len(rs) == 1 && rs[0] == '\t' {
+			w = t.tabstop - l%t.tabstop
 			strbuf.WriteString(strings.Repeat(" ", w))
 		} else {
-			strbuf.WriteRune(r)
+			w = runewidth.StringWidth(str)
+			strbuf.WriteString(str)
 		}
+		l += w
 	}
 	return strbuf.String(), l
 }

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -284,6 +284,7 @@ const (
 	actEnableSearch
 	actSelect
 	actDeselect
+	actUnbind
 )
 
 type placeholderFlags struct {
@@ -2656,6 +2657,11 @@ func (t *Terminal) Loop() {
 				if valid {
 					command := t.replacePlaceholder(a.a, false, string(t.input), list)
 					newCommand = &command
+				}
+			case actUnbind:
+				keys := parseKeyChords(a.a, "PANIC")
+				for key := range keys {
+					delete(t.keymap, key)
 				}
 			}
 			return true

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -10,7 +10,8 @@ import (
 	"time"
 	"unicode/utf8"
 
-	"github.com/junegunn/fzf/src/util"
+	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
 
 	"golang.org/x/term"
 )
@@ -50,7 +51,7 @@ func (r *LightRenderer) stderrInternal(str string, allowNLCR bool) {
 		}
 		bytes = bytes[sz:]
 	}
-	r.queued += string(runes)
+	r.queued.WriteString(string(runes))
 }
 
 func (r *LightRenderer) csi(code string) {
@@ -58,9 +59,9 @@ func (r *LightRenderer) csi(code string) {
 }
 
 func (r *LightRenderer) flush() {
-	if len(r.queued) > 0 {
-		fmt.Fprint(os.Stderr, r.queued)
-		r.queued = ""
+	if r.queued.Len() > 0 {
+		fmt.Fprint(os.Stderr, r.queued.String())
+		r.queued.Reset()
 	}
 }
 
@@ -82,7 +83,7 @@ type LightRenderer struct {
 	escDelay      int
 	fullscreen    bool
 	upOneLine     bool
-	queued        string
+	queued        strings.Builder
 	y             int
 	x             int
 	maxHeightFunc func(int) int
@@ -889,20 +890,26 @@ func wrapLine(input string, prefixLength int, max int, tabstop int) []wrappedLin
 	lines := []wrappedLine{}
 	width := 0
 	line := ""
-	for _, r := range input {
-		w := util.RuneWidth(r, prefixLength+width, 8)
-		width += w
-		str := string(r)
-		if r == '\t' {
+	gr := uniseg.NewGraphemes(input)
+	for gr.Next() {
+		rs := gr.Runes()
+		str := string(rs)
+		var w int
+		if len(rs) == 1 && rs[0] == '\t' {
+			w = tabstop - (prefixLength+width)%tabstop
 			str = repeat(' ', w)
+		} else {
+			w = runewidth.StringWidth(str)
 		}
+		width += w
+
 		if prefixLength+width <= max {
 			line += str
 		} else {
 			lines = append(lines, wrappedLine{string(line), width - w})
 			line = str
 			prefixLength = 0
-			width = util.RuneWidth(r, prefixLength, 8)
+			width = w
 		}
 	}
 	lines = append(lines, wrappedLine{string(line), width})

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -7,22 +7,29 @@ import (
 
 	"github.com/mattn/go-isatty"
 	"github.com/mattn/go-runewidth"
+	"github.com/rivo/uniseg"
 )
 
-var _runeWidths = make(map[rune]int)
-
-// RuneWidth returns rune width
-func RuneWidth(r rune, prefixWidth int, tabstop int) int {
-	if r == '\t' {
-		return tabstop - prefixWidth%tabstop
-	} else if w, found := _runeWidths[r]; found {
-		return w
-	} else if r == '\n' || r == '\r' {
-		return 1
+// RunesWidth returns runes width
+func RunesWidth(runes []rune, prefixWidth int, tabstop int, limit int) (int, int) {
+	width := 0
+	gr := uniseg.NewGraphemes(string(runes))
+	idx := 0
+	for gr.Next() {
+		rs := gr.Runes()
+		var w int
+		if len(rs) == 1 && rs[0] == '\t' {
+			w = tabstop - (prefixWidth+width)%tabstop
+		} else {
+			w = runewidth.StringWidth(string(rs))
+		}
+		width += w
+		if limit > 0 && width > limit {
+			return width, idx
+		}
+		idx += len(rs)
 	}
-	w := runewidth.RuneWidth(r)
-	_runeWidths[r] = w
-	return w
+	return width, -1
 }
 
 // Max returns the largest integer

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -3,6 +3,7 @@ package util
 import (
 	"math"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/mattn/go-isatty"
@@ -21,7 +22,8 @@ func RunesWidth(runes []rune, prefixWidth int, tabstop int, limit int) (int, int
 		if len(rs) == 1 && rs[0] == '\t' {
 			w = tabstop - (prefixWidth+width)%tabstop
 		} else {
-			w = runewidth.StringWidth(string(rs))
+			s := string(rs)
+			w = runewidth.StringWidth(s) + strings.Count(s, "\n")
 		}
 		width += w
 		if limit > 0 && width > limit {

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2042,6 +2042,17 @@ class TestGoFZF < TestBase
     tmux.send_keys 'C-K'
     tmux.until { |lines| assert_equal(%w[1 2 3 4 5], top5[lines]) }
   end
+
+  def test_unbind
+    tmux.send_keys "seq 100 | #{FZF} --bind 'c:clear-query,d:unbind(c,d)'", :Enter
+    tmux.until { |lines| assert_equal 100, lines.item_count }
+    tmux.send_keys 'ab'
+    tmux.until { |lines| assert_equal '> ab', lines[-1] }
+    tmux.send_keys 'c'
+    tmux.until { |lines| assert_equal '>', lines[-1] }
+    tmux.send_keys 'dabcd'
+    tmux.until { |lines| assert_equal '> abcd', lines[-1] }
+  end
 end
 
 module TestShell


### PR DESCRIPTION
Hello,

I've been using fzf for a while now, both from the cli and by embedding it into programs the recommended way (https://junegunn.kr/2016/02/using-fzf-in-your-program).
However, now I'm learning Go and I wanted to use fzf in a program without needing to rely on it being on the target system.
I first tried to do that client-side by using Fzf's public API, but a lot of necessary parts are private (e.g. defaultOptions).
Failing that, I forked your repo and created two new functions:
 - Fzf(in <-chan string, out chan<- Out, options string) {} is largely based on Run from core.go, except it replaces os.StdIn with a string channel, and os.StdOut and os.StdErr by an output channel (containing both strings and errors).
 - FzfFilter(choices []string, options string) (chosen []string, err error) {} is a helper function doing what I'll mostly need, and it does not require any private stuff.

Since I did not want to refactor any of your code (I don't want to introduce any bug), everything is contained in a new file.
However, since Run is a large function, there are a lot of redundancy, I think you should consider splitting it.

In order to break out of the started goroutines (such as matcher.Loop()) without needing to refactor important parts, I used an ugly defer, panic and recover trick. I believe it works as intended without leaking any ressource.

There are a lot of calls to os.Exit in options.go and elsewhere, the functions will crash the whole program if those are triggered.

There may be other unwanted side effects I am not aware of, and they are probably the reason why you did not want to do this in the first place...