### PR TITLE
Enable alt+c bash binding with version > 4 syntax.

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -76,6 +76,11 @@ if (( BASH_VERSINFO[0] < 4 )); then
   bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u"$(__fzf_history__)"\e\C-e\er"'
   bind -m vi-command '"\C-r": "\C-z\C-r\C-z"'
   bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
+
+   # ALT-C - cd into the selected directory
+   bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
+   bind -m vi-command '"\ec": "\C-z\ec\C-z"'
+   bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
 else
   # CTRL-T - Paste the selected file path into the command line
   bind -m emacs-standard -x '"\C-t": fzf-file-widget'
@@ -86,11 +91,11 @@ else
   bind -m emacs-standard -x '"\C-r": __fzf_history__'
   bind -m vi-command -x '"\C-r": __fzf_history__'
   bind -m vi-insert -x '"\C-r": __fzf_history__'
-fi
 
-# ALT-C - cd into the selected directory
-bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
-bind -m vi-command '"\ec": "\C-z\ec\C-z"'
-bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
+  # ALT-C - cd into the selected directory
+  bind -m emacs-standard -x '"\ec": $(__fzf_cd__)'
+  bind -m vi-command -x '"\ec": $(__fzf_cd__)'
+  bind -m vi-insert -x '"\ec": $(__fzf_cd__)'
+fi
 
 fi


### PR DESCRIPTION
# What?

This patch introduces the same backwards compatible logic as the other
bash bindings, I believe the logic for alt+c was perhaps just missed in
a previous patch to use the bash > 4 syntax, which is cleaner and
actually resolves an issue with the terminal bash prompt overlapping in
a strange way / line wrapping. (with vi-mode enabled on bash)

This is mostly a cosmetic fix but also fixes another issue with the fzf
command exiting cleanly when aborted.

See some screenshots showing the issue I was having, too me way too
long to figure out that this was the issue. Full disclosure I'm not sure if
this will cause issues on bash versions < 4 or whether or not there was
something else in my configuration that was conflicting. Ultimately, this
resolved the issue you can see was occurring in the screenshots.

## Broken / malformed prompt

<img width="473" alt="Screen Shot 2021-11-30 at 10 38 29 pm" src="https://user-images.githubusercontent.com/20388321/144041117-9cd68cd7-89c3-489e-91fe-fa51dbfa9395.png">
<img width="480" alt="Screen Shot 2021-11-30 at 10 38 44 pm" src="https://user-images.githubusercontent.com/20388321/144041160-5e443686-288f-4abd-b231-692f662e31d0.png">

## After patch

<img width="466" alt="Screen Shot 2021-11-30 at 10 43 37 pm" src="https://user-images.githubusercontent.com/20388321/144041384-2133b579-6241-4683-8ce1-693eebf4ee64.png">