### PR TITLE
key-bindings.bash: disable pipefail in Alt+C

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -14,7 +14,8 @@
 # Key bindings
 # ------------
 __fzf_select__() {
-  local cmd opts
+  local cmd opts -
+  set +o pipefail # restored on return because we declared $- local above
   cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type f -print \
     -o -type d -print \
@@ -50,7 +51,8 @@ __fzf_cd__() {
 }
 
 __fzf_history__() {
-  local output opts script
+  local output opts script -
+  set +o pipefail # restored on return because we declared $- local above
   opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore ${FZF_DEFAULT_OPTS-} -n2..,.. --scheme=history --bind=ctrl-r:toggle-sort ${FZF_CTRL_R_OPTS-} +m --read0"
   script='BEGIN { getc; $/ = "\n\t"; $HISTCOUNT = $ENV{last_hist} + 1 } s/^[ *]//; print $HISTCOUNT - $. . "\t$_" if !$seen{$_}++'
   output=$(

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -41,7 +41,8 @@ fzf-file-widget() {
 }
 
 __fzf_cd__() {
-  local cmd opts dir
+  local cmd opts dir -
+  set +o pipefail # restored on return because we declared $- local above
   cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/\\.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type d -print 2> /dev/null | cut -b3-"}"
   opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore --reverse ${FZF_DEFAULT_OPTS-} ${FZF_ALT_C_OPTS-} +m"


### PR DESCRIPTION
With `set -o pipefail` enabled globally, the Alt+C keybinding silently fails without changing directory or indicating an error.

This change temporarily disables the shell option locally within the scope of `__fzf_cd__()`, as expected by the existing pipelines, and then restores it to the user's original setting prior to invoking Alt+C.

Requires Bash 4.4 at least, which is more than safe to assume here :)

> Reference: https://unix.stackexchange.com/a/406332

------
Proof that this technique works can be demonstrated with:
```bash
check(){ echo $*: $(set -o|grep pipefail); }
f() { check at enter f; local -; set +o pipefail; check at exit f; }
check before call f
f
check after call f
```