### PR TITLE
[bash] adapt to bash-completion’s naming consolidation

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -411,8 +411,18 @@ _fzf_proc_completion_post() {
 # The function is expected to print hostnames, one per line as well as in the
 # desired sorting and with any duplicates removed, to standard output.
 if ! declare -F __fzf_list_hosts > /dev/null; then
-  if declare -F _known_hosts_real > /dev/null; then
-    # if available, use bash-completions’s _known_hosts_real() for getting the list of hosts
+  if declare -F _comp_compgen_known_hosts > /dev/null; then
+    # if available, use bash-completions’s _comp_compgen_known_hosts() for getting the list of hosts
+
+    __fzf_list_hosts() {
+      # set the local attribute for any non-local variable that is set by _comp_compgen_known_hosts()
+      local COMPREPLY=()
+
+      _comp_compgen_known_hosts ''
+      printf '%s\n' "${COMPREPLY[@]}" | command sort -u --version-sort
+    }
+  elif declare -F _known_hosts_real > /dev/null; then
+    # if available, use old bash-completions’s _known_hosts_real() for getting the list of hosts
 
     __fzf_list_hosts() {
       # set the local attribute for any non-local variable that is set by _known_hosts_real()


### PR DESCRIPTION
Recently, bash-completion started to give their functions a more systematic naming schema by adding a `_comp`- respectively `_comp_compgen`-prefix.

bash-completion’s `_known_hosts_real()`, which we optionally use, was renamed in bash-completion commit d3119216c5de651e39e1026d0e81faf8949d46f6 to `_comp_compgen_known_hosts()`, which is now, AFAIU “official API”.

This commit adds support for and prefers the new name, but – if not found – falls back to the old name, in order to support old versions of bash-completion for the foreseeable future.