### PR TITLE
test(eventbox): remove obsolete EvtClose const

### DIFF
--- a/src/util/eventbox_test.go
+++ b/src/util/eventbox_test.go
@@ -9,7 +9,6 @@ const (
 	EvtSearchNew
 	EvtSearchProgress
 	EvtSearchFin
-	EvtClose
 )
 
 func TestEventBox(t *testing.T) {


### PR DESCRIPTION
Hi

The `EvtClose` constant was removed in 2017 in this commit refactoring the Reader : https://github.com/junegunn/fzf/commit/487c8fe88f4cfcc55850b8aef73665b1d09b8fe0

I was confused by finding this type of Event I didn't know about yet while executing this EventBox test-suite.

As it's not used in the code-base anymore, this obsolete event can be retired.

Thanks