### PR TITLE
Don't expand user defined functions in shell scripts

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -108,7 +108,7 @@ __fzf_comprun() {
     fi
   else
     shift
-    fzf "$@"
+    command fzf "$@"
   fi
 }
 

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -56,7 +56,7 @@ __fsel() {
 
 __fzfcmd() {
   [ -n "$TMUX_PANE" ] && { [ "${FZF_TMUX:-0}" != 0 ] || [ -n "$FZF_TMUX_OPTS" ]; } &&
-    echo "fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} -- " || echo "fzf"
+    echo "fzf-tmux ${FZF_TMUX_OPTS:--d${FZF_TMUX_HEIGHT:-40%}} -- " || echo "command fzf"
 }
 
 fzf-file-widget() {


### PR DESCRIPTION
Useful when, for example, doing
```zsh
fzf() {
    file_dir=$(command fzf "$@")
    if [[ $? -eq 0 ]]; then
        nvim $file_dir
    fi
}
```
or any other convenient wrappers around fzf, but don't want them to be
part of the `CTRL+T`, `CTRL+r` or `ALT+c` invocations of fzf.