### PR TITLE
Add key combinations for ctrl-delete and shift-delete

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -870,6 +870,8 @@ e.g.
 .br
 \fIctrl-space\fR
 .br
+\fIctrl-delete\fR
+.br
 \fIctrl-\\\fR
 .br
 \fIctrl-]\fR
@@ -937,6 +939,8 @@ e.g.
 \fIshift-left\fR
 .br
 \fIshift-right\fR
+.br
+\fIshift-delete\fR
 .br
 \fIalt-shift-up\fR
 .br

--- a/src/options.go
+++ b/src/options.go
@@ -612,6 +612,8 @@ func parseKeyChordsImpl(str string, message string, exit func(string)) map[tui.E
 			add(tui.BSpace)
 		case "ctrl-space":
 			add(tui.CtrlSpace)
+		case "ctrl-delete":
+			add(tui.CtrlDelete)
 		case "ctrl-^", "ctrl-6":
 			add(tui.CtrlCaret)
 		case "ctrl-/", "ctrl-_":
@@ -682,6 +684,8 @@ func parseKeyChordsImpl(str string, message string, exit func(string)) map[tui.E
 			add(tui.SLeft)
 		case "shift-right":
 			add(tui.SRight)
+		case "shift-delete":
+			add(tui.SDelete)
 		case "left-click":
 			add(tui.LeftClick)
 		case "right-click":

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -430,7 +430,19 @@ func (r *LightRenderer) escSequence(sz *int) Event {
 				}
 				return Event{Invalid, 0, nil} // INS
 			case '3':
-				return Event{Del, 0, nil}
+				if r.buffer[3] == '~' {
+					return Event{Del, 0, nil}
+				}
+				if len(r.buffer) == 6 && r.buffer[5] == '~' {
+					*sz = 6
+					switch r.buffer[4] {
+					case '5':
+						return Event{CtrlDelete, 0, nil}
+					case '2':
+						return Event{SDelete, 0, nil}
+					}
+				}
+				return Event{Invalid, 0, nil}
 			case '4':
 				return Event{End, 0, nil}
 			case '5':

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -346,8 +346,6 @@ func (r *FullscreenRenderer) GetChar() Event {
 		// section 2: Ctrl+[ \]_]
 		case tcell.KeyCtrlSpace:
 			return Event{CtrlSpace, 0, nil}
-		case tcell.KeyCtrlDelete:
-			return Event{CtrlDelete, 0, nil}
 		case tcell.KeyCtrlBackslash:
 			return Event{CtrlBackSlash, 0, nil}
 		case tcell.KeyCtrlRightSq:
@@ -408,8 +406,6 @@ func (r *FullscreenRenderer) GetChar() Event {
 				return Event{AltRight, 0, nil}
 			}
 			return Event{Right, 0, nil}
-		case tcell.KeySDelete:
-			return Event{SDelete, 0, nil}
 
 		// section 5: (Insert|Home|Delete|End|PgUp|PgDn|BackTab|F1-F12)
 		case tcell.KeyInsert:
@@ -417,6 +413,12 @@ func (r *FullscreenRenderer) GetChar() Event {
 		case tcell.KeyHome:
 			return Event{Home, 0, nil}
 		case tcell.KeyDelete:
+			if ctrl {
+				return Event{CtrlDelete, 0, nil}
+			}
+			if shift {
+				return Event{SDelete, 0, nil}
+			}
 			return Event{Del, 0, nil}
 		case tcell.KeyEnd:
 			return Event{End, 0, nil}

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -346,6 +346,8 @@ func (r *FullscreenRenderer) GetChar() Event {
 		// section 2: Ctrl+[ \]_]
 		case tcell.KeyCtrlSpace:
 			return Event{CtrlSpace, 0, nil}
+		case tcell.KeyCtrlDelete:
+			return Event{CtrlDelete, 0, nil}
 		case tcell.KeyCtrlBackslash:
 			return Event{CtrlBackSlash, 0, nil}
 		case tcell.KeyCtrlRightSq:
@@ -406,6 +408,8 @@ func (r *FullscreenRenderer) GetChar() Event {
 				return Event{AltRight, 0, nil}
 			}
 			return Event{Right, 0, nil}
+		case tcell.KeySDelete:
+			return Event{SDelete, 0, nil}
 
 		// section 5: (Insert|Home|Delete|End|PgUp|PgDn|BackTab|F1-F12)
 		case tcell.KeyInsert:

--- a/src/tui/tcell_test.go
+++ b/src/tui/tcell_test.go
@@ -92,9 +92,6 @@ func TestGetCharEventKey(t *testing.T) {
 		{giveKey{tcell.KeyCtrlSpace, rune(tcell.KeyCtrlSpace), tcell.ModCtrl}, wantKey{CtrlSpace, 0, nil}}, // fabricated
 		{giveKey{tcell.KeyNUL, rune(tcell.KeyNUL), tcell.ModNone}, wantKey{CtrlSpace, 0, nil}},             // fabricated, unhandled
 		{giveKey{tcell.KeyRune, ' ', tcell.ModCtrl}, wantKey{CtrlSpace, 0, nil}},                           // actual Ctrl+' '
-
-		{giveKey{tcell.KeyCtrlDelete, rune(tcell.KeyCtrlDelete), tcell.ModCtrl}, wantKey{CtrlDelete, 0, nil}}, // fabricated
-		{giveKey{tcell.KeyNUL, rune(tcell.KeyNUL), tcell.ModNone}, wantKey{CtrlDelete, 0, nil}},               // fabricated, unhandled
 		{giveKey{tcell.KeyCtrlBackslash, rune(tcell.KeyCtrlBackslash), tcell.ModCtrl}, wantKey{CtrlBackSlash, 0, nil}},
 		{giveKey{tcell.KeyCtrlRightSq, rune(tcell.KeyCtrlRightSq), tcell.ModCtrl}, wantKey{CtrlRightBracket, 0, nil}},
 		{giveKey{tcell.KeyCtrlCarat, rune(tcell.KeyCtrlCarat), tcell.ModShift | tcell.ModCtrl}, wantKey{CtrlCaret, 0, nil}}, // fabricated

--- a/src/tui/tcell_test.go
+++ b/src/tui/tcell_test.go
@@ -92,6 +92,9 @@ func TestGetCharEventKey(t *testing.T) {
 		{giveKey{tcell.KeyCtrlSpace, rune(tcell.KeyCtrlSpace), tcell.ModCtrl}, wantKey{CtrlSpace, 0, nil}}, // fabricated
 		{giveKey{tcell.KeyNUL, rune(tcell.KeyNUL), tcell.ModNone}, wantKey{CtrlSpace, 0, nil}},             // fabricated, unhandled
 		{giveKey{tcell.KeyRune, ' ', tcell.ModCtrl}, wantKey{CtrlSpace, 0, nil}},                           // actual Ctrl+' '
+
+		{giveKey{tcell.KeyCtrlDelete, rune(tcell.KeyCtrlDelete), tcell.ModCtrl}, wantKey{CtrlDelete, 0, nil}}, // fabricated
+		{giveKey{tcell.KeyNUL, rune(tcell.KeyNUL), tcell.ModNone}, wantKey{CtrlDelete, 0, nil}},               // fabricated, unhandled
 		{giveKey{tcell.KeyCtrlBackslash, rune(tcell.KeyCtrlBackslash), tcell.ModCtrl}, wantKey{CtrlBackSlash, 0, nil}},
 		{giveKey{tcell.KeyCtrlRightSq, rune(tcell.KeyCtrlRightSq), tcell.ModCtrl}, wantKey{CtrlRightBracket, 0, nil}},
 		{giveKey{tcell.KeyCtrlCarat, rune(tcell.KeyCtrlCarat), tcell.ModShift | tcell.ModCtrl}, wantKey{CtrlCaret, 0, nil}}, // fabricated

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -41,6 +41,7 @@ const (
 	CtrlZ
 	ESC
 	CtrlSpace
+	CtrlDelete
 
 	// https://apple.stackexchange.com/questions/24261/how-do-i-send-c-that-is-control-slash-to-the-terminal
 	CtrlBackSlash
@@ -74,6 +75,7 @@ const (
 	SDown
 	SLeft
 	SRight
+	SDelete
 
 	F1
 	F2

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2929,6 +2929,7 @@ class TestGoFZF < TestBase
     tmux.until { |lines| assert_equal '[3]', lines[-1] }
     tmux.send_keys 'S-Delete'
     tmux.until { |lines| assert_equal '[2]', lines[-1] }
+  end
 
   def test_become_tty
     tmux.send_keys "sleep 0.5 | #{FZF} --bind 'start:reload:ls' --bind 'load:become:tty'", :Enter

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2917,6 +2917,15 @@ class TestGoFZF < TestBase
     OUTPUT
     tmux.until { assert_block(expected, _1) }
   end
+
+  def test_delete_with_modifiers
+    tmux.send_keys "seq 100 | #{FZF} --bind 'ctrl-delete:up+up,shift-delete:down,focus:transform-prompt:echo [{}]'", :Enter
+    tmux.until { |lines| assert_equal 100, lines.item_count }
+    tmux.send_keys 'C-Delete'
+    tmux.until { |lines| assert_equal '[3]', lines[-1] }
+    tmux.send_keys 'S-Delete'
+    tmux.until { |lines| assert_equal '[2]', lines[-1] }
+  end
 end
 
 module TestShell


### PR DESCRIPTION
Currently there is not option to bind ctrl-delete and shift-delete. As suggested by issue #3240, shift-delete could be used to bind "delete entry from history" as it is a common way to do so in other applications, e.g. browsers.

This, however, does only implement to use the key combination itself and does not assign a default action to any of them. This does enable to call one's all predefined actions. With the exec action this can expanded like the issue #3240 suggested.
If desirable, the key combinations could later get a default behavior.

I mainly wanted to use shift-delete like suggested in #3240. My approach would be to use the exec() action to build this functionality myself. I would not be comfortable deleting from the uses history due to expansion/escape issue and deleting too much or the wrong thing (for me I would risk it).

Two issues I would like to point to:
1. I am not sure which tests need to be expanded on and how. I could use some feedback on this, if the current tests, are not sufficient.
2. I modified the switch case for `Del`. In my testing, pressing only `Del` yielded an `r.buffer` with a length of 4. When combined with <kbd>Ctrl</kbd> or <kbd>Shift</kbd> the lenght went up to 6. Index 3 was always `;` though. So I skipped it for now. Should I check for for this explicitly and if so. Should I start a new switch to keep it analogous to other code and easier expansion, if there is ever another key combination that needs it?