### PR TITLE
fzf-tmux: disable tmux popup window border if fzf has already enabled its border

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ CHANGELOG
 0.32.1
 ------
 - Fixed incorrect ordering of `--tiebreak=chunk`
+- fzf-tmux will show fzf border instead of tmux popup border (requires tmux 3.3)
+  ```sh
+  fzf-tmux -p70%
+  fzf-tmux -p70% --color=border:bright-red
+  fzf-tmux -p100%,60% --color=border:bright-yellow --border=horizontal
+  fzf-tmux -p70%,100% --color=border:bright-green --border=vertical
+  ```
 
 0.32.0
 ------

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -213,6 +213,11 @@ if [[ "$opt" =~ "-K -E" ]]; then
     opt="${opt} -R"
   fi
 
+  # disable tmux pop-up window border if fzf has already enabled border
+  if [[ $FZF_DEFAULT_OPTS =~ "--border" ]]; then
+      opt="${opt} -B"
+  fi
+
   tmux popup -d "$PWD" "${tmux_args[@]}" $opt "bash $argsf" > /dev/null 2>&1
   exit $?
 fi

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -181,7 +181,7 @@ trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
 envs="export TERM=$TERM "
-[[ "$opt" =~ "-K -E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 $FZF_DEFAULT_OPTS"
+[[ "$opt" =~ "-K -E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 --border $FZF_DEFAULT_OPTS"
 [[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS")"
 [[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs FZF_DEFAULT_COMMAND=$(printf %q "$FZF_DEFAULT_COMMAND")"
 echo "$envs;" > "$argsf"
@@ -213,12 +213,7 @@ if [[ "$opt" =~ "-K -E" ]]; then
     opt="${opt} -R"
   fi
 
-  # disable tmux pop-up window border if fzf has already enabled border
-  if [[ $FZF_DEFAULT_OPTS =~ "--border" ]]; then
-      opt="${opt} -B"
-  fi
-
-  tmux popup -d "$PWD" "${tmux_args[@]}" $opt "bash $argsf" > /dev/null 2>&1
+  tmux popup -d "$PWD" "${tmux_args[@]}" -B $opt "bash $argsf" > /dev/null 2>&1
   exit $?
 fi
 

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -58,7 +58,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     -p*|-w*|-h*|-x*|-y*|-d*|-u*|-r*|-l*)
       if [[ "$arg" =~ ^-[pwhxy] ]]; then
-        [[ "$opt" =~ "-K -E" ]] || opt="-K -E"
+        [[ "$opt" =~ "-E" ]] || opt="-E"
       elif [[ "$arg" =~ ^.[lr] ]]; then
         opt="-h"
         if [[ "$arg" =~ ^.l ]]; then
@@ -139,7 +139,7 @@ fi
 args=("${args[@]}" "--no-height" "--bind=ctrl-z:ignore")
 
 # Handle zoomed tmux pane without popup options by moving it to a temp window
-if [[ ! "$opt" =~ "-K -E" ]] && tmux list-panes -F '#F' | grep -q Z; then
+if [[ ! "$opt" =~ "-E" ]] && tmux list-panes -F '#F' | grep -q Z; then
   zoomed_without_popup=1
   original_window=$(tmux display-message -p "#{window_id}")
   tmp_window=$(tmux new-window -d -P -F "#{window_id}" "bash -c 'while :; do for c in \\| / - '\\;' do sleep 0.2; printf \"\\r\$c fzf-tmux is running\\r\"; done; done'")
@@ -181,7 +181,7 @@ trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
 envs="export TERM=$TERM "
-[[ "$opt" =~ "-K -E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 --border $FZF_DEFAULT_OPTS"
+[[ "$opt" =~ "-E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 --border $FZF_DEFAULT_OPTS"
 [[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS")"
 [[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs FZF_DEFAULT_COMMAND=$(printf %q "$FZF_DEFAULT_COMMAND")"
 echo "$envs;" > "$argsf"
@@ -195,7 +195,7 @@ close="; trap - EXIT SIGINT SIGTERM $close"
 
 export TMUX=$(cut -d , -f 1,2 <<< "$TMUX")
 mkfifo -m o+w $fifo2
-if [[ "$opt" =~ "-K -E" ]]; then
+if [[ "$opt" =~ "-E" ]]; then
   cat $fifo2 &
   if [[ -n "$term" ]] || [[ -t 0 ]]; then
     cat <<< "\"$fzf\" $opts > $fifo2; out=\$? $close; exit \$out" >> $argsf
@@ -203,14 +203,6 @@ if [[ "$opt" =~ "-K -E" ]]; then
     mkfifo $fifo1
     cat <<< "\"$fzf\" $opts < $fifo1 > $fifo2; out=\$? $close; exit \$out" >> $argsf
     cat <&0 > $fifo1 &
-  fi
-
-  # tmux dropped the support for `-K`, `-R` to popup command
-  #   TODO: We can remove this once tmux 3.2 is released
-  if [[ ! "$(tmux popup --help 2>&1)" =~ '-R shell-command' ]]; then
-    opt="${opt/-K/}"
-  else
-    opt="${opt} -R"
   fi
 
   tmux popup -d "$PWD" "${tmux_args[@]}" -B $opt "bash $argsf" > /dev/null 2>&1

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -181,7 +181,14 @@ trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
 envs="export TERM=$TERM "
-[[ "$opt" =~ "-E" ]] && FZF_DEFAULT_OPTS="--margin 0,1 --border $FZF_DEFAULT_OPTS"
+tmux_verson=$(tmux -V)
+if [[ "$opt" =~ "-E" ]]; then
+  FZF_DEFAULT_OPTS="--margin 0,1 $FZF_DEFAULT_OPTS"
+  if [[ ! $tmux_verson =~ 3\.2 ]]; then
+    FZF_DEFAULT_OPTS="--border $FZF_DEFAULT_OPTS"
+    opt="-B $opt"
+  fi
+fi
 [[ -n "$FZF_DEFAULT_OPTS"    ]] && envs="$envs FZF_DEFAULT_OPTS=$(printf %q "$FZF_DEFAULT_OPTS")"
 [[ -n "$FZF_DEFAULT_COMMAND" ]] && envs="$envs FZF_DEFAULT_COMMAND=$(printf %q "$FZF_DEFAULT_COMMAND")"
 echo "$envs;" > "$argsf"
@@ -205,7 +212,7 @@ if [[ "$opt" =~ "-E" ]]; then
     cat <&0 > $fifo1 &
   fi
 
-  tmux popup -d "$PWD" "${tmux_args[@]}" -B $opt "bash $argsf" > /dev/null 2>&1
+  tmux popup -d "$PWD" "${tmux_args[@]}" $opt "bash $argsf" > /dev/null 2>&1
   exit $?
 fi
 

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -181,9 +181,9 @@ trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
 envs="export TERM=$TERM "
-tmux_verson=$(tmux -V)
 if [[ "$opt" =~ "-E" ]]; then
   FZF_DEFAULT_OPTS="--margin 0,1 $FZF_DEFAULT_OPTS"
+  tmux_verson=$(tmux -V)
   if [[ ! $tmux_verson =~ 3\.2 ]]; then
     FZF_DEFAULT_OPTS="--border $FZF_DEFAULT_OPTS"
     opt="-B $opt"


### PR DESCRIPTION
Before this PR, inside tmux, `fzf-tmux -p` will show double border if fzf has already enabled its border

![image](https://user-images.githubusercontent.com/14842664/183227994-93b1203f-bf12-4516-8737-5195077ca3b6.png)

After this PR, we will check if we've enabled `--border` in `FZF_DEFAULT_OPTS`. If so, we can turn off tmux popup window border 

![image](https://user-images.githubusercontent.com/14842664/183228054-d4797623-8727-47c5-b63a-e5ab80d438dc.png)
