### PR TITLE
Improve host completion

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -412,10 +412,22 @@ _fzf_proc_completion_post() {
 # desired sorting and with any duplicates removed, to standard output.
 if ! declare -F __fzf_list_hosts > /dev/null; then
   __fzf_list_hosts() {
-    command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | command awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
-      <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
-      <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
-      command awk '{if (length($2) > 0) {print $2}}' | command sort -u
+    if declare -F _known_hosts_real > /dev/null; then
+      # if available, use bash-completions’s _known_hosts_real() for getting the list of hosts
+
+      # set the local attribute for any non-local variable that is set by _known_hosts_real()
+      local COMPREPLY=()
+
+      _known_hosts_real ''
+      printf '%s\n' "${COMPREPLY[@]}" | command sort -u --version-sort
+    else
+      # otherwise, get a list of hosts on our own
+
+      command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | command awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
+        <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
+        <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
+        command awk '{if (length($2) > 0) {print $2}}' | command sort -u
+    fi
   }
 fi
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -409,8 +409,8 @@ _fzf_proc_completion_post() {
 
 __fzf_list_hosts() {
   command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | command awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
-    <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
-    <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
+    <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
+    <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
     command awk -v "user=$1" '{if (length($2) > 0) {print user $2}}' | command sort -u
 }
 

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -411,24 +411,26 @@ _fzf_proc_completion_post() {
 # The function is expected to print hostnames, one per line as well as in the
 # desired sorting and with any duplicates removed, to standard output.
 if ! declare -F __fzf_list_hosts > /dev/null; then
-  __fzf_list_hosts() {
-    if declare -F _known_hosts_real > /dev/null; then
-      # if available, use bash-completions’s _known_hosts_real() for getting the list of hosts
+  if declare -F _known_hosts_real > /dev/null; then
+    # if available, use bash-completions’s _known_hosts_real() for getting the list of hosts
 
+    __fzf_list_hosts() {
       # set the local attribute for any non-local variable that is set by _known_hosts_real()
       local COMPREPLY=()
 
       _known_hosts_real ''
       printf '%s\n' "${COMPREPLY[@]}" | command sort -u --version-sort
-    else
-      # otherwise, get a list of hosts on our own
+    }
+  else
+    # otherwise, get a list of hosts on our own
 
+    __fzf_list_hosts() {
       command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | command awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
         <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
         <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
         command awk '{if (length($2) > 0) {print $2}}' | command sort -u
-    fi
-  }
+    }
+  fi
 fi
 
 _fzf_host_completion() {

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -411,11 +411,11 @@ __fzf_list_hosts() {
   command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | command awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
     <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
     <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
-    command awk -v "user=$1" '{if (length($2) > 0) {print user $2}}' | command sort -u
+    command awk '{if (length($2) > 0) {print $2}}' | command sort -u
 }
 
 _fzf_host_completion() {
-  _fzf_complete +m -- "$@" < <(__fzf_list_hosts "")
+  _fzf_complete +m -- "$@" < <(__fzf_list_hosts)
 }
 
 # Values for $1 $2 $3 are described here
@@ -431,7 +431,7 @@ _fzf_complete_ssh() {
     *)
       local user=
       [[ "$2" =~ '@' ]] && user="${2%%@*}@"
-      _fzf_complete +m -- "$@" < <(__fzf_list_hosts "$user")
+      _fzf_complete +m -- "$@" < <(__fzf_list_hosts | command awk -v user="$user" '{print user $0}')
       ;;
   esac
 }

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -407,12 +407,17 @@ _fzf_proc_completion_post() {
   command awk '{print $2}'
 }
 
-__fzf_list_hosts() {
-  command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | command awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
-    <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
-    <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
-    command awk '{if (length($2) > 0) {print $2}}' | command sort -u
-}
+# To use custom hostname lists, override __fzf_list_hosts.
+# The function is expected to print hostnames, one per line as well as in the
+# desired sorting and with any duplicates removed, to standard output.
+if ! declare -F __fzf_list_hosts > /dev/null; then
+  __fzf_list_hosts() {
+    command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | command awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
+      <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | command tr ',' '\n' | command tr -d '[' | command awk '{ print $1 " " $1 }') \
+      <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
+      command awk '{if (length($2) > 0) {print $2}}' | command sort -u
+  }
+fi
 
 _fzf_host_completion() {
   _fzf_complete +m -- "$@" < <(__fzf_list_hosts)

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -218,13 +218,18 @@ _fzf_complete() {
   command rm -f "$fifo"
 }
 
-__fzf_list_hosts() {
-  setopt localoptions nonomatch
-  command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
-    <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
-    <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
-    awk '{if (length($2) > 0) {print $2}}' | sort -u
-}
+# To use custom hostname lists, override __fzf_list_hosts.
+# The function is expected to print hostnames, one per line as well as in the
+# desired sorting and with any duplicates removed, to standard output.
+if ! declare -f __fzf_list_hosts > /dev/null; then
+  __fzf_list_hosts() {
+    setopt localoptions nonomatch
+    command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
+      <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
+      <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
+      awk '{if (length($2) > 0) {print $2}}' | sort -u
+  }
+fi
 
 _fzf_complete_telnet() {
   _fzf_complete +m -- "$@" < <(__fzf_list_hosts)

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -221,8 +221,8 @@ _fzf_complete() {
 __fzf_list_hosts() {
   setopt localoptions nonomatch
   command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
-    <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
-    <(command grep -v '^\s*\(#\|$\)' /etc/hosts | command grep -Fv '0.0.0.0') |
+    <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
+    <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
     awk -v "user=$1" '{if (length($2) > 0) {print user $2}}' | sort -u
 }
 

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -223,11 +223,11 @@ __fzf_list_hosts() {
   command cat <(command tail -n +1 ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null | command grep -i '^\s*host\(name\)\? ' | awk '{for (i = 2; i <= NF; i++) print $1 " " $i}' | command grep -v '[*?%]') \
     <(command grep -oE '^[[a-z0-9.,:-]+' ~/.ssh/known_hosts 2> /dev/null | tr ',' '\n' | tr -d '[' | awk '{ print $1 " " $1 }') \
     <(command grep -v '^\s*\(#\|$\)' /etc/hosts 2> /dev/null | command grep -Fv '0.0.0.0') |
-    awk -v "user=$1" '{if (length($2) > 0) {print user $2}}' | sort -u
+    awk '{if (length($2) > 0) {print $2}}' | sort -u
 }
 
 _fzf_complete_telnet() {
-  _fzf_complete +m -- "$@" < <(__fzf_list_hosts "")
+  _fzf_complete +m -- "$@" < <(__fzf_list_hosts)
 }
 
 # The first and the only argument is the LBUFFER without the current word that contains the trigger.
@@ -241,7 +241,7 @@ _fzf_complete_ssh() {
     *)
       local user=
       [[ $prefix =~ @ ]] && user="${prefix%%@*}@"
-      _fzf_complete +m -- "$@" < <(__fzf_list_hosts "$user")
+      _fzf_complete +m -- "$@" < <(__fzf_list_hosts | awk -v user="$user" '{print user $0}')
       ;;
   esac
 }


### PR DESCRIPTION
Hey @junegunn.

This would fix #3450 and incorporates a number of improvements and ideas:
- IMO, `__fzf_list_hosts()` should be considered to be a function for user customisation, for which we provide however some reasonable default.
  This includes, that it’s up to that function to sort the host list it produces (if desired so) and the remove duplicates, if any.
- To keep things simple for users, I moved out the `username@` prefix handling from it into `_fzf_complete_ssh()` in c64fe9d4ea89e80405837772e7d8b0c876efbeec.
- fbe4c5408a21c981f774feeaaac81af302c9b7b5, makes `completion.bash` to use bash-completion’s `_known_hosts_real()`, if available, and falls back to the previous code for that, if not.

Some open points:
- For `completion.bash`, shall we remove the old host-list code altogether and only use `_known_hosts_real()`? I guess probably not… we need the same code anyway for zsh, and in principle `fzf`’s completion stuff can be used without bash-completion (though I doubt many do).
- I'd like to provide an easy way for users to override the sorting of the lists generated by `__fzf_list_hosts()`, so that one could make it easily configurable, whether e.g. natural sort is used or not, or easily hook in something that does what I've described [here](https://github.com/junegunn/fzf/issues/3450#issuecomment-1732762255) or perhaps a sorting that places all IPv4/6 addresses in the end, etc. pp..
  What do you think about introducing e.g. `FZF_COMPLETION_HOSTNAME_SORT_CMD`, which I'd then default to `sort -u --version-sort`?
- Possible side effects of invoking `_known_hosts_real()`.
  I went through it’s code, and if I didn’t miss anything, the only side effect is that it sets `COMPREPLY`, which I therefore made `local`. But of course, any bash-completion version may change that.
  Another approach would be to invoke `_known_hosts_real` and the `printf` in a `( … )` subshell. Would you prefer that?