### PR TITLE
fixes #2474 bash completion: possible retry loop

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -161,7 +161,11 @@ _fzf_handle_dynamic_completion() {
 
 __fzf_generic_path_completion() {
   local cur base dir leftover matches trigger cmd
-  cmd="${COMP_WORDS[0]//[^A-Za-z0-9_=]/_}"
+  cmd="${COMP_WORDS[0]}"
+  if [[ $cmd == \\* ]]; then
+    cmd="${cmd:1}"
+  fi
+  cmd="${cmd//[^A-Za-z0-9_=]/_}"
   COMPREPLY=()
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
   cur="${COMP_WORDS[COMP_CWORD]}"


### PR DESCRIPTION
I opened #2474 more than a year ago and came to the conclusion that it was more [bash-completion's](https://github.com/scop/bash-completion) fault than fzf's. However, it does not appear it's an easy fix in bash-completion, and it's a fairly easy fix in fzf. It also appears other people are running into it (ex: #2583) - I, myself, just ran into it again on a new machine - so maybe we should just fix it?

Open to other suggestions. This PR is my proposal from the ticket long ago =)