### PR TITLE
Add loongarch64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ BINARYARM7     := fzf-$(GOOS)_arm7
 BINARYARM8     := fzf-$(GOOS)_arm8
 BINARYPPC64LE  := fzf-$(GOOS)_ppc64le
 BINARYRISCV64  := fzf-$(GOOS)_riscv64
+BINARYLOONG64  := fzf-$(GOOS)_loong64
 
 # https://en.wikipedia.org/wiki/Uname
 UNAME_M := $(shell uname -m)
@@ -62,6 +63,8 @@ else ifeq ($(UNAME_M),ppc64le)
 	BINARY := $(BINARYPPC64LE)
 else ifeq ($(UNAME_M),riscv64)
 	BINARY := $(BINARYRISCV64)
+else ifeq ($(UNAME_M),loongarch64)
+	BINARY := $(BINARYLOONG64)
 else
 $(error Build on $(UNAME_M) is not supported, yet.)
 endif
@@ -147,6 +150,9 @@ target/$(BINARYPPC64LE): $(SOURCES)
 
 target/$(BINARYRISCV64): $(SOURCES)
 	GOARCH=riscv64 $(GO) build $(BUILD_FLAGS) -o $@
+
+target/$(BINARYLOONG64): $(SOURCES)
+	GOARCH=loong64 $(GO) build $(BUILD_FLAGS) -o $@
 
 bin/fzf: target/$(BINARY) | bin
 	cp -f target/$(BINARY) bin/fzf


### PR DESCRIPTION
Add loongarch64 support. Golang has supported [linux/loong64](https://github.com/golang/go/commit/ec464edb22301764b6caf7592ac8dc9451c595c6)
- golang: https://github.com/golang/go/tree/master
- os: https://github.com/sunhaiyong1978/CLFS-for-LoongArch/releases/download/4.0/loongarch64-clfs-system-4.0.tar.bz2

```
[root@upstream fzf]# make
GOARCH=loong64 go build -a -ldflags "-s -w -X main.version=0.30.0 -X main.revision=7052987" -tags "" -o target/fzf-go1.19-351e0f4083_loong64
[root@upstream fzf]# file target/fzf-go1.19-351e0f4083_loong64 
target/fzf-go1.19-351e0f4083_loong64: ELF 64-bit LSB executable, LoongArch, version 1 (SYSV), statically linked, Go BuildID=5iDziOizZrrXAzlds9wq/M5acTdJilXLFpQTMGG8n/k1KhML9cEvrnfvJIKIse/-N-KbgmUR6MODVFxdzZZ, stripped
```