### PR TITLE
Enable manual trigger on GitHub Workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master, devel ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   analyze:

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master, devel ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ on:
     branches: [ master, devel ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Hi, this enables manual trigger on your workflows. Documented [here][1].

This is useful for forks to run the checks/tests themselves (on their own account) in case of
- failure, to see full logs or verify reproducibility
- before sending pull request, or committing to PR (if one wants to see results beforehand)

Steps needed before this patch:
1. fork fzf
2. enable workflows for the fork (web ui)
3. push this patch in master
4. push this patch in feature branch
5. trigger workflow (web ui)

Steps needed after this patch:
1. fork fzf
2. enable workflows for the fork (web ui)
3. trigger workflow (web ui)

The annoying part is pushing the same patch in fork's master and feature branch. Also pushing workflow changes may require additional authorization, so fork dev may need to generate new github's access token (just to push it in master).

[1]: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/
