### PR TITLE
feat(fzf.vim): Adding option `g:fzf_fullscreen_layout`

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -403,6 +403,9 @@ function! fzf#wrap(...)
         call remove(opts, key)
       endif
     endfor
+    if exists('g:fzf_fullscreen_layout')
+      let opts = extend(opts, s:validate_layout(get(g:, 'fzf_fullscreen_layout', {})))
+    endif
   elseif !s:has_any(opts, s:layout_keys)
     if !exists('g:fzf_layout') && exists('g:fzf_height')
       let opts.down = g:fzf_height


### PR DESCRIPTION
The behavior of  fzf `Command!` (fullscreen)  has some differences between  Vim and Neovim.  

In Neovim,  it create a new tab to cause some exceptions when using `vimspector`  (but Vim does not).

https://github.com/puremourning/vimspector/issues/771

This option `g:fzf_fullscreen_layout` can customize the  fullscreen layout as you like. Below is an example:

```vim
    if has('nvim')
        let g:fzf_layout = { 'window': { 'width': 1, 'height': 0.4, 'relative': v:true, 'xoffset': 0, 'yoffset': 1 } }
        let g:fzf_fullscreen_layout = { 'window': { 'width': 1, 'height': 1, 'relative': v:false, 'xoffset': 0, 'yoffset': 1 } }
    else
        if exists('$TMUX')
            " See `fzf-tmux --help` for available options
            let g:fzf_layout = { 'tmux': '-p99%,40% -y 60%' }
            let g:fzf_fullscreen_layout = { 'tmux': '-p99%,96% -y 4%' }
        endif
    endif

```