### PR TITLE
Change the version check invocation in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -4,7 +4,7 @@ $fzf_base=Split-Path -Parent $MyInvocation.MyCommand.Definition
 
 function check_binary () {
   Write-Host "  - Checking fzf executable ... " -NoNewline
-  $output=cmd /c $fzf_base\bin\fzf.exe --version 2>&1
+  $output= & $fzf_base\bin\fzf.exe --version
   if (-not $?) {
     Write-Host "Error: $output"
     $binary_error="Invalid binary"


### PR DESCRIPTION
When install.ps1 is executed inside MSYS (or cygwin I suspect) cmd
is a shell script that invokes the real cmd.  But in install.ps1 it
tries to open this shell script instead of executing it.

AFAICT the only reason to use cmd /c is to capture stderr because
there is a bug with powersehll; but fzf prints the version information
on stdout so we don't need to care about stderr.  So we can just call
the binary directly.  This avoids the cmd issues.

------------

This is desirable because 0.23.0 removed x86 windows binaries, meaning the ./install script no longer works if you are in an x86 shell.  This affects Firefox developers in particular because our build environment [tries to install fzf automatically](https://searchfox.org/mozilla-central/rev/618f9970972adc5a21194d39d690ec0865f26024/tools/tryselect/selectors/fuzzy.py#193-201) but [MozillaBuild is 32-bit](https://bugzilla.mozilla.org/show_bug.cgi?id=1722098#c5) causing it to fail.