### PR TITLE
doc(man): complete the definition of what --no-unicode impacts

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -276,7 +276,8 @@ the label. Label is printed on the top border line by default, add
 
 .TP
 .B "--no-unicode"
-Use ASCII characters instead of Unicode box drawing characters to draw border
+Use ASCII characters instead of Unicode drawing characters to draw borders,
+the spinner and the horizontal separator.
 
 .TP
 .BI "--margin=" MARGIN


### PR DESCRIPTION
Hello

By following through the codebase what the `opt.Unicode` flag was reaching, it turns out that the spinner is also what of the ui element impacted : https://github.com/junegunn/fzf/blob/master/src/terminal.go#L450-L455

```go
func makeSpinner(unicode bool) []string {
	if unicode {
		return []string{`⠋`, `⠙`, `⠹`, `⠸`, `⠼`, `⠴`, `⠦`, `⠧`, `⠇`, `⠏`}
	}
	return []string{`-`, `\`, `|`, `/`, `-`, `\`, `|`, `/`}
}
```

I thought it's worth mentioning this in the documentation.

Thanks