### PR TITLE
Exclude macOS containers from default find commands

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -17,8 +17,11 @@
 # Key bindings
 # ------------
 __fzf_select__() {
-  local cmd opts
-  cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local cmd opts macos_exclude
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
+  fi
+  cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null | command cut -b3-"}"
@@ -42,8 +45,11 @@ fzf-file-widget() {
 }
 
 __fzf_cd__() {
-  local cmd opts dir
-  cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local cmd opts dir macos_exclude
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
+  fi
+  cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \
     -o -type d -print 2> /dev/null | command cut -b3-"}"
   opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore --reverse --scheme=path ${FZF_DEFAULT_OPTS-} ${FZF_ALT_C_OPTS-} +m"
   dir=$(set +o pipefail; eval "$cmd" | FZF_DEFAULT_OPTS="$opts" $(__fzfcmd)) && printf 'builtin cd -- %q' "$dir"

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -18,7 +18,7 @@
 # ------------
 __fzf_select__() {
   local cmd opts macos_exclude
-  if [[ "$(uname -s)" == "Darwin" ]]; then
+  if command find /dev/null -xattrname 'com.apple.containermanager.uuid' 2> /dev/null; then
     macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
   fi
   cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \
@@ -46,7 +46,7 @@ fzf-file-widget() {
 
 __fzf_cd__() {
   local cmd opts dir macos_exclude
-  if [[ "$(uname -s)" == "Darwin" ]]; then
+  if command find /dev/null -xattrname 'com.apple.containermanager.uuid' 2> /dev/null; then
     macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
   fi
   cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -24,11 +24,15 @@ function fzf_key_bindings
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
     set -l prefix $commandline[3]
+    set -l macos_exclude ''
+    if [ (uname -s) = "Darwin" ]
+      set macos_exclude "-o -xattrname 'com.apple.containermanager.uuid'"
+    end
 
     # "-path \$dir'*/.*'" matches hidden files/folders inside $dir but not
     # $dir itself, even if hidden.
     test -n "$FZF_CTRL_T_COMMAND"; or set -l FZF_CTRL_T_COMMAND "
-    command find -L \$dir -mindepth 1 \\( -path \$dir'*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' \\) -prune \
+    command find -L \$dir -mindepth 1 \\( -path \$dir'*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' \$macos_exclude \\) -prune \
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null | sed 's@^\./@@'"
@@ -80,9 +84,13 @@ function fzf_key_bindings
     set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
     set -l prefix $commandline[3]
+    set -l macos_exclude ''
+    if [ (uname -s) = "Darwin" ]
+      set macos_exclude "-o -xattrname 'com.apple.containermanager.uuid'"
+    end
 
     test -n "$FZF_ALT_C_COMMAND"; or set -l FZF_ALT_C_COMMAND "
-    command find -L \$dir -mindepth 1 \\( -path \$dir'*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' \\) -prune \
+    command find -L \$dir -mindepth 1 \\( -path \$dir'*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' \$macos_exclude \\) -prune \
     -o -type d -print 2> /dev/null | sed 's@^\./@@'"
     test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
     begin

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -25,7 +25,7 @@ function fzf_key_bindings
     set -l fzf_query $commandline[2]
     set -l prefix $commandline[3]
     set -l macos_exclude ''
-    if [ (uname -s) = "Darwin" ]
+    if command find /dev/null -xattrname 'com.apple.containermanager.uuid' 2> /dev/null
       set macos_exclude "-o -xattrname 'com.apple.containermanager.uuid'"
     end
 
@@ -85,7 +85,7 @@ function fzf_key_bindings
     set -l fzf_query $commandline[2]
     set -l prefix $commandline[3]
     set -l macos_exclude ''
-    if [ (uname -s) = "Darwin" ]
+    if command find /dev/null -xattrname 'com.apple.containermanager.uuid' 2> /dev/null
       set macos_exclude "-o -xattrname 'com.apple.containermanager.uuid'"
     end
 

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -42,7 +42,7 @@ fi
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
   local macos_exclude
-  if [[ "$(uname -s)" == "Darwin" ]]; then
+  if command find /dev/null -xattrname 'com.apple.containermanager.uuid' 2> /dev/null; then
     macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
   fi
   local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \
@@ -78,7 +78,7 @@ bindkey -M viins '^T' fzf-file-widget
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
   local macos_exclude
-  if [[ "$(uname -s)" == "Darwin" ]]; then
+  if command find /dev/null -xattrname 'com.apple.containermanager.uuid' 2> /dev/null; then
     macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
   fi
   local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -41,7 +41,11 @@ fi
 
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
-  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local macos_exclude
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
+  fi
+  local cmd="${FZF_CTRL_T_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \
     -o -type f -print \
     -o -type d -print \
     -o -type l -print 2> /dev/null | cut -b3-"}"
@@ -73,7 +77,11 @@ bindkey -M viins '^T' fzf-file-widget
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
-  local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' \\) -prune \
+  local macos_exclude
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    macos_exclude="-o -xattrname 'com.apple.containermanager.uuid'"
+  fi
+  local cmd="${FZF_ALT_C_COMMAND:-"command find -L . -mindepth 1 \\( -path '*/.*' -o -fstype 'sysfs' -o -fstype 'devfs' -o -fstype 'devtmpfs' -o -fstype 'proc' $macos_exclude \\) -prune \
     -o -type d -print 2> /dev/null | cut -b3-"}"
   setopt localoptions pipefail no_aliases 2> /dev/null
   local dir="$(eval "$cmd" | FZF_DEFAULT_OPTS="--height ${FZF_TMUX_HEIGHT:-40%} --reverse --scheme=path --bind=ctrl-z:ignore ${FZF_DEFAULT_OPTS-} ${FZF_ALT_C_OPTS-}" $(__fzfcmd) +m)"


### PR DESCRIPTION
Specifically, exclude any file with the com.apple.containermanager.uuid extended attribute from the default Ctrl-T and Alt-C commands.

See additional discussion at #2705 