### PR TITLE
Use absolute filepath of shell rc files in uninstall

### DIFF
--- a/uninstall
+++ b/uninstall
@@ -53,6 +53,9 @@ remove() {
 remove_line() {
   src=$(readlink "$1")
   if [ $? -eq 0 ]; then
+    if [ $(expr "$src" : '/*') -eq 0 ]; then
+      src="$(dirname "$1")/$src"
+    fi
     echo "Remove from $1 ($src):"
   else
     src=$1


### PR DESCRIPTION
If the shell rc file is a relative symlink, readlink without the `-f`
option gives the relative path of the file which doesn't work if
uninstall is called from a non-HOME directory.