### PR TITLE
Add check for powershell 7 users

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -164,7 +164,7 @@ function s:get_version(bin)
   if has_key(s:versions, a:bin)
     return s:versions[a:bin]
   end
-  let command = (&shell =~ 'powershell' || &shell =~ 'pwsh' ? '&' : '') . s:fzf_call('shellescape', a:bin) . ' --version --no-height'
+  let command = (&shell =~ 'powershell\|pwsh' ? '&' : '') . s:fzf_call('shellescape', a:bin) . ' --version --no-height'
   let output = systemlist(command)
   if v:shell_error || empty(output)
     return ''

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -164,7 +164,7 @@ function s:get_version(bin)
   if has_key(s:versions, a:bin)
     return s:versions[a:bin]
   end
-  let command = (&shell =~ 'powershell' ? '&' : '') . s:fzf_call('shellescape', a:bin) . ' --version --no-height'
+  let command = (&shell =~ 'powershell' || &shell =~ 'pwsh' ? '&' : '') . s:fzf_call('shellescape', a:bin) . ' --version --no-height'
   let output = systemlist(command)
   if v:shell_error || empty(output)
     return ''


### PR DESCRIPTION
If you are using Powershell 7 under Windows (meaning you have `shell` set to `pwsh`), FZF will fail to run with the following error:
![image](https://user-images.githubusercontent.com/52922541/233370302-ef009e51-2de2-43bb-8ae9-51ec565ff73a.png)
