### PR TITLE
Add bat to bash autocomplete commands

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -309,7 +309,7 @@ complete -o default -F _fzf_opts_completion fzf-tmux
 
 d_cmds="${FZF_COMPLETION_DIR_COMMANDS:-cd pushd rmdir}"
 a_cmds="
-  awk cat diff diff3
+  awk bat cat diff diff3
   emacs emacsclient ex file ftp g++ gcc gvim head hg hx java
   javac ld less more mvim nvim patch perl python ruby
   sed sftp sort source tail tee uniq vi view vim wc xdg-open


### PR DESCRIPTION
Bat is a common alternative to `cat`, it's even referenced multiple times in fzf docs. This makes `bat **` work by default.