### PR TITLE
Fix fzf#shellescape when shell=fish

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -96,13 +96,12 @@ function! fzf#shellescape(arg, ...)
   if shell =~# 'cmd.exe$'
     return s:shellesc_cmd(a:arg)
   endif
-try
-  let oldshell = &shell
-  let &shell = shell
-  return s:fzf_call('shellescape', a:arg)
-finally
-  let &shell = oldshell
-endtry
+  try
+    let [shell, &shell] = [&shell, shell]
+    return s:fzf_call('shellescape', a:arg)
+  finally
+    let [shell, &shell] = [&shell, shell]
+  endtry
 endfunction
 
 function! s:fzf_getcwd()

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -96,7 +96,13 @@ function! fzf#shellescape(arg, ...)
   if shell =~# 'cmd.exe$'
     return s:shellesc_cmd(a:arg)
   endif
+try
+  let oldshell = &shell
+  let &shell = shell
   return s:fzf_call('shellescape', a:arg)
+finally
+  let &shell = oldshell
+endtry
 endfunction
 
 function! s:fzf_getcwd()


### PR DESCRIPTION
`shellescape()` behaviour different when `shell=fish`, so we should set `shell` before calling `shellescape()`, otherwise some wired behaviour (such as https://github.com/kevinhwang91/nvim-bqf/issues/56) may apper.