### PR TITLE
Various bash improvements

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -12,7 +12,7 @@
 if [[ $- =~ i ]]; then
 
 # To use custom commands instead of find, override _fzf_compgen_{path,dir}
-if ! declare -f _fzf_compgen_path > /dev/null; then
+if ! declare -F _fzf_compgen_path > /dev/null; then
   _fzf_compgen_path() {
     echo "$1"
     command find -L "$1" \
@@ -21,7 +21,7 @@ if ! declare -f _fzf_compgen_path > /dev/null; then
   }
 fi
 
-if ! declare -f _fzf_compgen_dir > /dev/null; then
+if ! declare -F _fzf_compgen_dir > /dev/null; then
   _fzf_compgen_dir() {
     command find -L "$1" \
       -name .git -prune -o -name .hg -prune -o -name .svn -prune -o -type d \


### PR DESCRIPTION
Again... someone should thoroughly double check these, especially I have no `bash` versions from the primordial times of the universe around. ;-)


Speaking of which... does it really make sense to keep code for `bash` versions < 4? I mean bash 4 was something like early 2009.<br>
I'd just drop all code for those ancient versions, especially as all the use of `\C-b\C-k`, etc.  may anyway easily break, if a user has re-assigned them to something else.