### PR TITLE
fix: defaultCommand retrieves dotfiles in cwd; document defaultCommand in readme and man

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,9 +194,12 @@ selected item to STDOUT.
 find * -type f | fzf > selected
 ```
 
-Without STDIN pipe, fzf will use find command to fetch the list of
-files excluding hidden ones. (You can override the default command with
-`FZF_DEFAULT_COMMAND`)
+Without STDIN pipe, fzf will use a find command to fetch the list of files:
+```sh
+set -o pipefail; command find -L . -mindepth 1 \( -path '*/\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune -print -o -type f -print -o -type l -print 2> /dev/null | cut -b3-
+```
+
+You can override the default command with `FZF_DEFAULT_COMMAND`.
 
 ```sh
 vim $(fzf)

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -627,6 +627,10 @@ Note that most options have the opposite versions with \fB--no-\fR prefix.
 Default command to use when input is tty. On *nix systems, fzf runs the command
 with \fB$SHELL -c\fR if \fBSHELL\fR is set, otherwise with \fBsh -c\fR, so in
 this case make sure that the command is POSIX-compliant.
+
+.RS
+When not set fzf will run: \fBset -o pipefail; command find -L . -mindepth 1 \( -path '*/\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune -print -o -type f -print -o -type l -print 2> /dev/null | cut -b3-\fR
+.RE
 .TP
 .B FZF_DEFAULT_OPTS
 Default options. e.g. \fBexport FZF_DEFAULT_OPTS="--extended --cycle"\fR

--- a/src/constants.go
+++ b/src/constants.go
@@ -58,9 +58,9 @@ var defaultCommand string
 
 func init() {
 	if !util.IsWindows() {
-		defaultCommand = `set -o pipefail; command find -L . -mindepth 1 \( -path '*/\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-`
+		defaultCommand = `set -o pipefail; command find -L . -mindepth 1 \( -path '*/\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune -print -o -type f -print -o -type l -print 2> /dev/null | cut -b3-`
 	} else if os.Getenv("TERM") == "cygwin" {
-		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
+		defaultCommand = `sh -c "command find -L . -mindepth 1 -path '*/\.*' -prune -print -o -type f -print -o -type l -print 2> /dev/null | cut -b3-"`
 	}
 }
 

--- a/src/constants.go
+++ b/src/constants.go
@@ -57,6 +57,7 @@ const (
 var defaultCommand string
 
 func init() {
+	// please update README.md and man/man1/fzf.1 when changig defaultCommand
 	if !util.IsWindows() {
 		defaultCommand = `set -o pipefail; command find -L . -mindepth 1 \( -path '*/\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \) -prune -print -o -type f -print -o -type l -print 2> /dev/null | cut -b3-`
 	} else if os.Getenv("TERM") == "cygwin" {


### PR DESCRIPTION
The default find command was not printing dotfiles in the current directory.

Added the default to readme and man pages: it was very difficult to fix via `$FZF_DEFAULT_COMMAND` as I did not know what the default was without digging into source.