### PR TITLE
Fix deprecations of ioutil

### DIFF
--- a/src/history.go
+++ b/src/history.go
@@ -2,7 +2,6 @@ package fzf
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"strings"
 )
@@ -26,12 +25,12 @@ func NewHistory(path string, maxSize int) (*History, error) {
 	}
 
 	// Read history file
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		// If it doesn't exist, check if we can create a file with the name
 		if os.IsNotExist(err) {
 			data = []byte{}
-			if err := ioutil.WriteFile(path, data, 0600); err != nil {
+			if err := os.WriteFile(path, data, 0600); err != nil {
 				return nil, fmtError(err)
 			}
 		} else {
@@ -62,11 +61,11 @@ func (h *History) append(line string) error {
 		lines = lines[len(lines)-h.maxSize:]
 	}
 	h.lines = append(lines, "")
-	return ioutil.WriteFile(h.path, []byte(strings.Join(h.lines, "\n")), 0600)
+	return os.WriteFile(h.path, []byte(strings.Join(h.lines, "\n")), 0600)
 }
 
 func (h *History) override(str string) {
-	// You can update the history but they're not written to the file
+	// You can update the history, but they're not written to the file
 	if h.cursor == len(h.lines)-1 {
 		h.lines[h.cursor] = str
 	} else if h.cursor < len(h.lines)-1 {

--- a/src/history_test.go
+++ b/src/history_test.go
@@ -1,7 +1,6 @@
 package fzf
 
 import (
-	"io/ioutil"
 	"os"
 	"runtime"
 	"testing"
@@ -25,7 +24,7 @@ func TestHistory(t *testing.T) {
 		}
 	}
 
-	f, _ := ioutil.TempFile("", "fzf-history")
+	f, _ := os.CreateTemp("", "fzf-history")
 	f.Close()
 
 	{ // Append lines

--- a/src/options_test.go
+++ b/src/options_test.go
@@ -2,7 +2,7 @@ package fzf
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/junegunn/fzf/src/tui"
@@ -357,7 +357,7 @@ func TestDefaultCtrlNP(t *testing.T) {
 	check([]string{"--bind=ctrl-n:accept"}, tui.CtrlN, actAccept)
 	check([]string{"--bind=ctrl-p:accept"}, tui.CtrlP, actAccept)
 
-	f, _ := ioutil.TempFile("", "fzf-history")
+	f, _ := os.CreateTemp("", "fzf-history")
 	f.Close()
 	hist := "--history=" + f.Name()
 	check([]string{hist}, tui.CtrlN, actNextHistory)

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/exec"
@@ -2208,7 +2207,7 @@ func hasPreviewFlags(template string) (slot bool, plus bool, query bool) {
 }
 
 func writeTemporaryFile(data []string, printSep string) string {
-	f, err := ioutil.TempFile("", "fzf-preview-*")
+	f, err := os.CreateTemp("", "fzf-preview-*")
 	if err != nil {
 		errorExit("Unable to create temporary file")
 	}

--- a/src/tui/ttyname_unix.go
+++ b/src/tui/ttyname_unix.go
@@ -3,7 +3,6 @@
 package tui
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 )
@@ -17,13 +16,17 @@ func ttyname() string {
 	}
 
 	for _, prefix := range devPrefixes {
-		files, err := ioutil.ReadDir(prefix)
+		files, err := os.ReadDir(prefix)
 		if err != nil {
 			continue
 		}
 
 		for _, file := range files {
-			if stat, ok := file.Sys().(*syscall.Stat_t); ok && stat.Rdev == stderr.Rdev {
+			info, err := file.Info()
+			if err != nil {
+				continue
+			}
+			if stat, ok := info.Sys().(*syscall.Stat_t); ok && stat.Rdev == stderr.Rdev {
 				return prefix + file.Name()
 			}
 		}


### PR DESCRIPTION
This PR addresses the recent deprecations in Go 1.16. I replaced them to the suggested versions (some of these methods where already under the hood calling the correct methods).