### PR TITLE
Respect SHELL env var on Windows (#2638)

### DIFF
--- a/src/terminal_windows.go
+++ b/src/terminal_windows.go
@@ -27,8 +27,11 @@ func quoteEntry(entry string) string {
 	}
 
 	if strings.Contains(shell, "cmd") {
+		// backslash escaping is done here for applications
+		// (see ripgrep test case in terminal_test.go#TestWindowsCommands)
 		escaped := strings.Replace(entry, `\`, `\\`, -1)
 		escaped = `"` + strings.Replace(escaped, `"`, `\"`, -1) + `"`
+		// caret is the escape character for cmd shell
 		r, _ := regexp.Compile(`[&|<>()@^%!"]`)
 		return r.ReplaceAllStringFunc(escaped, func(match string) string {
 			return "^" + match

--- a/src/util/util_windows.go
+++ b/src/util/util_windows.go
@@ -15,7 +15,7 @@ func ExecCommand(command string, setpgid bool) *exec.Cmd {
 	shell := os.Getenv("SHELL")
 	if len(shell) == 0 {
 		shell = "cmd"
-	} else if strings.ContainsAny(shell, `/\`) {
+	} else if strings.Contains(shell, "/") {
 		out, err := exec.Command("cygpath", "-w", shell).Output()
 		if err == nil {
 			shell = strings.Trim(string(out), "\n")


### PR DESCRIPTION
This PR makes fzf respect SHELL environment variable on Windows, like it does on *nix, whenever defined.

Closes #2638 