### PR TITLE
Improve interactiveness checks

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -11,6 +11,7 @@
 
 [[ $- =~ i ]] || return 0
 
+
 # To use custom commands instead of find, override _fzf_compgen_{path,dir}
 if ! declare -F _fzf_compgen_path > /dev/null; then
   _fzf_compgen_path() {

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -9,7 +9,7 @@
 # - $FZF_COMPLETION_TRIGGER (default: '**')
 # - $FZF_COMPLETION_OPTS    (default: empty)
 
-if [[ $- =~ i ]]; then
+[[ $- =~ i ]] || return 0
 
 # To use custom commands instead of find, override _fzf_compgen_{path,dir}
 if ! declare -F _fzf_compgen_path > /dev/null; then
@@ -401,5 +401,3 @@ _fzf_setup_completion 'var'   export unset printenv
 _fzf_setup_completion 'alias' unalias
 _fzf_setup_completion 'host'  telnet
 _fzf_setup_completion 'proc'  kill
-
-fi

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -9,6 +9,9 @@
 # - $FZF_COMPLETION_TRIGGER (default: '**')
 # - $FZF_COMPLETION_OPTS    (default: empty)
 
+[[ -o interactive ]] || return 0
+
+
 # Both branches of the following `if` do the same thing -- define
 # __fzf_completion_options such that `eval $__fzf_completion_options` sets
 # all options to the same values they currently have. We'll do just that at
@@ -72,9 +75,6 @@ fi
 # This brace is the start of try-always block. The `always` part is like
 # `finally` in lesser languages. We use it to *always* restore user options.
 {
-
-# Bail out if not interactive shell.
-[[ -o interactive ]] || return 0
 
 # To use custom commands instead of find, override _fzf_compgen_{path,dir}
 if ! declare -f _fzf_compgen_path > /dev/null; then

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -27,7 +27,7 @@ __fzf_select__() {
     done
 }
 
-if [[ $- =~ i ]]; then
+[[ $- =~ i ]] || return 0
 
 __fzfcmd() {
   [[ -n "${TMUX_PANE-}" ]] && { [[ "${FZF_TMUX:-0}" != 0 ]] || [[ -n "${FZF_TMUX_OPTS-}" ]]; } &&
@@ -130,5 +130,3 @@ fi
 bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
 bind -m vi-command '"\ec": "\C-z\ec\C-z"'
 bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
-
-fi

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -11,6 +11,9 @@
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
 
+[[ $- =~ i ]] || return 0
+
+
 # Key bindings
 # ------------
 __fzf_select__() {
@@ -26,8 +29,6 @@ __fzf_select__() {
       printf '%q ' "$item"  # escape special chars
     done
 }
-
-[[ $- =~ i ]] || return 0
 
 __fzfcmd() {
   [[ -n "${TMUX_PANE-}" ]] && { [[ "${FZF_TMUX:-0}" != 0 ]] || [[ -n "${FZF_TMUX_OPTS-}" ]]; } &&

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -11,6 +11,9 @@
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
 
+[[ -o interactive ]] || return 0
+
+
 # Key bindings
 # ------------
 
@@ -35,8 +38,6 @@ fi
 'emulate' 'zsh' '-o' 'no_aliases'
 
 {
-
-[[ -o interactive ]] || return 0
 
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {


### PR DESCRIPTION
This should fix #3445 and bring some further minor cleanups.

As for the last commit of this series, which removes the interactiveness checks from the completion scripts and your comment:
> Fair enough. Please note that fzf can be installed by manually cloning the repo, so the files can be placed anywhere the user wants and they can make any mistake they want :)

over in #3445:<br>

I'd guess most people will install software via some form of packaging, which takes care of that - after all that's what the whole distros-system in *nix/BSD/Linux is there for.<br>
If someone installs manually from the sources, well than I think one can reasonably expect him to know what he's doing - or at least to live with it, when doing stupid things.

After all, we can only do so much to prevent people from shooting themselves.<br>
Checking for interactiveness in the key-binding scripts is IMO still some reasonable effort, because users **are** expected to actually source them manually in their `.bashrc` or similar.<br>
But for the completion scripts its IMO overkill. We also don't check there whether the shell is really bash or perhaps just POSIX sh.

That being said, if you still insist on keeping the key in the completion scripts, too, just don't pick 1ee68e1.

Cheers,
Chris.