### PR TITLE
Minor changes

### DIFF
--- a/src/ansi_test.go
+++ b/src/ansi_test.go
@@ -1,7 +1,6 @@
 package fzf
 
 import (
-	"fmt"
 	"math/rand"
 	"regexp"
 	"strings"
@@ -207,7 +206,7 @@ func TestExtractColor(t *testing.T) {
 		if output != "hello world" {
 			t.Errorf("Invalid output: %s %v", output, []rune(output))
 		}
-		fmt.Println(src, ansiOffsets, clean)
+		t.Log(src, ansiOffsets, clean)
 		assertion(ansiOffsets, state)
 	}
 

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -385,7 +385,6 @@ func (r *FullscreenRenderer) GetChar() Event {
 		case tcell.KeyF12:
 			return Event{F12, 0, nil}
 
-		// ev.Ch doesn't work for some reason for space:
 		case tcell.KeyRune:
 			r := ev.Rune()
 			if alt {


### PR DESCRIPTION
This is few minor things I came across lately.

- fmt.Println in tests doesn't honor verbosity flags like t.Log does
- the keyboard event works just fine for space character
