### PR TITLE
Update fzf.vim

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -219,7 +219,7 @@ function! fzf#exec(...)
   endif
 
   if a:0 && !has_key(s:checked, a:1)
-    let fzf_version = s:get_version(s:exec)
+    let fzf_version = s:get_version('"' . s:exec . '"')
     if empty(fzf_version)
       let message = printf('Failed to run "%s --version"', s:exec)
       unlet s:exec


### PR DESCRIPTION
In windows 11, if the fzf installed in directory, say "C:\Program Files\Vim\vimfiles\myplugs\fzf\bin", then error: E605: Exception not caught: Failed to run "C:\Program Files\Vim\vimfiles\myplugs\fzf/bin/fzf --version"
![图片](https://user-images.githubusercontent.com/22927046/179381282-d6b1eae9-5657-448b-8fd9-4fff64962e55.png)