### PR TITLE
ansi: speed up escape sequence parsing by ~20%

### DIFF
--- a/src/ansi.go
+++ b/src/ansi.go
@@ -107,19 +107,27 @@ func matchControlSequence(s string) int {
 	//                     ^ match starting here
 	//
 	i := 2 // prefix matched in nextAnsiEscapeSequence()
-	for ; i < len(s) && (isNumeric(s[i]) || s[i] == ';' || s[i] == ':' || s[i] == '?'); i++ {
-	}
-	if i < len(s) {
+	for ; i < len(s); i++ {
 		c := s[i]
-		if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '@' {
-			return i + 1
+		switch c {
+		case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ';', ':', '?':
+			// ok
+		default:
+			if 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '@' {
+				return i + 1
+			}
+			return -1
 		}
 	}
 	return -1
 }
 
 func isCtrlSeqStart(c uint8) bool {
-	return c == '\\' || c == '[' || c == '(' || c == ')'
+	switch c {
+	case '\\', '[', '(', ')':
+		return true
+	}
+	return false
 }
 
 // nextAnsiEscapeSequence returns the ANSI escape sequence and is equivalent to


### PR DESCRIPTION
This commit slightly refactors the escape sequence matching functions
for a 20% speed up.

ANSI Benchmarks:
```
goos: darwin
goarch: arm64
pkg: github.com/junegunn/fzf/src

name                       old time/op    new time/op    delta
NextAnsiEscapeSequence-10     114ns ± 1%      90ns ± 1%  -21.57%  (p=0.008 n=5+5)
ExtractColor-10               544ns ± 0%     517ns ± 0%   -5.01%  (p=0.008 n=5+5)

name                       old speed      new speed      delta
NextAnsiEscapeSequence-10  1.09GB/s ± 1%  1.39GB/s ± 1%  +27.52%  (p=0.008 n=5+5)
ExtractColor-10             230MB/s ± 0%   242MB/s ± 0%   +5.27%  (p=0.008 n=5+5)
```