### PR TITLE
Hide previewer when screen width < 40

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -801,6 +801,7 @@ func (t *Terminal) resizeWindows() {
 		}
 	}
 
+	t.previewer.enabled = screenWidth > 39 // Hide previewer when window is too narrow
 	previewVisible := t.isPreviewEnabled() && t.previewOpts.size.size > 0
 	minAreaWidth := minWidth
 	minAreaHeight := minHeight


### PR DESCRIPTION
This is a one-liner solution, that does not take into account the calculated margins, only the true screenWidth.

This is because it would require a refactor of the resizeWindows() function to prevent a cyclic depencency, wherein the previewer's enabled is determined by margins, and the margins size is determined by whether the previewer is enabled.

This hardly affects anything when the padding and margins combined are less than 3 or 4 cells in width.

Fixes #2804