### PR TITLE
Check if SHELL supports FZF_DEFAULT_COMMAND

### DIFF
--- a/src/constants.go
+++ b/src/constants.go
@@ -54,6 +54,7 @@ const (
 	defaultJumpLabels string = "asdfghjklqwertyuiopzxcvbnm1234567890ASDFGHJKLQWERTYUIOPZXCVBNM`~;:,<.>/?'\"!@#$%^&*()[{]}-_=+"
 )
 
+var supportedShells = []string {"bash", "zsh", "ksh", "ash", "hush", "yash"}
 var defaultCommand string
 
 func init() {

--- a/src/reader.go
+++ b/src/reader.go
@@ -98,9 +98,15 @@ func (r *Reader) ReadSource() {
 	r.startEventPoller()
 	var success bool
 	if util.IsTty() {
-		// The default command for *nix requires bash
-		shell := "bash"
+		shell := os.Getenv("SHELL")
 		cmd := os.Getenv("FZF_DEFAULT_COMMAND")
+
+		// The default command for *nix requires support for 'set -o pipefail'.
+		// Check if the current shell supports it and if not fallback to bash.
+		if ! util.InArray(supportedShells, filepath.Base(shell)) {
+			shell = "bash"
+		}
+
 		if len(cmd) == 0 {
 			if defaultCommand != "" {
 				success = r.readFromCommand(&shell, defaultCommand)

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -177,3 +177,13 @@ func RepeatToFill(str string, length int, limit int) string {
 	}
 	return output
 }
+
+// InArray checks if a string is contained in the array
+func InArray(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
When FZF_DEFAULT_COMMAND is unset, it defaults to a command that depends on 'set -o pipefail'. Since not every shell supports this option, bash was hardcoded as the default shell to be used for this specific case. With this commit, other shells that support this option are first compared to SHELL before depending/falling back to bash.

This commit closes #3339