### PR TITLE
revisit after Oct 2027: drop support for ancient fish versions in interactiveness checks

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -11,7 +11,7 @@
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
 
-if status is-interactive
+status is-interactive; or return 0
 
 
 # Key bindings
@@ -171,8 +171,5 @@ function fzf_key_bindings
 
     echo $dir
   end
-
-end
-
 
 end

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -11,7 +11,7 @@
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
 
-status is-interactive; or return 0
+status is-interactive; or exit
 
 
 # Key bindings

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -11,6 +11,9 @@
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
 
+if status is-interactive
+
+
 # Key bindings
 # ------------
 function fzf_key_bindings
@@ -168,5 +171,8 @@ function fzf_key_bindings
 
     echo $dir
   end
+
+end
+
 
 end


### PR DESCRIPTION
This improves commit 5cb5bbdc32fa581c5e2c93552cf60a9ded4d147a by just returning
from the script in case it’s sourced from a non-interactive shell, rather then
using an `if`-block to not execute any further code (which is error prone, in
case code gets accidentally added outside the `if`, and also less readable).

This removes support for fish versions < 3.4.0, which should now no longer be
used.