### PR TITLE
[shell] improve mawk detection

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -66,7 +66,7 @@ if command -v perl > /dev/null; then
       READLINE_POINT=0x7fffffff
     fi
   }
-elif command -v awk > /dev/null || command -v mawk > /dev/null; then # awk - fallback for POSIX systems
+else # awk - fallback for POSIX systems
   __fzf_history__() {
     local output opts script n x y z d
     if [[ -z $__fzf_awk ]]; then
@@ -110,24 +110,20 @@ if (( BASH_VERSINFO[0] < 4 )); then
   bind -m vi-command '"\C-t": "\C-z\C-t\C-z"'
   bind -m vi-insert '"\C-t": "\C-z\C-t\C-z"'
 
-  if [[ $(type -t __fzf_history__) == function ]]; then
-    # CTRL-R - Paste the selected command from history into the command line
-    bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\er"'
-    bind -m vi-command '"\C-r": "\C-z\C-r\C-z"'
-    bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
-  fi
+  # CTRL-R - Paste the selected command from history into the command line
+  bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\er"'
+  bind -m vi-command '"\C-r": "\C-z\C-r\C-z"'
+  bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
 else
   # CTRL-T - Paste the selected file path into the command line
   bind -m emacs-standard -x '"\C-t": fzf-file-widget'
   bind -m vi-command -x '"\C-t": fzf-file-widget'
   bind -m vi-insert -x '"\C-t": fzf-file-widget'
 
-  if [[ $(type -t __fzf_history__) == function ]]; then
-    # CTRL-R - Paste the selected command from history into the command line
-    bind -m emacs-standard -x '"\C-r": __fzf_history__'
-    bind -m vi-command -x '"\C-r": __fzf_history__'
-    bind -m vi-insert -x '"\C-r": __fzf_history__'
-  fi
+  # CTRL-R - Paste the selected command from history into the command line
+  bind -m emacs-standard -x '"\C-r": __fzf_history__'
+  bind -m vi-command -x '"\C-r": __fzf_history__'
+  bind -m vi-insert -x '"\C-r": __fzf_history__'
 fi
 
 # ALT-C - cd into the selected directory

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -48,7 +48,7 @@ __fzf_cd__() {
   dir=$(set +o pipefail; eval "$cmd" | FZF_DEFAULT_OPTS="$opts" $(__fzfcmd)) && printf 'builtin cd -- %q' "$dir"
 }
 
-if command -v perl > /dev/null ; then
+if command -v perl > /dev/null; then
   __fzf_history__() {
     local output opts script
     opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore ${FZF_DEFAULT_OPTS-} -n2..,.. --scheme=history --bind=ctrl-r:toggle-sort ${FZF_CTRL_R_OPTS-} +m --read0"

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -84,8 +84,8 @@ elif command -v awk > /dev/null || command -v mawk > /dev/null; then # awk - fal
     END { if (NR) P(b) }'
     output=$(
       set +o pipefail
-      builtin fc -lnr -2147483648 2> /dev/null   |   # ( $'\t '<lines>$'\n' )* ; <lines> ::= [^\n]* ( $'\n'<lines> )*
-        command $__fzf_awk "$script"             |   # ( <counter>$'\t'<lines>$'\000' )*
+      builtin fc -lnr -2147483648 2> /dev/null |   # ( $'\t '<lines>$'\n' )* ; <lines> ::= [^\n]* ( $'\n'<lines> )*
+        command $__fzf_awk "$script"           |   # ( <counter>$'\t'<lines>$'\000' )*
         FZF_DEFAULT_OPTS="$opts" $(__fzfcmd) --query "$READLINE_LINE"
     ) || return
     READLINE_LINE=${output#*$'\t'}

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -66,7 +66,7 @@ if command -v perl > /dev/null; then
       READLINE_POINT=0x7fffffff
     fi
   }
-elif command -v awk > /dev/null || command -v mawk > /dev/null ; then # awk - fallback for POSIX systems
+elif command -v awk > /dev/null || command -v mawk > /dev/null; then # awk - fallback for POSIX systems
   __fzf_history__() {
     local output opts script n x y z d
     if [[ -z $__fzf_awk ]]; then

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -48,7 +48,7 @@ __fzf_cd__() {
   dir=$(set +o pipefail; eval "$cmd" | FZF_DEFAULT_OPTS="$opts" $(__fzfcmd)) && printf 'builtin cd -- %q' "$dir"
 }
 
-if command -v perl >&- ; then
+if command -v perl > /dev/null ; then
   __fzf_history__() {
     local output opts script
     opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore ${FZF_DEFAULT_OPTS-} -n2..,.. --scheme=history --bind=ctrl-r:toggle-sort ${FZF_CTRL_R_OPTS-} +m --read0"
@@ -66,13 +66,13 @@ if command -v perl >&- ; then
       READLINE_POINT=0x7fffffff
     fi
   }
-elif command -v awk >&- || command -v mawk >&- ; then # awk - fallback for POSIX systems
+elif command -v awk > /dev/null || command -v mawk > /dev/null ; then # awk - fallback for POSIX systems
   __fzf_history__() {
     local output opts script n x y z d
     if [[ -z $__fzf_awk ]]; then
       __fzf_awk=awk
       # choose the faster mawk if: it's installed && build date >= 20230322 && version >= 1.3.4
-      IFS=' .' read n x y z d <<< $(command mawk -W version 2>&-)
+      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
       [[ $n == mawk ]] && (( d >= 20230302 && (x *1000 +y) *1000 +z >= 1003004 )) && __fzf_awk=mawk
     fi
     opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore ${FZF_DEFAULT_OPTS-} -n2..,.. --scheme=history --bind=ctrl-r:toggle-sort ${FZF_CTRL_R_OPTS-} +m --read0"
@@ -84,8 +84,8 @@ elif command -v awk >&- || command -v mawk >&- ; then # awk - fallback for POSIX
     END { if (NR) P(b) }'
     output=$(
       set +o pipefail
-      builtin fc -lnr -2147483648 2>&-   |   # ( $'\t '<lines>$'\n' )* ; <lines> ::= [^\n]* ( $'\n'<lines> )*
-        command $__fzf_awk "$script"     |   # ( <counter>$'\t'<lines>$'\000' )*
+      builtin fc -lnr -2147483648 2> /dev/null   |   # ( $'\t '<lines>$'\n' )* ; <lines> ::= [^\n]* ( $'\n'<lines> )*
+        command $__fzf_awk "$script"             |   # ( <counter>$'\t'<lines>$'\000' )*
         FZF_DEFAULT_OPTS="$opts" $(__fzfcmd) --query "$READLINE_LINE"
     ) || return
     READLINE_LINE=${output#*$'\t'}


### PR DESCRIPTION
* Use the all-compatible mawk `-W version` option. https://github.com/junegunn/fzf/pull/3313#issuecomment-1747934690.
* Do not remap the history key if no dependent commands is installed (perl, awk or mawk in this order).
* Run the command and not a function consistently with #3462.

The version check bash code relies on the following mawk source code, extracted from mawk 1.3.4 20230322.

```
version.c:
18-  #include "init.h"
19-  #include "patchlev.h"
20-
21:  #define	 VERSION_STRING	 \
22-    "mawk %d.%d%s %s\n\
23-  Copyright 2008-2022,2023, Thomas E. Dickey\n\
24-  Copyright 1991-1996,2014, Michael D. Brennan\n\n"
....
30-  void
31-  print_version(FILE *fp)
32-  {
33:      fprintf(fp, VERSION_STRING, PATCH_BASE, PATCH_LEVEL, PATCH_STRING, DATE_STRING);
34-      fflush(fp);
35-
36-  #define SHOW_RANDOM "random-funcs:"

patchlev.h:
13-  /*
14-   * $MawkId: patchlev.h,v 1.128 2023/03/23 00:23:57 tom Exp $
15-   */
16:  #define  PATCH_BASE	1
17-  #define  PATCH_LEVEL	3
18-  #define  PATCH_STRING	".4"
19-  #define  DATE_STRING    "20230322"
```