### PR TITLE
fzf-tmux: Executes fzf in env-based shell

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -198,10 +198,10 @@ mkfifo -m o+w $fifo2
 if [[ "$opt" =~ "-K -E" ]]; then
   cat $fifo2 &
   if [[ -n "$term" ]] || [[ -t 0 ]]; then
-    cat <<< "\"$fzf\" $opts > $fifo2; out=\$? $close; exit \$out" >> $argsf
+    cat <<< "$SHELL -c \"$fzf $opts > $fifo2\"; out=\$? $close; exit \$out" >> $argsf
   else
     mkfifo $fifo1
-    cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; out=\$? $close; exit \$out" >> $argsf
+    cat <<< "$SHELL -c \"$fzf $opts < $fifo1 > $fifo2\"; out=\$? $close; exit \$out" >> $argsf
     cat <&0 > $fifo1 &
   fi
 
@@ -219,10 +219,10 @@ fi
 
 mkfifo -m o+w $fifo3
 if [[ -n "$term" ]] || [[ -t 0 ]]; then
-  cat <<< "\"$fzf\" $opts > $fifo2; echo \$? > $fifo3 $close" >> $argsf
+  cat <<< "$SHELL -c \"$fzf $opts > $fifo2\"; echo \$? > $fifo3 $close" >> $argsf
 else
   mkfifo $fifo1
-  cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; echo \$? > $fifo3 $close" >> $argsf
+  cat <<< "$SHELL -c \"$fzf $opts < $fifo1 > $fifo2\"; echo \$? > $fifo3 $close" >> $argsf
   cat <&0 > $fifo1 &
 fi
 tmux set-window-option synchronize-panes off \;\


### PR DESCRIPTION
This allows executing fzf in a user-defined shell, rather than just using the bash. I noticed that both fzf and fzf-tmux has different behavior due to different shell environment (fzf runs in the commandline shell, but fzf-tmux always executes fzf in bash).

This behavior got prominent when using [fzf.fish plugin](https://github.com/PatrickF1/fzf.fish) that had a fish autoloaded function to preview file contents. In fzf it ran succesfully, but in fzf-tmux it threw an error due to missing function in bash.