### PR TITLE
[vim] Use &bg for --color parameter

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -358,7 +358,9 @@ endfunction
 function! s:defaults()
   let rules = copy(get(g:, 'fzf_colors', {}))
   let colors = join(map(items(filter(map(rules, 'call("s:get_color", v:val)'), '!empty(v:val)')), 'join(v:val, ":")'), ',')
-  return empty(colors) ? '' : fzf#shellescape('--color='.colors)
+  return !empty(colors) ? fzf#shellescape('--color=' . &bg . ',' . colors) 
+        \ : &bg == 'light' ? '--color=light'
+        \ : ''
 endfunction
 
 function! s:validate_layout(layout)


### PR DESCRIPTION
Fixes https://github.com/junegunn/fzf/issues/1614.

Vim has a [`&bg` option][bg-option] which can either be `dark` (default) or `light`, we can add this to the [`--color` parameter][fzf-color] when processing `g:fzf_colors` and fzf will respect the setting in Vim.

[bg-option]: https://vimhelp.org/options.txt.html#'background%27
[fzf-color]: https://github.com/junegunn/fzf/blob/250496c953f8e36cb70ca99d58034bd79a1d0670/man/man1/fzf.1#L443

### Testing
Tested with Rose Pine theme: https://github.com/rose-pine/neovim:
1. `&bg == 'dark'` and `g:fzf_colors` is not customized --> fzf uses dark theme
2. `&bg == 'light'` and `g:fzf_colors` is not customized --> fzf uses light theme
3. `&bg == 'light'` and `g:fzf_colors` is customized --> fzf uses light theme + customization