### PR TITLE
doc(man): add a hint about which UI element is the finder info

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -281,7 +281,7 @@ e.g.
 
 .TP
 .BI "--info=" "STYLE"
-Determines the display style of finder info.
+Determines the display style of finder info (match counters).
 
 .br
 .BR default "       Display on the next line to the prompt"


### PR DESCRIPTION
Hi

While reading the description of the `--info` flag, it's not immediately obvious that the "finder info" is in fact the UI element representing the match counters.

Thanks