### PR TITLE
zsh keybindings: ctrl-t: pass the last buffer word as query

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -39,7 +39,7 @@ fi
 
 {
 
-# CTRL-T - Paste the selected file path(s) into the command line
+# CTRL-T - Paste the selected file path(s) into the command line using the last part of the buffer as fzf query
 __fsel() {
   local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
     -o -type f -print \
@@ -47,7 +47,9 @@ __fsel() {
     -o -type l -print 2> /dev/null | cut -b3-"}"
   setopt localoptions pipefail no_aliases 2> /dev/null
   local item
-  eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --scheme=path --bind=ctrl-z:ignore ${FZF_DEFAULT_OPTS-} ${FZF_CTRL_T_OPTS-}" $(__fzfcmd) -m "$@" | while read item; do
+  local -a words=(${(z)LBUFFER})
+  local query=${words[-1]}
+  eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --scheme=path --bind=ctrl-z:ignore ${FZF_DEFAULT_OPTS-} ${FZF_CTRL_T_OPTS-}" $(__fzfcmd) -m --query="${query}" | while read item; do
     echo -n "${(q)item} "
   done
   local ret=$?


### PR DESCRIPTION
When using the Ctrl-T keybinding, to complete paths, I often start writing part of a path only to realize I want to use fzf. 

With this patch, Ctrl-T now uses the last word in the buffer as initial query for fzf, which improves this scenario.

Here's a demo:

[![zsh-keybindings-query](https://github.com/junegunn/fzf/assets/8560118/e7796faf-c887-46f1-997a-b4b1be5c7aa2)](https://asciinema.org/a/XG5gFyULA0XKqcby0QppOi2y4)


 This always uses the last word in the buffer, so typing something like `ls<space><ctrl-t>` will start fzf with `ls` as query