### PR TITLE
[bash] Update the completion setting after `_completion_loader`

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -299,6 +299,12 @@ _fzf_handle_dynamic_completion() {
     # _completion_loader may not have updated completion for the command
     if [[ "$(complete -p "$orig_cmd" 2> /dev/null)" != "$orig_complete" ]]; then
       __fzf_orig_completion < <(complete -p "$orig_cmd" 2> /dev/null)
+
+      # Update orig_complete by _fzf_orig_completion entry
+      [[ $orig_complete =~ ' -F '(_fzf_[^ ]+)' ' ]] &&
+        __fzf_orig_completion_instantiate "$cmd" "${BASH_REMATCH[1]}" &&
+        orig_complete=$REPLY
+
       if [[ "${__fzf_nospace_commands-}" = *" $orig_cmd "* ]]; then
         eval "${orig_complete/ -F / -o nospace -F }"
       else


### PR DESCRIPTION
## Original problem

This is a fix for an issue reported at https://github.com/scop/bash-completion/issues/1123. The original problem is that the fzf completion setting does not fully preserve the completion settings of `cd` set by `bash-completion-2.12`. More specifically, `bash-completion` completes also variable names through the `-v` option of `complete` when `shopt -s autocd` is specified, but the `-v` option is lost for bash-completion 2.12 when Fzf's completion setting is present. See the original thread for the details.

## Description of the problem

The problem is that when the completion setting is loaded by `_fzf_handle_dynamic_completion` using `bash-completion`'s `_completion_loader`, only the function specified by `-F` is used by `fzf`. The completion settings specified by other `complete` options are ignored.

The problem does not arise when the completion setting already exists when Fzf's `completion.bash` is loaded or when `_fzf_setup_completion` is called. This is because `__fzf_defc` preserves the other `complete` options. The reason that the problem was not observed with bash-completion 2.11 is that bash-completion 2.12 started to load the completion setting of `cd` dynamically. 

## Solution

When the completion settings are loaded using `_completion_loader`, the other `complete` options should be applied to the completion setting in the same way as `__fzf_defc` does.

The main fix is in commit c7322984aa88aa44fd35c5475b5f80ec8bc320b0.

### Associated refactoring

To reuse existing codes, there is a refactoring commit (0214e503d45776e0552d3350d64823bbb02ed8fa) before the main commit. In the current codebase, for the original completion settings, the pieces of the codes to determine the variable name and access the stored data are scattered.  In this commit, we define functions to access these variables. The functions are used in the main fix of this PR.

This refactoring also resolves an inconsistent escaping of `$cmd`: `$cmd` is escaped as `${...//[^A-Za-z0-9_]/_}` in some places, but it is escaped as `${...//[^A-Za-z0-9_=]/_}` in some other places.  The latter leaves the character `=` in the command name, which causes an issue because `=` cannot be a part of a variable name.  For example, the following test case produces an error message:

```bash
$ COMP_WORDBREAKS=${COMP_WORDBREAKS//=}
$ _test1() { COMPREPLY=(); }
$ complete -vF _test1 cmd.v=1.0
$ _fzf_setup_completion path cmd.v=1.0
$ cmd.v=1.0 [TAB]
bash: _fzf_orig_completion_cmd_v=1_0: invalid variable name
```

The behavior of leaving `=` was present from the beginning when saving the original completion is introduced in commit 91401514ab68c3903305bfbb8f731ca8bf3e1c59, and this does not seem to be a specific reasoning.  We replace `=` as well as the other non-identifier characters.

Note: In the new functions, the variable `REPLY` is used to return values.  This design is to make it useful with the value substitutions, which is a new Bash feature of the next release 5.3, and was originally the feature introduced by `mksh`.
