### PR TITLE
Add --builtin-filter-dirs

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -117,7 +117,7 @@ func Run(opts *Options, version string, revision string) {
 		reader = NewReader(func(data []byte) bool {
 			return chunkList.Push(data)
 		}, eventBox, opts.ReadZero, opts.Filter == nil)
-		go reader.ReadSource()
+		go reader.ReadSource(opts.FilterDirs)
 	}
 
 	// Matcher
@@ -165,7 +165,7 @@ func Run(opts *Options, version string, revision string) {
 					}
 					return false
 				}, eventBox, opts.ReadZero, false)
-			reader.ReadSource()
+			reader.ReadSource(opts.FilterDirs)
 		} else {
 			eventBox.Unwatch(EvtReadNew)
 			eventBox.WaitFor(EvtReadFin)

--- a/src/options.go
+++ b/src/options.go
@@ -39,6 +39,8 @@ const usage = `usage: fzf [options]
     --tiebreak=CRI[,..]    Comma-separated list of sort criteria to apply
                            when the scores are tied [length|chunk|begin|end|index]
                            (default: length)
+    --builtin-filter-dirs  Filter directories instead of files when FZF_DEFAULT_COMMAND
+                           is not set and input is not tty
 
   Interface
     -m, --multi[=MAX]      Enable multi-select with tab/shift-tab
@@ -336,6 +338,7 @@ type Options struct {
 	Tabstop      int
 	ListenPort   *int
 	ClearOnExit  bool
+	FilterDirs   bool
 	Version      bool
 }
 
@@ -405,6 +408,7 @@ func defaultOptions() *Options {
 		BorderLabel:  labelOpts{},
 		PreviewLabel: labelOpts{},
 		ClearOnExit:  true,
+		FilterDirs:   false,
 		Version:      false}
 }
 
@@ -1821,6 +1825,8 @@ func parseOptions(opts *Options, allArgs []string) {
 			opts.ClearOnExit = true
 		case "--no-clear":
 			opts.ClearOnExit = false
+		case "--builtin-filter-dirs":
+			opts.FilterDirs = true
 		case "--version":
 			opts.Version = true
 		case "--":


### PR DESCRIPTION
* fzf's builtin filesystem walker is faster then overridding via `FZF_DEFAULT_COMMAND`, especially on Windows
* If this switch is specified, fzf will read directories instead of files if `FZF_DEFAULT_COMMAND` is not specified and there's no input from tty