### PR TITLE
Terminate simple server success response with double CRLF

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -218,7 +218,7 @@ func (server *httpServer) handleHttpRequest(conn net.Conn) string {
 	}
 
 	server.actionChannel <- actions
-	return httpOk
+	return httpOk + crlf
 }
 
 func parseGetParams(query string) getParams {


### PR DESCRIPTION
The simple success case had only the status line plus a single CRLF, and pedantic HTTP client implementations (`hyper`) stumbled over this. The RFC [requires two](https://www.rfc-editor.org/rfc/rfc9112#section-2.1) even if there's no body.

Fixes #3541.