### PR TITLE
Add $FZF_DEFAULT_OPTS_FILE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ CHANGELOG
     - You would wonder why fzf implements directory traversal anyway when it's a filter program following the Unix philosophy.
       But fzf has had [the traversal code for years][walker] to tackle the performance problem on Windows. And I decided to use the same approach on different platforms as well for the benefits listed above.
     - Built-in traversal is now done using the excellent [charlievieth/fastwalk][fastwalk] library, which easily outperforms its competitors and supports safely following symlinks.
+- Added `$FZF_DEFAULT_OPTS_FILE` to allow managing default options in a file
+    - See [#3618](https://github.com/junegunn/fzf/pull/3618)
+    - Option precedence from lower to higher
+        1. Options read from `$FZF_DEFAULT_OPTS_FILE`
+        1. Options from `$FZF_DEFAULT_OPTS`
+        1. Options from command-line arguments
 
 [find]: https://github.com/junegunn/fzf/blob/0.46.1/src/constants.go#L60-L64
 [walker]: https://github.com/junegunn/fzf/pull/1847

--- a/README.md
+++ b/README.md
@@ -329,6 +329,10 @@ or `py`.
 - `FZF_DEFAULT_OPTS`
     - Default options
     - e.g. `export FZF_DEFAULT_OPTS="--layout=reverse --inline-info"`
+- `FZF_DEFAULT_OPTS_FILE`
+    - If you prefer to manage default options in a file, set this variable to
+      point to the location of the file
+    - e.g. `export FZF_DEFAULT_OPTS_FILE=~/.fzfrc`
 
 ### Options
 

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -865,7 +865,14 @@ with \fB$SHELL -c\fR if \fBSHELL\fR is set, otherwise with \fBsh -c\fR, so in
 this case make sure that the command is POSIX-compliant.
 .TP
 .B FZF_DEFAULT_OPTS
-Default options. e.g. \fBexport FZF_DEFAULT_OPTS="--extended --cycle"\fR
+Default options.
+.br
+e.g. \fBexport FZF_DEFAULT_OPTS="--layout=reverse --border --cycle"\fR
+.TP
+.B FZF_DEFAULT_OPTS_FILE
+The location of the file that contains the default options.
+.br
+e.g. \fBexport FZF_DEFAULT_OPTS_FILE=~/.fzfrc\fR
 .TP
 .B FZF_API_KEY
 Can be used to require an API key when using \fB--listen\fR option. If not set,

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2582,6 +2582,7 @@ class TestGoFZF < TestBase
   def test_change_preview_window_rotate
     tmux.send_keys "seq 100 | #{FZF} --preview-window left,border-none --preview 'echo hello' --bind '" \
       "a:change-preview-window(right|down|up|hidden|)'", :Enter
+    tmux.until { |lines| assert(lines.any? { _1.include?('100/100') }) }
     3.times do
       tmux.until { |lines| lines[0].start_with?('hello') }
       tmux.send_keys 'a'


### PR DESCRIPTION
For those who prefer to manage default options in a file. If the file is not found, fzf will exit with an error.

We're not setting a default value for it because:

1. it's hard to find a default value that can be universally agreed upon
2. to avoid fzf having to check for the existence of the file even when it's not used

## Comparison to the alternatives

### 1. Reading the file from the shell configuration file

```sh
export FZF_DEFAULT_OPTS=$(cat ~/.fzfrc)
```

Compared to the above, with `FZF_DEFAULT_OPTS_FILE`,

* You don't have to reload your shell configuration file after editing the file
* An external script can modify the configuration file in the background

### 2. Wrapper script or function

```sh
fzf() {
  FZF_DEFAULT_OPTS=$(cat ~/.fzfrc) command fzf "$@"
}
```

This gives the same benefits of `FZF_DEFAULT_OPTS_FILE` listed above. But you have to manage the function or script yourself.