### PR TITLE
Add riscv64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ BINARYARM6     := fzf-$(GOOS)_arm6
 BINARYARM7     := fzf-$(GOOS)_arm7
 BINARYARM8     := fzf-$(GOOS)_arm8
 BINARYPPC64LE  := fzf-$(GOOS)_ppc64le
+BINARYRISCV64  := fzf-$(GOOS)_riscv64
 
 # https://en.wikipedia.org/wiki/Uname
 UNAME_M := $(shell uname -m)
@@ -59,6 +60,8 @@ else ifeq ($(UNAME_M),aarch64)
 	BINARY := $(BINARYARM8)
 else ifeq ($(UNAME_M),ppc64le)
 	BINARY := $(BINARYPPC64LE)
+else ifeq ($(UNAME_M),riscv64)
+	BINARY := $(BINARYRISCV64)
 else
 $(error Build on $(UNAME_M) is not supported, yet.)
 endif
@@ -140,6 +143,9 @@ target/$(BINARYARM8): $(SOURCES)
 
 target/$(BINARYPPC64LE): $(SOURCES)
 	GOARCH=ppc64le $(GO) build $(BUILD_FLAGS) -o $@
+
+target/$(BINARYRISCV64): $(SOURCES)
+	GOARCH=riscv64 $(GO) build $(BUILD_FLAGS) -o $@
 
 bin/fzf: target/$(BINARY) | bin
 	cp -f target/$(BINARY) bin/fzf


### PR DESCRIPTION
Build successfully on Arch Linux RISC-V.