### PR TITLE
Update fzf#install to handle spaces on Windows

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -143,7 +143,7 @@ function! fzf#install()
     if !filereadable(script)
       throw script.' not found'
     endif
-    let script = 'powershell -ExecutionPolicy Bypass -file ' . script
+    let script = 'powershell -ExecutionPolicy Bypass -file ' . shellescape(script)
   else
     let script = s:base_dir.'/install'
     if !executable(script)


### PR DESCRIPTION
Didn't see any issues addressing this problem, or any other pull requests. Should fix problems for Windows users that have a space in the plugin path.