### PR TITLE
fix: #2094

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -67,7 +67,7 @@ fi
 # control. There are several others that could wreck havoc if they are set
 # to values we don't expect. With the following `emulate` command we
 # sidestep this issue entirely.
-'emulate' 'zsh' '-o' 'no_aliases'
+'builtin' 'emulate' 'zsh' && 'builtin' 'setopt' 'no_aliases'
 
 # This brace is the start of try-always block. The `always` part is like
 # `finally` in lesser languages. We use it to *always* restore user options.

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -32,7 +32,7 @@ else
   }
 fi
 
-'emulate' 'zsh' '-o' 'no_aliases'
+'builtin' 'emulate' 'zsh' && 'builtin' 'setopt' 'no_aliases'
 
 {
 


### PR DESCRIPTION
### Description

- fix #2094
- The 'emulate' command's ability to accept 'setopt' flags after the shell name is not available for
  Zsh versions below 5, causing an unwanted message when sourcing the file.
	- This issue was confirmed by @romkatv.
- Despite the original reporter claiming to have a more recent version of zsh, it's recommended they
  verify their version again. @fluency03
