### PR TITLE
Expose custom options for fzf#run

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -463,6 +463,9 @@ try
   let dict   = exists('a:1') ? copy(a:1) : {}
   let temps  = { 'result': s:fzf_tempname() }
   let optstr = s:evaluate_opts(get(dict, 'options', ''))
+  if exists('g:fzf_run_options')
+    let optstr = printf("%s %s", optstr, g:fzf_run_options)
+  endif
   try
     let fzf_exec = shellescape(fzf#exec())
   catch


### PR DESCRIPTION
With the exception of buffer open actions and preview toggling, I haven't found a way to declare action bindings (i.e. movement, selection toggling, etc.) from my vimrc. All resources I've been able to find indicate that this should be done through zsh, which is heavy-handed.

This is a simple mechanism to pass additional options for the vim plugin, without modifying the shell environment. I use this to pass bindings and other fzf options that I want applied unilaterally, such as `--layout reverse`.