### PR TITLE
[shell] use builtin cd to avoid conflicts

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -41,7 +41,7 @@ __fzf_cd__() {
   local cmd dir
   cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type d -print 2> /dev/null | cut -b3-"}"
-  dir=$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m) && printf 'cd -- %q' "$dir"
+  dir=$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --bind=ctrl-z:ignore $FZF_DEFAULT_OPTS $FZF_ALT_C_OPTS" $(__fzfcmd) +m) && printf 'builtin cd -- %q' "$dir"
 }
 
 __fzf_history__() {

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -87,7 +87,7 @@ function fzf_key_bindings
       eval "$FZF_ALT_C_COMMAND | "(__fzfcmd)' +m --query "'$fzf_query'"' | read -l result
 
       if [ -n "$result" ]
-        cd -- $result
+        builtin cd -- $result
 
         # Remove last token from commandline.
         commandline -t ""

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -81,7 +81,7 @@ fzf-cd-widget() {
     return 0
   fi
   zle push-line # Clear buffer. Auto-restored on next prompt.
-  BUFFER="cd -- ${(q)dir}"
+  BUFFER="builtin cd -- ${(q)dir}"
   zle accept-line
   local ret=$?
   unset dir # ensure this doesn't end up appearing in prompt expansion


### PR DESCRIPTION
Ever since https://github.com/junegunn/fzf/pull/2659 was merged, the ALT-C command completes to `cd -- /selected/path`.  The `--` was added to prevent directories starting with `-` from being treated as options.

However, this also creates problems for people using tools like [zoxide](https://github.com/ajeetdsouza/zoxide) to replace their `cd` command (https://github.com/ajeetdsouza/zoxide/issues/332). A more correct approach would be to use `builtin cd`.