### PR TITLE
Don't export PATH in ~/.fzf.{bash,zsh}

### DIFF
--- a/install
+++ b/install
@@ -256,7 +256,7 @@ for shell in $shells; do
 # Setup fzf
 # ---------
 if [[ ! "\$PATH" == *$fzf_base_esc/bin* ]]; then
-  export PATH="\${PATH:+\${PATH}:}$fzf_base/bin"
+  PATH="\${PATH:+\${PATH}:}$fzf_base/bin"
 fi
 
 # Auto-completion


### PR DESCRIPTION
There is no use exporting PATH when it is already exported. Moreover, it
causes things like `typeset -U path` in zsh to break if done before
sourcing "~/.fzf.zsh".