### PR TITLE
Fix version check on windows/powershell

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -164,11 +164,7 @@ function s:get_version(bin)
   if has_key(s:versions, a:bin)
     return s:versions[a:bin]
   end
-  if &shell == 'powershell'
-    let command = '&' . shellescape(a:bin) . ' --version --no-height'
-  else
-    let command = shellescape(a:bin) . ' --version --no-height'
-  endif
+  let command = (&shell == 'powershell' ? '&' : '') . shellescape(a:bin) . ' --version --no-height'
   let output = systemlist(command)
   if v:shell_error || empty(output)
     return ''

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -164,7 +164,11 @@ function s:get_version(bin)
   if has_key(s:versions, a:bin)
     return s:versions[a:bin]
   end
-  let command = fzf#shellescape(a:bin) . ' --version --no-height'
+  if &shell == 'powershell'
+    let command = '&' . shellescape(a:bin) . ' --version --no-height'
+  else
+    let command = shellescape(a:bin) . ' --version --no-height'
+  endif
   let output = systemlist(command)
   if v:shell_error || empty(output)
     return ''


### PR DESCRIPTION
- Replace fzf#shellescape with shellescape as it was surround the command in "^" characters that powershell did not recognise as escape characters
- Prepend command with '&' in powershell to deal with quoted exe name