### PR TITLE
add support for ansi strikethrough

### DIFF
--- a/src/ansi.go
+++ b/src/ansi.go
@@ -55,6 +55,9 @@ func (s *ansiState) ToString() string {
 	if s.attr&tui.Reverse > 0 {
 		ret += "7;"
 	}
+	if s.attr&tui.Strikethrough > 0 {
+		ret += "9;"
+	}
 	ret += toAnsiString(s.fg, 30) + toAnsiString(s.bg, 40)
 
 	return "\x1b[" + strings.TrimSuffix(ret, ";") + "m"
@@ -368,6 +371,8 @@ func interpretCode(ansiCode string, prevState *ansiState) ansiState {
 					state.attr = state.attr | tui.Blink
 				case 7:
 					state.attr = state.attr | tui.Reverse
+				case 9:
+					state.attr = state.attr | tui.Strikethrough
 				case 23: // tput rmso
 					state.attr = state.attr &^ tui.Italic
 				case 24: // tput rmul

--- a/src/tui/dummy.go
+++ b/src/tui/dummy.go
@@ -16,6 +16,7 @@ const (
 	AttrUndefined = Attr(0)
 	AttrRegular   = Attr(1 << 7)
 	AttrClear     = Attr(1 << 8)
+	Strikethrough = Attr(1 << 9)
 
 	Bold      = Attr(1)
 	Dim       = Attr(1 << 1)

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -856,6 +856,9 @@ func attrCodes(attr Attr) []string {
 	if (attr & Reverse) > 0 {
 		codes = append(codes, "7")
 	}
+	if (attr & Strikethrough) > 0 {
+		codes = append(codes, "9")
+	}
 	return codes
 }
 

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -77,6 +77,7 @@ const (
 	Blink          = Attr(tcell.AttrBlink)
 	Reverse        = Attr(tcell.AttrReverse)
 	Underline      = Attr(tcell.AttrUnderline)
+	Strikethrough  = Attr(tcell.AttrStrikethrough)
 	Italic         = Attr(tcell.AttrItalic)
 )
 
@@ -561,6 +562,7 @@ func (w *TcellWindow) printString(text string, pair ColorPair) {
 		style = style.
 			Reverse(a&Attr(tcell.AttrReverse) != 0).
 			Underline(a&Attr(tcell.AttrUnderline) != 0).
+			Strikethrough(a&Attr(tcell.AttrStrikethrough) != 0).
 			Italic(a&Attr(tcell.AttrItalic) != 0).
 			Blink(a&Attr(tcell.AttrBlink) != 0).
 			Dim(a&Attr(tcell.AttrDim) != 0)
@@ -612,6 +614,7 @@ func (w *TcellWindow) fillString(text string, pair ColorPair) FillReturn {
 		Dim(a&Attr(tcell.AttrDim) != 0).
 		Reverse(a&Attr(tcell.AttrReverse) != 0).
 		Underline(a&Attr(tcell.AttrUnderline) != 0).
+		Strikethrough(a&Attr(tcell.AttrStrikethrough) != 0).
 		Italic(a&Attr(tcell.AttrItalic) != 0)
 
 	gr := uniseg.NewGraphemes(text)


### PR DESCRIPTION
I'm sure more is missing, but this seems to work already with piping ansi strike through text to fzf.