### PR TITLE
Restore VT hack for Windows

### DIFF
--- a/src/tui/light_windows.go
+++ b/src/tui/light_windows.go
@@ -73,6 +73,9 @@ func (r *LightRenderer) initPlatform() error {
 		fd := int(r.inHandle)
 		b := make([]byte, 1)
 		for {
+			// HACK: if run from PSReadline, something resets ConsoleMode to remove ENABLE_VIRTUAL_TERMINAL_INPUT.
+			_ = windows.SetConsoleMode(windows.Handle(r.inHandle), consoleFlagsInput)
+
 			_, err := util.Read(fd, b)
 			if err == nil {
 				r.ttyinChannel <- b[0]


### PR DESCRIPTION
- restore VT enable hack;  this is restoring 2 lines of code that were removed in a previous commit of mine (https://github.com/junegunn/fzf/pull/2430/commits/281f9982acef2d3dfcb68545cee2383f0d29ad3f)
- resolves an issue reported in kelleyma49/PSFzf#84 