### PR TITLE
feat: add --no-bin option to the install file

### DIFF
--- a/install
+++ b/install
@@ -166,9 +166,9 @@ download() {
   chmod +x fzf && check_binary
 }
 
+archi=$(uname -sm)
 if [ $download_binary -eq 1 ]; then
   # Try to download binary executable
-  archi=$(uname -sm)
   binary_available=1
   binary_error=""
   case "$archi" in

--- a/install
+++ b/install
@@ -3,6 +3,7 @@
 set -u
 
 version=0.42.0
+download_binary=1
 auto_completion=
 key_bindings=
 update_config=2
@@ -24,6 +25,7 @@ usage: $0 [OPTIONS]
     --[no-]completion    Enable/disable fuzzy completion (bash & zsh)
     --[no-]update-rc     Whether or not to update shell configuration files
 
+    --no-bin             Do not download binary
     --no-bash            Do not set up bash configuration
     --no-zsh             Do not set up zsh configuration
     --no-fish            Do not set up fish configuration
@@ -53,6 +55,7 @@ for opt in "$@"; do
     --update-rc)       update_config=1   ;;
     --no-update-rc)    update_config=0   ;;
     --bin)             ;;
+    --no-bin)          download_binary=0 ;;
     --no-bash)         shells=${shells/bash/} ;;
     --no-zsh)          shells=${shells/zsh/} ;;
     --no-fish)         shells=${shells/fish/} ;;
@@ -163,58 +166,60 @@ download() {
   chmod +x fzf && check_binary
 }
 
-# Try to download binary executable
-archi=$(uname -sm)
-binary_available=1
-binary_error=""
-case "$archi" in
-  Darwin\ arm64)      download fzf-$version-darwin_arm64.zip     ;;
-  Darwin\ x86_64)     download fzf-$version-darwin_amd64.zip     ;;
-  Linux\ armv5*)      download fzf-$version-linux_armv5.tar.gz   ;;
-  Linux\ armv6*)      download fzf-$version-linux_armv6.tar.gz   ;;
-  Linux\ armv7*)      download fzf-$version-linux_armv7.tar.gz   ;;
-  Linux\ armv8*)      download fzf-$version-linux_arm64.tar.gz   ;;
-  Linux\ aarch64*)    download fzf-$version-linux_arm64.tar.gz   ;;
-  Linux\ loongarch64) download fzf-$version-linux_loong64.tar.gz ;;
-  Linux\ ppc64le)     download fzf-$version-linux_ppc64le.tar.gz ;;
-  Linux\ *64)         download fzf-$version-linux_amd64.tar.gz   ;;
-  Linux\ s390x)       download fzf-$version-linux_s390x.tar.gz   ;;
-  FreeBSD\ *64)       download fzf-$version-freebsd_amd64.tar.gz ;;
-  OpenBSD\ *64)       download fzf-$version-openbsd_amd64.tar.gz ;;
-  CYGWIN*\ *64)       download fzf-$version-windows_amd64.zip    ;;
-  MINGW*\ *64)        download fzf-$version-windows_amd64.zip    ;;
-  MSYS*\ *64)         download fzf-$version-windows_amd64.zip    ;;
-  Windows*\ *64)      download fzf-$version-windows_amd64.zip    ;;
-  *)                  binary_available=0 binary_error=1          ;;
-esac
-
-cd "$fzf_base"
-if [ -n "$binary_error" ]; then
-  if [ $binary_available -eq 0 ]; then
-    echo "No prebuilt binary for $archi ..."
-  else
-    echo "  - $binary_error !!!"
-  fi
-  if command -v go > /dev/null; then
-    echo -n "Building binary (go install github.com/junegunn/fzf) ... "
-    if [ -z "${GOPATH-}" ]; then
-      export GOPATH="${TMPDIR:-/tmp}/fzf-gopath"
-      mkdir -p "$GOPATH"
-    fi
-    if go install -ldflags "-s -w -X main.version=$version -X main.revision=go-install" github.com/junegunn/fzf; then
-      echo "OK"
-      cp "$GOPATH/bin/fzf" "$fzf_base/bin/"
+if [ $download_binary -eq 1 ]; then
+  # Try to download binary executable
+  archi=$(uname -sm)
+  binary_available=1
+  binary_error=""
+  case "$archi" in
+    Darwin\ arm64)      download fzf-$version-darwin_arm64.zip     ;;
+    Darwin\ x86_64)     download fzf-$version-darwin_amd64.zip     ;;
+    Linux\ armv5*)      download fzf-$version-linux_armv5.tar.gz   ;;
+    Linux\ armv6*)      download fzf-$version-linux_armv6.tar.gz   ;;
+    Linux\ armv7*)      download fzf-$version-linux_armv7.tar.gz   ;;
+    Linux\ armv8*)      download fzf-$version-linux_arm64.tar.gz   ;;
+    Linux\ aarch64*)    download fzf-$version-linux_arm64.tar.gz   ;;
+    Linux\ loongarch64) download fzf-$version-linux_loong64.tar.gz ;;
+    Linux\ ppc64le)     download fzf-$version-linux_ppc64le.tar.gz ;;
+    Linux\ *64)         download fzf-$version-linux_amd64.tar.gz   ;;
+    Linux\ s390x)       download fzf-$version-linux_s390x.tar.gz   ;;
+    FreeBSD\ *64)       download fzf-$version-freebsd_amd64.tar.gz ;;
+    OpenBSD\ *64)       download fzf-$version-openbsd_amd64.tar.gz ;;
+    CYGWIN*\ *64)       download fzf-$version-windows_amd64.zip    ;;
+    MINGW*\ *64)        download fzf-$version-windows_amd64.zip    ;;
+    MSYS*\ *64)         download fzf-$version-windows_amd64.zip    ;;
+    Windows*\ *64)      download fzf-$version-windows_amd64.zip    ;;
+    *)                  binary_available=0 binary_error=1          ;;
+  esac
+  
+  cd "$fzf_base"
+  if [ -n "$binary_error" ]; then
+    if [ $binary_available -eq 0 ]; then
+      echo "No prebuilt binary for $archi ..."
     else
-      echo "Failed to build binary. Installation failed."
+      echo "  - $binary_error !!!"
+    fi
+    if command -v go > /dev/null; then
+      echo -n "Building binary (go install github.com/junegunn/fzf) ... "
+      if [ -z "${GOPATH-}" ]; then
+        export GOPATH="${TMPDIR:-/tmp}/fzf-gopath"
+        mkdir -p "$GOPATH"
+      fi
+      if go install -ldflags "-s -w -X main.version=$version -X main.revision=go-install" github.com/junegunn/fzf; then
+        echo "OK"
+        cp "$GOPATH/bin/fzf" "$fzf_base/bin/"
+      else
+        echo "Failed to build binary. Installation failed."
+        exit 1
+      fi
+    else
+      echo "go executable not found. Installation failed."
       exit 1
     fi
-  else
-    echo "go executable not found. Installation failed."
-    exit 1
   fi
+  
+  [[ "$*" =~ "--bin" ]] && exit 0
 fi
-
-[[ "$*" =~ "--bin" ]] && exit 0
 
 for s in $shells; do
   if ! command -v "$s" > /dev/null; then


### PR DESCRIPTION
Fixes #3438 

One can now run:

`./install --no-bin --key-bindings --completion --update-rc`