### PR TITLE
Support kill completion for busybox

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -270,8 +270,13 @@ _fzf_complete_kill() {
 }
 
 _fzf_proc_completion() {
+  if test $(readlink /bin/ps); then
+    local ps_args='-o user,pid,time,args'
+  else
+    local ps_args='-ef'
+  fi
   _fzf_complete -m --preview 'echo {}' --preview-window down:3:wrap --min-height 15 -- "$@" < <(
-    command ps -o user,pid,time,args | sed 1d
+    command ps $ps_args | sed 1d
   )
 }
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -271,7 +271,7 @@ _fzf_complete_kill() {
 
 _fzf_proc_completion() {
   _fzf_complete -m --preview 'echo {}' --preview-window down:3:wrap --min-height 15 -- "$@" < <(
-    command ps -ef | sed 1d
+    command ps -o user,pid,time,args | sed 1d
   )
 }
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -270,7 +270,7 @@ _fzf_complete_kill() {
 }
 
 _fzf_proc_completion() {
-  if test $(readlink /bin/ps); then
+  if [ $(ps --help 2>&1 | head -c7) == 'BusyBox' ]; then
     local ps_args='-o user,pid,time,args'
   else
     local ps_args='-ef'

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -251,7 +251,7 @@ _fzf_complete_unalias() {
 }
 
 _fzf_complete_kill() {
-  if test $(readlink /bin/ps); then
+  if [ $(ps --help 2>&1 | head -c7) == 'BusyBox' ]; then
     local ps_args='-o user,pid,time,args'
   else
     local ps_args='-ef'

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -251,8 +251,13 @@ _fzf_complete_unalias() {
 }
 
 _fzf_complete_kill() {
+  if test $(readlink /bin/ps); then
+    local ps_args='-o user,pid,time,args'
+  else
+    local ps_args='-ef'
+  fi
   _fzf_complete -m --preview 'echo {}' --preview-window down:3:wrap --min-height 15 -- "$@" < <(
-    command ps -o user,pid,time,args | sed 1d
+    command ps $ps_args | sed 1d
   )
 }
 

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -252,7 +252,7 @@ _fzf_complete_unalias() {
 
 _fzf_complete_kill() {
   _fzf_complete -m --preview 'echo {}' --preview-window down:3:wrap --min-height 15 -- "$@" < <(
-    command ps -ef | sed 1d
+    command ps -o user,pid,time,args | sed 1d
   )
 }
 


### PR DESCRIPTION
The GNU `ps -ef` lists the processes with fields in the order of `user pid time args`, but the busybox `ps` lists them in the order of `pid user time args`. This makes the tab completion for kill expand to the user instead of the pid.

Specifying the order explicitly allows us to support busybox without changing the behaviour for GNU.