### PR TITLE
Remove unnecessary pipe in image preview example

### DIFF
--- a/README.md
+++ b/README.md
@@ -741,7 +741,7 @@ Kitty, you can make fzf display an image in the preview window.
 ```sh
 fzf --preview='
   if file --mime-type {} | grep -qF image/; then
-    kitty icat --clear --transfer-mode=memory --stdin=no --place=${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES}@0x0 {} | sed \$d
+    kitty icat --clear --transfer-mode=memory --stdin=no --place=${FZF_PREVIEW_COLUMNS}x${FZF_PREVIEW_LINES}@0x0 {}
   else
     bat --color=always {}
   fi


### PR DESCRIPTION
Removed an unnecessary pipe from the Kitty image preview example that was preventing it from working properly.