### PR TITLE
Allow passing args to __fzf_select__ via fzf-file-widget

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -32,7 +32,7 @@ __fzfcmd() {
 }
 
 fzf-file-widget() {
-  local selected="$(__fzf_select__)"
+  local selected="$(__fzf_select__ "$@")"
   READLINE_LINE="${READLINE_LINE:0:$READLINE_POINT}$selected${READLINE_LINE:$READLINE_POINT}"
   READLINE_POINT=$(( READLINE_POINT + ${#selected} ))
 }


### PR DESCRIPTION
This makes it easier to make customizations, for example instead of

    bind -x '"\C-o\C-i": FZF_CTRL_T_COMMAND="fasd -Rl" FZF_DEFAULT_OPTS="$FZF_DEFAULT_OPTS --tiebreak=index " fzf-file-widget'

it's enough to just

    bind -x '"\C-o\C-i": FZF_CTRL_T_COMMAND="fasd -Rl" fzf-file-widget --tiebreak=index'