### PR TITLE
Fix bash completion var or aliase containing newlines

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -288,7 +288,7 @@ _fzf_host_completion() {
 
 _fzf_var_completion() {
   _fzf_complete -m -- "$@" < <(
-    declare -xp | sed -En 's|^declare -x ([^=]+).*|\1|p'
+    declare -xp | sed -En 's|^declare [^ ]+ ([^=]+).*|\1|p'
   )
 }
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -288,13 +288,13 @@ _fzf_host_completion() {
 
 _fzf_var_completion() {
   _fzf_complete -m -- "$@" < <(
-    declare -xp | sed 's/=.*//' | sed 's/.* //'
+    declare -xp | sed -En 's|^declare -x ([^=]+).*|\1|p'
   )
 }
 
 _fzf_alias_completion() {
   _fzf_complete -m -- "$@" < <(
-    alias | sed 's/=.*//' | sed 's/.* //'
+    alias | sed -En 's|^alias ([^=]+).*|\1|p'
   )
 }
 


### PR DESCRIPTION
This PR fixes the following minor problem.

In bash completion, if an environment variable contains a newline, the completion list contains the value (not the name) of the variable. The same problem exists with aliases.

Ex)

```bash
$ export AAA="
aaa_line1
aaa_line2
"

$ unset **<TAB>
> < 91/91 (0)
> AAA
  aaa_line1
  aaa_line2
  "
  ...
```