### PR TITLE
Added possibility for shell key binding remapping.

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -10,6 +10,9 @@
 # - $FZF_CTRL_R_OPTS
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
+# - $FZF_CTRL_T_BINDING
+# - $FZF_CTRL_R_BINDING
+# - $FZF_ALT_C_BINDING
 
 # Key bindings
 # ------------
@@ -66,9 +69,9 @@ fzf-file-widget() {
   return $ret
 }
 zle     -N            fzf-file-widget
-bindkey -M emacs '^T' fzf-file-widget
-bindkey -M vicmd '^T' fzf-file-widget
-bindkey -M viins '^T' fzf-file-widget
+bindkey -M emacs ${FZF_CTRL_T_BINDING:-'^T'} fzf-file-widget
+bindkey -M vicmd ${FZF_CTRL_T_BINDING:-'^T'} fzf-file-widget
+bindkey -M viins ${FZF_CTRL_T_BINDING:-'^T'} fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
@@ -89,9 +92,9 @@ fzf-cd-widget() {
   return $ret
 }
 zle     -N             fzf-cd-widget
-bindkey -M emacs '\ec' fzf-cd-widget
-bindkey -M vicmd '\ec' fzf-cd-widget
-bindkey -M viins '\ec' fzf-cd-widget
+bindkey -M emacs ${FZF_ALT_C_BINDING:-'\ec'} fzf-cd-widget
+bindkey -M vicmd ${FZF_ALT_C_BINDING:-'\ec'} fzf-cd-widget
+bindkey -M viins ${FZF_ALT_C_BINDING:-'\ec'} fzf-cd-widget
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
@@ -110,9 +113,9 @@ fzf-history-widget() {
   return $ret
 }
 zle     -N            fzf-history-widget
-bindkey -M emacs '^R' fzf-history-widget
-bindkey -M vicmd '^R' fzf-history-widget
-bindkey -M viins '^R' fzf-history-widget
+bindkey -M emacs ${FZF_CTRL_R_BINDING:-'^R'} fzf-history-widget
+bindkey -M vicmd ${FZF_CTRL_R_BINDING:-'^R'} fzf-history-widget
+bindkey -M viins ${FZF_CTRL_R_BINDING:-'^R'} fzf-history-widget
 
 } always {
   eval $__fzf_key_bindings_options


### PR DESCRIPTION
By setting FZF_{CTRL_T,ALT_C,CTRL_R}_BINDING to something different before loading the keybindings, the functionality can be remapped to different keys.