### PR TITLE
fix a bug of height range.

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -219,6 +219,7 @@ func Run(opts *Options, version string, revision string) {
 	determine := func(final bool) {
 		if heightUnknown {
 			if total >= maxFit || final {
+				deferred = false
 				heightUnknown = false
 				terminal.startChan <- fitpad{util.Min(total, maxFit), padHeight}
 			}

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2716,6 +2716,13 @@ class TestGoFZF < TestBase
       assert(lines.any? { _1.include?('only match') })
     end
   end
+
+  def test_height_range_with_exit_0
+    tmux.send_keys "seq 10 | #{FZF} --height ~10% --exit-0", :Enter
+    tmux.until { |lines| assert_equal 10, lines.item_count }
+    tmux.send_keys :c
+    tmux.until { |lines| assert_equal 0, lines.match_count }
+  end
 end
 
 module TestShell


### PR DESCRIPTION
# Overview
Fixed an issue where fzf could crash when using the height range option and either the --exit-0 or --select-1 options simultaneously.

# Reproduction of the Bug
When running the following command:
```
> echo "aaa
bbb" | fzf --height=~10% --exit-0
```
fzf's filtering interface displays 'aaa' and 'bbb' as candidates, but if the filtering string 'c' is entered, fzf will force quit and fail.
Normally, fzf's filtering interface should continue and the candidates should be narrowed down to zero.

Additionally, after launching fzf in the following way, entering 'a' to filter causes fzf to force quit in the same way.
```
> echo "aaa
bbb" | fzf --height=~10% --select-1
```

# Cause and Fix
The source code in this section is the cause:
https://github.com/junegunn/fzf/blob/025aa3377342135f527d728574e59db4cb781292/src/core.go#L219-L229

If both the heightUnknown and deferred flags are true, the flags for both need to be reset to false when executing `terminal.startChan <- ...`.

# Verification
When using the binary that implements the fix in this pull request, even if the steps described in "Reproduction of the Bug" are performed, fzf does not force quit and the filtering interface continues as expected.
Fixed a bug that when both heightUnknown and deferred are true, deferred is not properly reset and the program terminates abnormally.
