### PR TITLE
Add ppc64le binaries

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -73,6 +73,7 @@ builds:
       - arm
       - arm64
       - loong64
+      - ppc64le
     goarm:
       - 5
       - 6

--- a/install
+++ b/install
@@ -176,7 +176,7 @@ case "$archi" in
   Linux\ armv8*)      download fzf-$version-linux_arm64.tar.gz   ;;
   Linux\ aarch64*)    download fzf-$version-linux_arm64.tar.gz   ;;
   Linux\ loongarch64) download fzf-$version-linux_loong64.tar.gz ;;
-  Linux\ ppc64le    ) download fzf-$version-linux_ppc64le.tar.gz ;;
+  Linux\ ppc64le)     download fzf-$version-linux_ppc64le.tar.gz ;;
   Linux\ *64)         download fzf-$version-linux_amd64.tar.gz   ;;
   FreeBSD\ *64)       download fzf-$version-freebsd_amd64.tar.gz ;;
   OpenBSD\ *64)       download fzf-$version-openbsd_amd64.tar.gz ;;

--- a/install
+++ b/install
@@ -176,6 +176,7 @@ case "$archi" in
   Linux\ armv8*)      download fzf-$version-linux_arm64.tar.gz   ;;
   Linux\ aarch64*)    download fzf-$version-linux_arm64.tar.gz   ;;
   Linux\ loongarch64) download fzf-$version-linux_loong64.tar.gz ;;
+  Linux\ ppc64le    ) download fzf-$version-linux_ppc64le.tar.gz ;;
   Linux\ *64)         download fzf-$version-linux_amd64.tar.gz   ;;
   FreeBSD\ *64)       download fzf-$version-freebsd_amd64.tar.gz ;;
   OpenBSD\ *64)       download fzf-$version-openbsd_amd64.tar.gz ;;


### PR DESCRIPTION
Little-endian 64 bit PowerPC (ppc64le) is the "normal" PowerPC architecture supported by standard Linux distributions (RedHat, SUSE, Ubuntu, etc.).

Add support for this architecture in the install script, and add binary builds for it as well.