### PR TITLE
[zsh] Fix the problem command history deduplication not working on macOS

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -97,7 +97,7 @@ bindkey -M viins '\ec' fzf-cd-widget
 fzf-history-widget() {
   local selected num
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
-  selected=( $(fc -rl 1 | awk '{ cmd=$0; sub(/^\s*[0-9]+\**\s+/, "", cmd); if (!seen[cmd]++) print $0 }' |
+  selected=( $(fc -rl 1 | awk '{ cmd=$0; sub(/^[ \t]*[0-9]+\**[ \t]+/, "", cmd); if (!seen[cmd]++) print $0 }' |
     FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} $FZF_DEFAULT_OPTS -n2..,.. --tiebreak=index --bind=ctrl-r:toggle-sort,ctrl-z:ignore $FZF_CTRL_R_OPTS --query=${(qqq)LBUFFER} +m" $(__fzfcmd)) )
   local ret=$?
   if [ -n "$selected" ]; then


### PR DESCRIPTION
Currently `fzf-history-widget` simply shows duplicated candidates, because unlike GNU awk `\s` is not supported by Apple's awk.
This PR fixes this issue by modifying regex so that it works with both GNU and macOS awk.

```sh-session
$ echo '123  hello' | awk '{ sub(/^\s*[0-9]+\s+/, "", $0); print $0 }'
123  hello

$ echo '123  hello' | awk '{ sub(/^[ \t]*[0-9]+[ \t]+/, "", $0); print $0 }'
hello

$ awk --version
awk version 20200816
```