### PR TITLE
[bash] bring fzf’s own bash completion up to date

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -69,55 +69,185 @@ _fzf_opts_completion() {
   cur="${COMP_WORDS[COMP_CWORD]}"
   prev="${COMP_WORDS[COMP_CWORD-1]}"
   opts="
+    -h --help
     -x --extended
     -e --exact
+    --extended-exact
+    +x --no-extended
+    +e --no-exact
+    -q --query
+    -f --filter
+    --literal
+    --no-literal
     --algo
-    -i +i
+    --scheme
+    --expect
+    --no-expect
+    --enabled --no-phony
+    --disabled --phony
+    --tiebreak
+    --bind
+    --color
+    --toggle-sort
+    -d --delimiter
     -n --nth
     --with-nth
-    -d --delimiter
+    -s --sort
     +s --no-sort
+    --track
+    --no-track
     --tac
-    --tiebreak
+    --no-tac
+    -i
+    +i
     -m --multi
+    +m --no-multi
+    --ansi
+    --no-ansi
     --no-mouse
-    --bind
-    --cycle
-    --no-hscroll
-    --jump-labels
-    --height
-    --literal
+    +c --no-color
+    +2 --no-256
+    --black
+    --no-black
+    --bold
+    --no-bold
+    --layout
     --reverse
-    --margin
+    --no-reverse
+    --cycle
+    --no-cycle
+    --keep-right
+    --no-keep-right
+    --hscroll
+    --no-hscroll
+    --hscroll-off
+    --scroll-off
+    --filepath-word
+    --no-filepath-word
+    --info
+    --no-info
     --inline-info
+    --no-inline-info
+    --separator
+    --no-separator
+    --scrollbar
+    --no-scrollbar
+    --jump-labels
+    -1 --select-1
+    +1 --no-select-1
+    -0 --exit-0
+    +0 --no-exit-0
+    --read0
+    --no-read0
+    --print0
+    --no-print0
+    --print-query
+    --no-print-query
     --prompt
     --pointer
     --marker
-    --header
-    --header-lines
-    --ansi
-    --tabstop
-    --color
-    --no-bold
+    --sync
+    --no-sync
+    --async
+    --no-history
     --history
     --history-size
+    --no-header
+    --no-header-lines
+    --header
+    --header-lines
+    --header-first
+    --no-header-first
+    --ellipsis
     --preview
+    --no-preview
     --preview-window
-    -q --query
-    -1 --select-1
-    -0 --exit-0
-    -f --filter
-    --print-query
-    --expect
-    --sync"
+    --height
+    --min-height
+    --no-height
+    --no-margin
+    --no-padding
+    --no-border
+    --border
+    --no-border-label
+    --border-label
+    --border-label-pos
+    --no-preview-label
+    --preview-label
+    --preview-label-pos
+    --no-unicode
+    --unicode
+    --margin
+    --padding
+    --tabstop
+    --listen
+    --no-listen
+    --clear
+    --no-clear
+    --version
+    --"
 
   case "${prev}" in
+  --algo)
+    COMPREPLY=( $(compgen -W "v1 v2" -- "$cur") )
+    return 0
+    ;;
+  --scheme)
+    COMPREPLY=( $(compgen -W "default path history" -- "$cur") )
+    return 0
+    ;;
   --tiebreak)
-    COMPREPLY=( $(compgen -W "length begin end index" -- "$cur") )
+    COMPREPLY=( $(compgen -W "length chunk begin end index" -- "$cur") )
     return 0
     ;;
   --color)
-    COMPREPLY=( $(compgen -W "dark light 16 bw" -- "$cur") )
+    COMPREPLY=( $(compgen -W "dark light 16 bw no" -- "$cur") )
+    return 0
+    ;;
+  --layout)
+    COMPREPLY=( $(compgen -W "default reverse reverse-list" -- "$cur") )
+    return 0
+    ;;
+  --info)
+    COMPREPLY=( $(compgen -W "default right hidden inline inline-right" -- "$cur") )
+    return 0
+    ;;
+  --preview-window)
+    COMPREPLY=( $(compgen -W "
+      default
+      hidden
+      nohidden
+      wrap
+      nowrap
+      cycle
+      nocycle
+      up top
+      down bottom
+      left
+      right
+      rounded border border-rounded
+      sharp border-sharp
+      border-bold
+      border-block
+      border-thinblock
+      border-double
+      noborder border-none
+      border-horizontal
+      border-vertical
+      border-up border-top
+      border-down border-bottom
+      border-left
+      border-right
+      follow
+      nofollow" -- "$cur") )
+    return 0
+    ;;
+  --border)
+    COMPREPLY=( $(compgen -W "rounded sharp bold block thinblock double horizontal vertical top bottom left right none" -- "$cur") )
+    return 0
+    ;;
+  --border-label-pos|--preview-label-pos)
+    COMPREPLY=( $(compgen -W "center bottom top" -- "$cur") )
     return 0
     ;;
   --history)

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -250,10 +250,6 @@ _fzf_opts_completion() {
     COMPREPLY=( $(compgen -W "center bottom top" -- "$cur") )
     return 0
     ;;
-  --history)
-    COMPREPLY=()
-    return 0
-    ;;
   esac
 
   if [[ "$cur" =~ ^-|\+ ]]; then


### PR DESCRIPTION
Well, I tried to find out all possible options and "fixed" values as good as I could from the actual parsing code.<br>
Unfortunately both, `--help`-output and the manpage seem to be also outdated (see #3470), so these were couldn’t really be used as a reference.

Yeah,... I remember your comment in https://github.com/junegunn/fzf/issues/3457#issuecomment-1741704506 ... but it sounded rather unclear whether/when you'd go that "cobra"-way... and I don't want `fzf`’s own completion to be dropped.<br>
So here's an update.

That being said, I still think we should do #3457, but maybe we can discuss that in terms of some larger ideas.

btw:<br>
Why are you doing this:
https://github.com/junegunn/fzf/blob/a0d61b4c373f6b977314f7ebe53f6236798151e9/shell/completion.bash#L123-L126
?
Can it be dropped?