### PR TITLE
fix `fzf-tmux` to have `fzf`'s completion

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -304,6 +304,13 @@ _fzf_alias_completion() {
 
 # fzf options
 complete -o default -F _fzf_opts_completion fzf
+if command -v fzf-tmux >/dev/null; then
+  complete -o default -F _fzf_opts_completion fzf-tmux
+  # fzf-tmux is a thin fzf wrapper that has only a few more options than fzf
+  # istself. As a quick improvement we'll take fzf's completion and adding the
+  # few extra fzf-tmux specific options (like `-w WIDTH`) leave as a future
+  # patch.
+fi
 
 d_cmds="${FZF_COMPLETION_DIR_COMMANDS:-cd pushd rmdir}"
 a_cmds="

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -304,13 +304,10 @@ _fzf_alias_completion() {
 
 # fzf options
 complete -o default -F _fzf_opts_completion fzf
-if command -v fzf-tmux >/dev/null; then
-  complete -o default -F _fzf_opts_completion fzf-tmux
-  # fzf-tmux is a thin fzf wrapper that has only a few more options than fzf
-  # istself. As a quick improvement we'll take fzf's completion and adding the
-  # few extra fzf-tmux specific options (like `-w WIDTH`) leave as a future
-  # patch.
-fi
+# fzf-tmux is a thin fzf wrapper that has only a few more options than fzf
+# itself. As a quick improvement we take fzf's completion. Adding the few extra
+# fzf-tmux specific options (like `-w WIDTH`) are left as a future patch.
+complete -o default -F _fzf_opts_completion fzf-tmux
 
 d_cmds="${FZF_COMPLETION_DIR_COMMANDS:-cd pushd rmdir}"
 a_cmds="


### PR DESCRIPTION
this isn't the _full_ fix but I left an inline comment in case this ever
bugs a future user and they're wondering where the last few flags'
completions are (answer: they're not added yet, as they're just
diminishing return for _this_ particular quick itch-scratching).