### PR TITLE
[fish] exit as well when called from non-interactive shell

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -11,6 +11,9 @@
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
 
+status is-interactive; or exit 0
+
+
 # Key bindings
 # ------------
 function fzf_key_bindings


### PR DESCRIPTION
Let's see whether the test suite would pass if the old `--is-interactive` is used.