### PR TITLE
[vim] Let users decide to use --height instead of terminal buffer

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -487,6 +487,7 @@ try
   endif
 
   let prefer_tmux = get(g:, 'fzf_prefer_tmux', 0) || has_key(dict, 'tmux')
+  let prefer_height = get(g:, 'fzf_prefer_height', 0)
   let use_height = has_key(dict, 'down') && !has('gui_running') &&
         \ !(has('nvim') || s:is_win || has('win32unix') || s:present(dict, 'up', 'left', 'right', 'window')) &&
         \ executable('tput') && filereadable('/dev/tty')
@@ -497,6 +498,8 @@ try
   let use_tmux = (has_key(dict, 'tmux') || (!use_height && !use_term || prefer_tmux) && !has('win32unix') && s:splittable(dict)) && s:tmux_enabled()
   if prefer_tmux && use_tmux
     let use_height = 0
+    let use_term = 0
+  elseif prefer_height && use_height
     let use_term = 0
   endif
   if use_term


### PR DESCRIPTION
Commit 85ae745910 forced the use of terminal buffers whenever they're
available to improve consistency and avoid confusion. This, however, has
drawbacks:

* Using a terminal buffer is slightly slower (not noticeable to most
  people but visible to me).

* It breaks certain features of fzf.vim, requiring workarounds like
  https://github.com/junegunn/fzf.vim/pull/1363. And, unfortunately, it
  also breaks https://github.com/junegunn/fzf.vim/pull/1196 (a fix for
  :Snippets in insert-mode which relies on `<Cmd>` and the cursor
  staying behind the end-of-line) which I have no workaround for yet.

This commit adds `g:fzf_prefer_height` to optionally restore the old
behaviour.