### PR TITLE
Add new border style: 'thinblock'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ CHANGELOG
 ------
 - Added `zero` event that is triggered when there's no match
   ```sh
- https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing#:~:text=Symbols%20for%20Legacy%20Computing%20is,and%20in%20Teletext%20broadcasting%20standards # Reload the candidate list when there's no match
+  # Reload the candidate list when there's no match
   echo $RANDOM | fzf --bind 'zero:reload(echo $RANDOM)+clear-query' --height 3
   ```
 - New actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,16 @@ CHANGELOG
 
 0.41.2
 ------
-- Added new border style `thinblock` which uses symbols for legacy computing [one eighth block elements](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing)
+- Added new border style `thinblock` which uses symbols for legacy computing
+  [one eighth block elements](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing)
+    - Similarly to `block`, this style is suitable when using a different
+      background color because the window is completely contained within the border.
+      ```sh
+      fzf --preview 'cat {}' --border thinblock --preview-window border-thinblock \
+          --color border:233,bg:234,separator:235,preview-border:235,preview-bg:236
+      ```
+    - This style may not render correctly depending on the font and the
+      terminal emulator.
 
 0.41.1
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+0.41.2
+------
+- Added new border style `thinblock` which uses symbols for legacy computing [one eighth block elements](https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing)
+
 0.41.1
 ------
 - Fixed a bug where preview window is not updated when `--disabled` is set and
@@ -25,7 +29,7 @@ CHANGELOG
 ------
 - Added `zero` event that is triggered when there's no match
   ```sh
-  # Reload the candidate list when there's no match
+ https://en.wikipedia.org/wiki/Symbols_for_Legacy_Computing#:~:text=Symbols%20for%20Legacy%20Computing%20is,and%20in%20Teletext%20broadcasting%20standards # Reload the candidate list when there's no match
   echo $RANDOM | fzf --bind 'zero:reload(echo $RANDOM)+clear-query' --height 3
   ```
 - New actions

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -228,6 +228,10 @@ Draw border around the finder
 .br
 .BR double "        Border with double lines"
 .br
+.BR block "         Border using block elements; suitable when using different background colors"
+.br
+.BR thinblock "     Border using legacy computing symbols; may not be displayed on some terminals"
+.br
 .BR horizontal "    Horizontal lines above and below the finder"
 .br
 .BR vertical "      Vertical lines on each side of the finder"
@@ -598,6 +602,10 @@ Should be used with one of the following \fB--preview-window\fR options.
 .B * border-bold
 .br
 .B * border-double
+.br
+.B * border-block
+.br
+.B * border-thinblock
 .br
 .B * border-horizontal
 .br

--- a/src/options.go
+++ b/src/options.go
@@ -63,7 +63,7 @@ const usage = `usage: fzf [options]
                            (default: 10)
     --layout=LAYOUT        Choose layout: [default|reverse|reverse-list]
     --border[=STYLE]       Draw border around the finder
-                           [rounded|sharp|bold|block|double|horizontal|vertical|
+                           [rounded|sharp|bold|block|thinblock|double|horizontal|vertical|
                             top|bottom|left|right|none] (default: rounded)
     --border-label=LABEL   Label to print on the border
     --border-label-pos=COL Position of the border label
@@ -546,6 +546,8 @@ func parseBorder(str string, optional bool) tui.BorderShape {
 		return tui.BorderBold
 	case "block":
 		return tui.BorderBlock
+	case "thinblock":
+		return tui.BorderThinBlock
 	case "double":
 		return tui.BorderDouble
 	case "horizontal":
@@ -566,7 +568,7 @@ func parseBorder(str string, optional bool) tui.BorderShape {
 		if optional && str == "" {
 			return tui.DefaultBorderShape
 		}
-		errorExit("invalid border style (expected: rounded|sharp|bold|block|double|horizontal|vertical|top|bottom|left|right|none)")
+		errorExit("invalid border style (expected: rounded|sharp|bold|block|thinblock|double|horizontal|vertical|top|bottom|left|right|none)")
 	}
 	return tui.BorderNone
 }
@@ -1438,6 +1440,8 @@ func parsePreviewWindowImpl(opts *previewOpts, input string, exit func(string)) 
 			opts.border = tui.BorderBold
 		case "border-block":
 			opts.border = tui.BorderBlock
+		case "border-thinblock":
+			opts.border = tui.BorderThinBlock
 		case "border-double":
 			opts.border = tui.BorderDouble
 		case "noborder", "border-none":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -727,7 +727,7 @@ func (t *Terminal) environ() []string {
 
 func borderLines(shape tui.BorderShape) int {
 	switch shape {
-	case tui.BorderHorizontal, tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderDouble:
+	case tui.BorderHorizontal, tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderThinBlock, tui.BorderDouble:
 		return 2
 	case tui.BorderTop, tui.BorderBottom:
 		return 1
@@ -1085,7 +1085,7 @@ func (t *Terminal) adjustMarginAndPadding() (int, int, [4]int, [4]int) {
 			if idx == 3 {
 				extraMargin[idx] += 1 + bw
 			}
-		case tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderDouble:
+		case tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderThinBlock, tui.BorderDouble:
 			extraMargin[idx] += 1 + bw*(idx%2)
 		}
 		marginInt[idx] = sizeSpecToInt(idx, sizeSpec) + extraMargin[idx]
@@ -1178,7 +1178,7 @@ func (t *Terminal) resizeWindows(forcePreview bool) {
 		t.border = t.tui.NewWindow(
 			marginInt[0], marginInt[3], width+(1+bw), height,
 			false, tui.MakeBorderStyle(tui.BorderRight, t.unicode))
-	case tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderDouble:
+	case tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderThinBlock, tui.BorderDouble:
 		t.border = t.tui.NewWindow(
 			marginInt[0]-1, marginInt[3]-(1+bw), width+(1+bw)*2, height+2,
 			false, tui.MakeBorderStyle(t.borderShape, t.unicode))
@@ -1212,7 +1212,7 @@ func (t *Terminal) resizeWindows(forcePreview bool) {
 				}
 				t.pborder = t.tui.NewWindow(y, x, w, h, true, previewBorder)
 				switch previewOpts.border {
-				case tui.BorderSharp, tui.BorderRounded, tui.BorderBold, tui.BorderBlock, tui.BorderDouble:
+				case tui.BorderSharp, tui.BorderRounded, tui.BorderBold, tui.BorderBlock, tui.BorderThinBlock, tui.BorderDouble:
 					pwidth -= (1 + bw) * 2
 					pheight -= 2
 					x += 1 + bw
@@ -1356,7 +1356,7 @@ func (t *Terminal) printLabel(window tui.Window, render labelPrinter, opts label
 	}
 
 	switch borderShape {
-	case tui.BorderHorizontal, tui.BorderTop, tui.BorderBottom, tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderDouble:
+	case tui.BorderHorizontal, tui.BorderTop, tui.BorderBottom, tui.BorderRounded, tui.BorderSharp, tui.BorderBold, tui.BorderBlock, tui.BorderThinBlock, tui.BorderDouble:
 		if redrawBorder {
 			window.DrawHBorder()
 		}

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -757,7 +757,7 @@ func (w *LightWindow) DrawHBorder() {
 
 func (w *LightWindow) drawBorder(onlyHorizontal bool) {
 	switch w.border.shape {
-	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderDouble:
+	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderThinBlock, BorderDouble:
 		w.drawBorderAround(onlyHorizontal)
 	case BorderHorizontal:
 		w.drawBorderHorizontal(true, true)

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -715,7 +715,7 @@ func (w *TcellWindow) drawBorder(onlyHorizontal bool) {
 
 	hw := runewidth.RuneWidth(w.borderStyle.top)
 	switch shape {
-	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderDouble, BorderHorizontal, BorderTop:
+	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderThinBlock, BorderDouble, BorderHorizontal, BorderTop:
 		max := right - 2*hw
 		if shape == BorderHorizontal || shape == BorderTop {
 			max = right - hw
@@ -730,7 +730,7 @@ func (w *TcellWindow) drawBorder(onlyHorizontal bool) {
 		}
 	}
 	switch shape {
-	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderDouble, BorderHorizontal, BorderBottom:
+	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderThinBlock, BorderDouble, BorderHorizontal, BorderBottom:
 		max := right - 2*hw
 		if shape == BorderHorizontal || shape == BorderBottom {
 			max = right - hw
@@ -741,13 +741,13 @@ func (w *TcellWindow) drawBorder(onlyHorizontal bool) {
 	}
 	if !onlyHorizontal {
 		switch shape {
-		case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderDouble, BorderVertical, BorderLeft:
+		case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderThinBlock, BorderDouble, BorderVertical, BorderLeft:
 			for y := top; y < bot; y++ {
 				_screen.SetContent(left, y, w.borderStyle.left, nil, style)
 			}
 		}
 		switch shape {
-		case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderDouble, BorderVertical, BorderRight:
+		case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderThinBlock, BorderDouble, BorderVertical, BorderRight:
 			vw := runewidth.RuneWidth(w.borderStyle.right)
 			for y := top; y < bot; y++ {
 				_screen.SetContent(right-vw, y, w.borderStyle.right, nil, style)
@@ -755,7 +755,7 @@ func (w *TcellWindow) drawBorder(onlyHorizontal bool) {
 		}
 	}
 	switch shape {
-	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderDouble:
+	case BorderRounded, BorderSharp, BorderBold, BorderBlock, BorderThinBlock, BorderDouble:
 		_screen.SetContent(left, top, w.borderStyle.topLeft, nil, style)
 		_screen.SetContent(right-runewidth.RuneWidth(w.borderStyle.topRight), top, w.borderStyle.topRight, nil, style)
 		_screen.SetContent(left, bot-1, w.borderStyle.bottomLeft, nil, style)

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -315,6 +315,7 @@ const (
 	BorderSharp
 	BorderBold
 	BorderBlock
+	BorderThinBlock
 	BorderDouble
 	BorderHorizontal
 	BorderVertical
@@ -408,6 +409,23 @@ func MakeBorderStyle(shape BorderShape, unicode bool) BorderStyle {
 			bottomLeft:  '▙',
 			bottomRight: '▟',
 		}
+
+	case BorderThinBlock:
+		// 🭽▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔🭾
+		// ▏                  ▕
+		// 🭼▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁🭿
+		return BorderStyle{
+			shape:       shape,
+			top:         '▔',
+			bottom:      '▁',
+			left:        '▏',
+			right:       '▕',
+			topLeft:     '🭽',
+			topRight:    '🭾',
+			bottomLeft:  '🭼',
+			bottomRight: '🭿',
+		}
+
 	case BorderDouble:
 		return BorderStyle{
 			shape:       shape,


### PR DESCRIPTION
I saw that you recently added the block border and would like to introduce a thinblock border as well. It is using the symbols from https://www.unicode.org/charts/PDF/U1FB00.pdf Symbols for Legacy Computing, ONE EIGHTH BLOCK elements.

I searched for all places with `BorderBlock` and added `BorderThinBlock`. One thing to note about the symbols is that they a font specific, and may not exist or may not align perfectly depending on the font and terminal emulator. In the case of Kitty terminal, box drawings are handled by Kitty rather than the font so it appears correctly regardless of the font.

**MonaLisa font missing the corner symbols in Alacritty:**
![Alacritty MonaLisa](https://github.com/junegunn/fzf/assets/10135646/285ca350-bfcb-4ea6-a2e2-54c51e1fc830)
**Iosevka font in Alacritty**
![Alacritty Iosevka](https://github.com/junegunn/fzf/assets/10135646/67d35dbf-3662-4d48-8e55-38d732117021)
**Iosevka font in Wezterm**
![Wezterm Iosevka](https://github.com/junegunn/fzf/assets/10135646/106f873b-b9f3-4381-b208-f379817b33f0)
**Iosevka font in iTerm2**
![iTerm2 Iosevka](https://github.com/junegunn/fzf/assets/10135646/21b95f89-e398-4cca-b9c0-dea105448888)
**MonaLisa font in Kitty**
![Kitty MonaLisa](https://github.com/junegunn/fzf/assets/10135646/dafe3223-3877-4a5e-9926-62547984b4fd)

MonaLisa Font: https://www.monolisa.dev/
Iosevka Font: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.0.2/Iosevka.zip

Please let me know what you think. Thanks!