### PR TITLE
silence awk: cmd. line:1: warning

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -283,7 +283,7 @@ _fzf_host_completion() {
         <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
         <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
         awk '{if (length($2) > 0) {print $2}}' | sort -u
-  )
+  ) 2> /dev/null
 }
 
 _fzf_var_completion() {


### PR DESCRIPTION
When using Includes with ssh/config
esp:
---config--- 
Include config.d/*
Include config.d/**/*
---
ssh host<tab>
causes a warning and obfuscates the completions.
awk: cmd. line:1: warning: command line argument `/Users/yourHome/.ssh/config.d/SetOfHosts' is a directory: skipped

AWK has a long history of having strong feelings against directories, going back to the POSIX version, and would terminate.
This is an order of magnitude along that of clowns' dislike of mimes but with age awk's strong feelings toward directories "mellowed" into warnings (gawk).

Sometimes we just need bash completions without the editorial opinions from awk and this appears to be the best move to silence a AWK.