### PR TITLE
Allow files creation in /tmp on OpenBSD

### DIFF
--- a/src/protector/protector_openbsd.go
+++ b/src/protector/protector_openbsd.go
@@ -6,5 +6,5 @@ import "golang.org/x/sys/unix"
 
 // Protect calls OS specific protections like pledge on OpenBSD
 func Protect() {
-	unix.PledgePromises("stdio rpath tty proc exec inet")
+	unix.PledgePromises("stdio rpath tty proc exec inet tmppath")
 }


### PR DESCRIPTION
  - src/protector/protector_openbsd.go: add tmppath for pledge permissions
  - fix junegunn/fzf#3511