### PR TITLE
next-selected

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -850,10 +850,12 @@ A key or an event can be bound to one or more of the following actions.
     \fBkill-word\fR                  \fIalt-d\fR
     \fBlast\fR                       (move to the last match)
     \fBnext-history\fR               (\fIctrl-n\fR on \fB--history\fR)
+    \fBnext-selected\fR
     \fBpage-down\fR                  \fIpgdn\fR
     \fBpage-up\fR                    \fIpgup\fR
     \fBhalf-page-down\fR
     \fBhalf-page-up\fR
+    \fBprev-selected\fR
     \fBpreview(...)\fR               (see below for the details)
     \fBpreview-down\fR               \fIshift-down\fR
     \fBpreview-up\fR                 \fIshift-up\fR

--- a/src/options.go
+++ b/src/options.go
@@ -958,6 +958,10 @@ func parseKeymap(keymap map[tui.Event][]*action, str string) {
 				appendAction(actUp)
 			case "first", "top":
 				appendAction(actFirst)
+			case "next-selected":
+				appendAction(actNextSelected)
+			case "prev-selected":
+				appendAction(actPrevSelected)
 			case "last":
 				appendAction(actLast)
 			case "page-up":


### PR DESCRIPTION
The reason for this PR is that we've started to use fzf as a viewer for code traces that are produced using DMCE (https://github.com/PatrikAAberg/dmce). Having the code trace in fzf one would like to select multiple lines (--multi) and have the ability to jump between the selections. Note that we are using the fzf preview window to display the matching source code.

Btw, thx for fzf! It's such a great piece of software.