### PR TITLE
Issues 1432

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -484,7 +484,8 @@ try
     elseif type == 3
       let temps.input = s:fzf_tempname()
       call s:writefile(source, temps.input)
-      let source_command = (s:is_win ? 'type ' : 'cat ').fzf#shellescape(temps.input)
+      "let source_command = (s:is_win ? 'type ' : 'cat ').fzf#shellescape(temps.input)
+      let source_command = 'cat '.substitute(temps.input, '\', '/', 'g')
     else
       throw 'Invalid source type'
     endif

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -37,6 +37,9 @@ endif
 if s:is_win
   let s:term_marker = '&::FZF'
 
+  " This is not bulletproof, but cmd.exe does not have SHELL env var.
+  let s:is_gitbash = has_key(environ(), 'SHELL')
+
   function! s:fzf_call(fn, ...)
     let shellslash = &shellslash
     try
@@ -484,8 +487,8 @@ try
     elseif type == 3
       let temps.input = s:fzf_tempname()
       call s:writefile(source, temps.input)
-      "let source_command = (s:is_win ? 'type ' : 'cat ').fzf#shellescape(temps.input)
-      let source_command = 'cat '.substitute(temps.input, '\', '/', 'g')
+      let source_command = (s:is_win && !s:is_gitbash ? 'type ' : 'cat ')
+        \.(s:is_gitbash ? substitute(temps.input, '\', '/', 'g') : fzf#shellescape(temps.input))
     else
       throw 'Invalid source type'
     endif


### PR DESCRIPTION
This is the other part of the issue 1432 opened in the fzf.vim repository.

It fixes the feature of `:Buffers` in Neovim running on Windows' git-bash, while making sure not to break when running in Windows' cmd.