### PR TITLE
README.md: clarify what FZF_*_OPTS is used for

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,14 +333,14 @@ fish.
 
 - `CTRL-T` - Paste the selected files and directories onto the command-line
     - Set `FZF_CTRL_T_COMMAND` to override the default command
-    - Set `FZF_CTRL_T_OPTS` to pass additional options
+    - Set `FZF_CTRL_T_OPTS` to pass additional options to fzf
 - `CTRL-R` - Paste the selected command from history onto the command-line
     - If you want to see the commands in chronological order, press `CTRL-R`
       again which toggles sorting by relevance
-    - Set `FZF_CTRL_R_OPTS` to pass additional options
+    - Set `FZF_CTRL_R_OPTS` to pass additional options to fzf
 - `ALT-C` - cd into the selected directory
     - Set `FZF_ALT_C_COMMAND` to override the default command
-    - Set `FZF_ALT_C_OPTS` to pass additional options
+    - Set `FZF_ALT_C_OPTS` to pass additional options to fzf
 
 If you're on a tmux session, you can start fzf in a tmux split-pane or in
 a tmux popup window by setting `FZF_TMUX_OPTS` (e.g. `-d 40%`).


### PR DESCRIPTION
At first I thought they were appended to FZF_*_COMMAND. Let's make it
clear that these are passed to `fzf` itself.
