### PR TITLE
Add dependabot config for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-


### PR DESCRIPTION
Creates update PRs similar to https://github.com/dbast/fzf/pulls with history for each dependency bump etc for review.

PRs can be merged if CI is green or closed to ignore the dependency regarding auto updates.