### PR TITLE
FZF command run fails with "cmd.exe: Bad address" on Cygwin with TERM=xterm-256color

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -688,7 +688,7 @@ function! s:execute(dict, command, use_height, temps) abort
       call jobstart(cmd, fzf)
       return []
     endif
-  elseif has('win32unix') && $TERM !=# 'cygwin'
+  elseif has('win32unix') && executable('cygpath') && $TERM !=# 'cygwin'
     let shellscript = s:fzf_tempname()
     call s:writefile([command], shellscript)
     let command = '$(cygpath $COMSPEC) /C '.fzf#shellescape('set "TERM=" & start /WAIT sh '.shellscript)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -691,7 +691,7 @@ function! s:execute(dict, command, use_height, temps) abort
   elseif has('win32unix') && $TERM !=# 'cygwin'
     let shellscript = s:fzf_tempname()
     call s:writefile([command], shellscript)
-    let command = 'cmd.exe /C '.fzf#shellescape('set "TERM=" & start /WAIT sh -c '.shellscript)
+    let command = '$(cygpath $COMSPEC) /C '.fzf#shellescape('set "TERM=" & start /WAIT sh '.shellscript)
     let a:temps.shellscript = shellscript
   endif
   if a:use_height


### PR DESCRIPTION
If I run `:FZF` in vim under Cygwin in mintty with TERM=xterm-256color, the separate launched window quickly closes. Debugging shows that launched process terminates due to sh.exe reporting `cmd.exe: Bad address`. 
This pull request fixes the problem by using full path to cmd.exe.