### PR TITLE
[RFC] Add ability to traverse symlinks

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -596,6 +596,12 @@ ncurses finder only after the input stream is complete.
 e.g. \fBfzf --multi | fzf --sync\fR
 .RE
 .TP
+.B "-L, --dereference"
+Traverse every symbolic link encountered.
+.TP
+.B "-P, --no-dereference"
+Do not traverse any symbolic links (default).
+.TP
 .B "--version"
 Display version information and exit
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -108,7 +108,9 @@ _fzf_opts_completion() {
     -f --filter
     --print-query
     --expect
-    --sync"
+    --sync
+    -L --dereference
+    -P --no-dereference"
 
   case "${prev}" in
   --tiebreak)

--- a/src/core.go
+++ b/src/core.go
@@ -140,7 +140,7 @@ func Run(opts *Options, version string, revision string) {
 	if !streamingFilter {
 		reader = NewReader(func(data []byte) bool {
 			return chunkList.Push(data)
-		}, eventBox, opts.ReadZero, opts.Filter == nil)
+		}, eventBox, opts.ReadZero, opts.Filter == nil, opts.Dereference)
 		go reader.ReadSource()
 	}
 
@@ -184,7 +184,7 @@ func Run(opts *Options, version string, revision string) {
 						}
 					}
 					return false
-				}, eventBox, opts.ReadZero, false)
+				}, eventBox, opts.ReadZero, false, false)
 			reader.ReadSource()
 		} else {
 			eventBox.Unwatch(EvtReadNew)

--- a/src/options.go
+++ b/src/options.go
@@ -97,6 +97,8 @@ const usage = `usage: fzf [options]
     --read0               Read input delimited by ASCII NUL characters
     --print0              Print output delimited by ASCII NUL characters
     --sync                Synchronous search for multi-staged filtering
+    -L, --dereference     Traverse every symbolic link encountered.
+    -P, --no-dereference  Do not traverse any symbolic links (default).
     --version             Display version information and exit
 
   Environment variables
@@ -228,6 +230,7 @@ type Options struct {
 	Unicode     bool
 	Tabstop     int
 	ClearOnExit bool
+	Dereference bool
 	Version     bool
 }
 
@@ -288,6 +291,7 @@ func defaultOptions() *Options {
 		Unicode:     true,
 		Tabstop:     8,
 		ClearOnExit: true,
+		Dereference: false,
 		Version:     false}
 }
 
@@ -1461,6 +1465,10 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.ClearOnExit = true
 		case "--no-clear":
 			opts.ClearOnExit = false
+		case "-L", "--dereference":
+			opts.Dereference = true
+		case "-P", "--no-dereference":
+			opts.Dereference = false
 		case "--version":
 			opts.Version = true
 		default:

--- a/src/reader_test.go
+++ b/src/reader_test.go
@@ -15,7 +15,7 @@ func TestReadFromCommand(t *testing.T) {
 	eb := util.NewEventBox()
 	reader := NewReader(
 		func(s []byte) bool { strs = append(strs, string(s)); return true },
-		eb, false, true)
+		eb, false, true, false)
 
 	reader.startEventPoller()
 
@@ -66,13 +66,14 @@ func TestReadFromCommand(t *testing.T) {
 }
 
 // create temporary file structure, run fzf on it and check the files it saw
+// (symlink walker is tested)
 func TestReadFiles(t *testing.T) {
 	pushedStrings := []string{}
 	pusher := func(s []byte) bool {
 		pushedStrings = append(pushedStrings, string(s))
 		return true
 	}
-	reader := NewReader(pusher, util.NewEventBox(), false, true)
+	reader := NewReader(pusher, util.NewEventBox(), false, true, true)
 
 	// setup test dir
 	testRootPath, err := ioutil.TempDir("", "fzf-test-walk-")


### PR DESCRIPTION
This adds option to traverse symlinks that are encountered by fzf, when it recursively lists files in working directory. I myself need it to make fzf list and search from multiple dirs (source code locations) from single instance, but I guess it's generally useful.

It's ready for testing:
- disabled by default: `fzf`, `fzf --no-dereference`
- enabled: `fzf --dereference`
