### PR TITLE
feat: add support for `_fzf_find_dir` function to zsh shell

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -88,9 +88,13 @@ fi
 
 if ! declare -f _fzf_compgen_dir > /dev/null; then
   _fzf_compgen_dir() {
-    command find -L "$1" \
-      -name .git -prune -o -name .hg -prune -o -name .svn -prune -o -type d \
-      -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    if declare -f _fzf_find_dir &> /dev/null; then
+      _fzf_find_dir "$1"
+    else
+      command find -L "$1" \
+        -name .git -prune -o -name .hg -prune -o -name .svn -prune -o -type d \
+        -a -not -path "$1" -print 2> /dev/null | sed 's@^\./@@'
+    fi
   }
 fi
 

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -70,8 +70,12 @@ bindkey '^T' fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
-    -o -type d -print 2> /dev/null | cut -b3-"}"
+  if declare -f _fzf_find_dir &> /dev/null; then
+    local cmd="_fzf_find_dir ."
+  else
+    local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+      -o -type d -print 2> /dev/null | cut -b3-"}"
+  fi
   setopt localoptions pipefail no_aliases 2> /dev/null
   local dir="$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m)"
   if [[ -z "$dir" ]]; then


### PR DESCRIPTION
By introducing a new `_fzf_find_dir` function, fzf can sync the finding strategy between `_fzf_compgen_dir` and `fzf-cd-widget` without  breaking compatibility (#2718).