### PR TITLE
Add --complete-1 option

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -685,6 +685,9 @@ interactive finder and automatically select the only match
 If there is no match for the initial query (\fB--query\fR), do not start
 interactive finder and exit immediately
 .TP
+.B "--complete-1"
+Exit interactive finder when there's exactly one match
+.TP
 .BI "-f, --filter=" "STR"
 Filter mode. Do not start interactive finder. When used with \fB--no-sort\fR,
 fzf becomes a fuzzy-version of grep.

--- a/src/core.go
+++ b/src/core.go
@@ -337,8 +337,14 @@ func Run(opts *Options, version string, revision string) {
 								}
 								determine(val.final)
 							}
+						} else {
+							if opts.Complete1 && val.Length() == 1 {
+								opts.Printer(val.Get(0).item.AsString(opts.Ansi))
+								terminal.reqBox.Set(reqClose, nil)
+							} else {
+								terminal.UpdateList(val, clearSelection())
+							}
 						}
-						terminal.UpdateList(val, clearSelection())
 					}
 				}
 			}

--- a/src/options.go
+++ b/src/options.go
@@ -108,6 +108,7 @@ const usage = `usage: fzf [options]
     -1, --select-1         Automatically select the only match
     -0, --exit-0           Exit immediately when there's no match
     -f, --filter=STR       Filter mode. Do not start interactive finder.
+    --complete-1           Exit interactive finder when there's exactly one match
     --print-query          Print query as the first line
     --expect=KEYS          Comma-separated list of keys to complete fzf
     --read0                Read input delimited by ASCII NUL characters
@@ -274,6 +275,7 @@ type Options struct {
 	Query        string
 	Select1      bool
 	Exit0        bool
+	Complete1    bool
 	Filter       *string
 	ToggleSort   bool
 	Expect       map[tui.Event]string
@@ -342,6 +344,7 @@ func defaultOptions() *Options {
 		Query:        "",
 		Select1:      false,
 		Exit0:        false,
+		Complete1:    false,
 		Filter:       nil,
 		ToggleSort:   false,
 		Expect:       make(map[tui.Event]string),
@@ -1546,6 +1549,8 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.Exit0 = true
 		case "+0", "--no-exit-0":
 			opts.Exit0 = false
+		case "--complete-1":
+			opts.Complete1 = true
 		case "--read0":
 			opts.ReadZero = true
 		case "--no-read0":


### PR DESCRIPTION
This adds the `--complete-1` options that will cause the interactive finder to exit as soon as a single match is found.