### PR TITLE
Fix spelling and broken links

### DIFF
--- a/src/ansi_test.go
+++ b/src/ansi_test.go
@@ -16,8 +16,10 @@ import (
 //
 // References:
 // 	- https://github.com/gnachman/iTerm2
-// 	- http://ascii-table.com/ansi-escape-sequences.php
-// 	- http://ascii-table.com/ansi-escape-sequences-vt-100.php
+// 	- https://web.archive.org/web/20090204053813/http://ascii-table.com/ansi-escape-sequences.php
+//      (archived from http://ascii-table.com/ansi-escape-sequences.php)
+// 	- https://web.archive.org/web/20090227051140/http://ascii-table.com/ansi-escape-sequences-vt-100.php
+//      (archived from http://ascii-table.com/ansi-escape-sequences-vt-100.php)
 // 	- http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x405.html
 // 	- https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 var ansiRegexReference = regexp.MustCompile("(?:\x1b[\\[()][0-9;]*[a-zA-Z@]|\x1b][0-9];[[:print:]]+(?:\x1b\\\\|\x07)|\x1b.|[\x0e\x0f]|.\x08)")

--- a/src/ansi_test.go
+++ b/src/ansi_test.go
@@ -20,7 +20,7 @@ import (
 // 	- http://ascii-table.com/ansi-escape-sequences-vt-100.php
 // 	- http://tldp.org/HOWTO/Bash-Prompt-HOWTO/x405.html
 // 	- https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
-var ansiRegexRefence = regexp.MustCompile("(?:\x1b[\\[()][0-9;]*[a-zA-Z@]|\x1b][0-9];[[:print:]]+(?:\x1b\\\\|\x07)|\x1b.|[\x0e\x0f]|.\x08)")
+var ansiRegexReference = regexp.MustCompile("(?:\x1b[\\[()][0-9;]*[a-zA-Z@]|\x1b][0-9];[[:print:]]+(?:\x1b\\\\|\x07)|\x1b.|[\x0e\x0f]|.\x08)")
 
 func testParserReference(t testing.TB, str string) {
 	t.Helper()
@@ -35,7 +35,7 @@ func testParserReference(t testing.TB, str string) {
 	s := str
 	for i := 0; ; i++ {
 		got := toSlice(nextAnsiEscapeSequence(s))
-		exp := ansiRegexRefence.FindStringIndex(s)
+		exp := ansiRegexReference.FindStringIndex(s)
 
 		equal := len(got) == len(exp)
 		if equal {
@@ -408,7 +408,7 @@ func BenchmarkNextAnsiEscapeSequence_Regex(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		s := ansiBenchmarkString
 		for {
-			a := ansiRegexRefence.FindStringIndex(s)
+			a := ansiRegexReference.FindStringIndex(s)
 			if len(a) == 0 {
 				break
 			}


### PR DESCRIPTION
**1. Fixed just a minor spelling error**

`ansiRegexRefence` → `ansiRegexReference`

**2. I found some links in source code broken, so  replaced them with the archived ones.**

- http://ascii-table.com/ansi-escape-sequences.php
- http://ascii-table.com/ansi-escape-sequences-vt-100.php

↓

- https://web.archive.org/web/20090204053813/http://ascii-table.com/ansi-escape-sequences.php
- https://web.archive.org/web/20090227051140/http://ascii-table.com/ansi-escape-sequences-vt-100.php