### PR TITLE
Embed shell integration scripts in fzf binary (`--bash` / `--zsh` / `--fish`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ CHANGELOG
     - bash
       ```sh
       # Set up fzf key bindings and fuzzy completion
-      source <(fzf --bash)
+      eval "$(fzf --bash)"
       ```
     - zsh
       ```sh
       # Set up fzf key bindings and fuzzy completion
-      source <(fzf --zsh)
+      eval "$(fzf --zsh)"
       ```
     - fish
       ```fish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ CHANGELOG
         export FZF_DEFAULT_COMMAND='seq 100'
         fzf --walker=dir
         ```
-- Shell integration scripts (key bindings and fuzzy completion) have been updated to use the built-in walker with these new options and they are now much faster out of the box.
+- Shell integration scripts have been updated to use the built-in walker with these new options and they are now much faster out of the box.
 
 0.47.0
 ------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,25 @@
 CHANGELOG
 =========
 
+0.48.0
+------
+- Shell integration scripts are now embedded in the fzf binary. This simplifies the distribution, and the users are less likely to have problems caused by using incompatible scripts and binaries.
+    - bash
+      ```sh
+      # Set up fzf key bindings and fuzzy completion
+      source <(fzf --bash)
+      ```
+    - zsh
+      ```sh
+      # Set up fzf key bindings and fuzzy completion
+      source <(fzf --zsh)
+      ```
+    - fish
+      ```fish
+      # Set up fzf key bindings
+      fzf --fish | source
+      ```
+
 0.47.0
 ------
 - Replaced ["the default find command"][find] with a built-in directory traversal to simplify the code and to achieve better performance and consistent behavior across platforms.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ fzf project consists of the following components:
 - `fzf-tmux` script for launching fzf in a tmux pane
 - Shell integration
     - Key bindings (`CTRL-T`, `CTRL-R`, and `ALT-C`) (bash, zsh, fish)
-    - Fuzzy auto-completion (bash, zsh)
+    - Fuzzy completion (bash, zsh)
 - Vim/Neovim plugin
 
 You can [download fzf executable][bin] alone if you don't need the extra

--- a/README.md
+++ b/README.md
@@ -124,7 +124,8 @@ to install fzf.
 brew install fzf
 ```
 
-To set up shell integration, see [the instructions below](#setting-up-shell-integration).
+> :bulb: To set up shell integration (key bindings and fuzzy completion),
+> see [the instructions below](#setting-up-shell-integration).
 
 fzf is also available [via MacPorts][portfile]: `sudo port install fzf`
 
@@ -161,7 +162,8 @@ The install script will add lines to your shell configuration file to modify
 | XBPS            | Void Linux              | `sudo xbps-install -S fzf`         |
 | Zypper          | openSUSE                | `sudo zypper install fzf`          |
 
-To set up shell integration, see [the instructions below](#setting-up-shell-integration).
+> :bulb: To set up shell integration (key bindings and fuzzy completion),
+> see [the instructions below](#setting-up-shell-integration).
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/fzf.svg)](https://repology.org/project/fzf/versions)
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ brew install fzf
 ```
 
 > [!IMPORTANT]
-> :bulb: To set up shell integration (key bindings and fuzzy completion),
+> To set up shell integration (key bindings and fuzzy completion),
 > see [the instructions below](#setting-up-shell-integration).
 
 fzf is also available [via MacPorts][portfile]: `sudo port install fzf`
@@ -164,7 +164,7 @@ The install script will add lines to your shell configuration file to modify
 | Zypper          | openSUSE                | `sudo zypper install fzf`          |
 
 > [!IMPORTANT]
-> :bulb: To set up shell integration (key bindings and fuzzy completion),
+> To set up shell integration (key bindings and fuzzy completion),
 > see [the instructions below](#setting-up-shell-integration).
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/fzf.svg)](https://repology.org/project/fzf/versions)
@@ -211,7 +211,8 @@ Add the following line to your shell configuration file.
   fzf --fish | source
   ```
 
-> :warning: `--bash`, `--zsh`, and `--fish` options are only available in
+> [!NOTE]
+> `--bash`, `--zsh`, and `--fish` options are only available in
 > fzf 0.48.0 or above. If you have an older version of fzf, refer to the
 > package documentation for more information. (e.g. `apt show fzf`)
 
@@ -265,18 +266,20 @@ directory to get the list of files.
 vim $(fzf)
 ```
 
+> [!NOTE]
 > You can override the default behavior
 > * Either by setting `$FZF_DEFAULT_COMMAND` to a command that generates the desired list
 > * Or by setting `--walker`, `--walker-root`, and `--walker-skip` options in `$FZF_DEFAULT_OPTS`
 
-> *:bulb: A more robust solution would be to use `xargs` but we've presented
-> the above as it's easier to grasp*
+> [!WARNING]
+> A more robust solution would be to use `xargs` but we've presented
+> the above as it's easier to grasp
 > ```sh
 > fzf --print0 | xargs -0 -o vim
 > ```
 
->
-> *:bulb: fzf also has the ability to turn itself into a different process.*
+> [!TIP]
+> fzf also has the ability to turn itself into a different process.
 >
 > ```sh
 > fzf --bind 'enter:become(vim {})'
@@ -350,13 +353,6 @@ or `py`.
 - `FZF_DEFAULT_COMMAND`
     - Default command to use when input is tty
     - e.g. `export FZF_DEFAULT_COMMAND='fd --type f'`
-    - > :warning: This variable is not used by shell integration due to the
-      > slight difference in requirements.
-      >
-      > (e.g. `CTRL-T` runs `$FZF_CTRL_T_COMMAND` instead, `vim **<tab>` runs
-      > `_fzf_compgen_path()`, and `cd **<tab>` runs `_fzf_compgen_dir()`)
-      >
-      > The available options are described later in this document.
 - `FZF_DEFAULT_OPTS`
     - Default options
     - e.g. `export FZF_DEFAULT_OPTS="--layout=reverse --inline-info"`
@@ -364,6 +360,17 @@ or `py`.
     - If you prefer to manage default options in a file, set this variable to
       point to the location of the file
     - e.g. `export FZF_DEFAULT_OPTS_FILE=~/.fzfrc`
+
+> [!WARNING]
+> `FZF_DEFAULT_COMMAND` is not used by shell integration due to the
+> slight difference in requirements.
+>
+> * `CTRL-T` runs `$FZF_CTRL_T_COMMAND` to get a list of files and directories
+> * `ALT-C` runs `$FZF_ALT_C_COMMAND` to get a list of directories
+> * `vim ~/**<tab>` runs `fzf_compgen_path()` with the prefix (`~/`) as the first argument
+> * `cd foo**<tab>` runs `fzf_compgen_dir()` with the prefix (`foo`) as the first argument
+>
+> The available options are described later in this document.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ fzf project consists of the following components:
 
 - `fzf` executable
 - `fzf-tmux` script for launching fzf in a tmux pane
-- Shell extensions
+- Shell integration
     - Key bindings (`CTRL-T`, `CTRL-R`, and `ALT-C`) (bash, zsh, fish)
     - Fuzzy auto-completion (bash, zsh)
 - Vim/Neovim plugin
@@ -121,10 +121,23 @@ to install fzf.
 
 ```sh
 brew install fzf
-
-# To install useful key bindings and fuzzy completion:
-$(brew --prefix)/opt/fzf/install
 ```
+
+This only installs the binary. To set up shell integration, add the following
+line to your shell configuration file.
+
+* bash
+  ```sh
+  source <(fzf --bash)
+  ```
+* zsh
+  ```sh
+  source <(zsh --zsh)
+  ```
+* fish
+  ```fish
+  fzf --fish | source
+  ```
 
 fzf is also available [via MacPorts][portfile]: `sudo port install fzf`
 
@@ -319,7 +332,7 @@ or `py`.
 - `FZF_DEFAULT_COMMAND`
     - Default command to use when input is tty
     - e.g. `export FZF_DEFAULT_COMMAND='fd --type f'`
-    - > :warning: This variable is not used by shell extensions due to the
+    - > :warning: This variable is not used by shell integration due to the
       > slight difference in requirements.
       >
       > (e.g. `CTRL-T` runs `$FZF_CTRL_T_COMMAND` instead, `vim **<tab>` runs

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ to install fzf.
 brew install fzf
 ```
 
+> [!IMPORTANT]
 > :bulb: To set up shell integration (key bindings and fuzzy completion),
 > see [the instructions below](#setting-up-shell-integration).
 
@@ -162,6 +163,7 @@ The install script will add lines to your shell configuration file to modify
 | XBPS            | Void Linux              | `sudo xbps-install -S fzf`         |
 | Zypper          | openSUSE                | `sudo zypper install fzf`          |
 
+> [!IMPORTANT]
 > :bulb: To set up shell integration (key bindings and fuzzy completion),
 > see [the instructions below](#setting-up-shell-integration).
 

--- a/README.md
+++ b/README.md
@@ -196,12 +196,12 @@ Add the following line to your shell configuration file.
 * bash
   ```sh
   # Set up fzf key bindings and fuzzy completion
-  source <(fzf --bash)
+  eval "$(fzf --bash)"
   ```
 * zsh
   ```sh
   # Set up fzf key bindings and fuzzy completion
-  source <(fzf --zsh)
+  eval "$(fzf --zsh)"
   ```
 * fish
   ```fish

--- a/README.md
+++ b/README.md
@@ -195,14 +195,17 @@ Add the following line to your shell configuration file.
 
 * bash
   ```sh
+  # Set up fzf key bindings and fuzzy completion
   source <(fzf --bash)
   ```
 * zsh
   ```sh
+  # Set up fzf key bindings and fuzzy completion
   source <(fzf --zsh)
   ```
 * fish
   ```fish
+  # Set up fzf key bindings
   fzf --fish | source
   ```
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Table of Contents
     * [Using git](#using-git)
     * [Using Linux package managers](#using-linux-package-managers)
     * [Windows](#windows)
+    * [Setting up shell integration](#setting-up-shell-integration)
     * [As Vim plugin](#as-vim-plugin)
 * [Upgrading fzf](#upgrading-fzf)
 * [Building fzf](#building-fzf)
@@ -123,21 +124,7 @@ to install fzf.
 brew install fzf
 ```
 
-This only installs the binary. To set up shell integration, add the following
-line to your shell configuration file.
-
-* bash
-  ```sh
-  source <(fzf --bash)
-  ```
-* zsh
-  ```sh
-  source <(zsh --zsh)
-  ```
-* fish
-  ```fish
-  fzf --fish | source
-  ```
+To set up shell integration, see [the instructions below](#setting-up-shell-integration).
 
 fzf is also available [via MacPorts][portfile]: `sudo port install fzf`
 
@@ -152,6 +139,9 @@ Alternatively, you can "git clone" this repository to any directory and run
 git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 ~/.fzf/install
 ```
+
+The install script will add lines to your shell configuration file to modify
+`$PATH` and set up shell integration.
 
 ### Using Linux package managers
 
@@ -171,10 +161,7 @@ git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 | XBPS            | Void Linux              | `sudo xbps-install -S fzf`         |
 | Zypper          | openSUSE                | `sudo zypper install fzf`          |
 
-> :warning: **Key bindings (CTRL-T / CTRL-R / ALT-C) and fuzzy auto-completion
-> may not be enabled by default.**
->
-> Refer to the package documentation for more information. (e.g. `apt show fzf`)
+To set up shell integration, see [the instructions below](#setting-up-shell-integration).
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/fzf.svg)](https://repology.org/project/fzf/versions)
 
@@ -199,6 +186,27 @@ Known issues and limitations on Windows can be found on [the wiki
 page][windows-wiki].
 
 [windows-wiki]: https://github.com/junegunn/fzf/wiki/Windows
+
+### Setting up shell integration
+
+Add the following line to your shell configuration file.
+
+* bash
+  ```sh
+  source <(fzf --bash)
+  ```
+* zsh
+  ```sh
+  source <(fzf --zsh)
+  ```
+* fish
+  ```fish
+  fzf --fish | source
+  ```
+
+> :warning: `--bash`, `--zsh`, and `--fish` options are only available in
+> fzf 0.48.0 or above. If you have an older version of fzf, refer to the
+> package documentation for more information. (e.g. `apt show fzf`)
 
 ### As Vim plugin
 

--- a/README.md
+++ b/README.md
@@ -784,22 +784,21 @@ See the man page (`man fzf`) for the full list of options.
 
 More advanced examples can be found [here](https://github.com/junegunn/fzf/blob/master/ADVANCED.md).
 
-----
-
-Since fzf is a general-purpose text filter rather than a file finder, **it is
-not a good idea to add `--preview` option to your `$FZF_DEFAULT_OPTS`**.
-
-```sh
-# *********************
-# ** DO NOT DO THIS! **
-# *********************
-export FZF_DEFAULT_OPTS='--preview "bat --style=numbers --color=always --line-range :500 {}"'
-
-# bat doesn't work with any input other than the list of files
-ps -ef | fzf
-seq 100 | fzf
-history | fzf
-```
+> [!WARNING]
+> Since fzf is a general-purpose text filter rather than a file finder, **it is
+> not a good idea to add `--preview` option to your `$FZF_DEFAULT_OPTS`**.
+>
+> ```sh
+> # *********************
+> # ** DO NOT DO THIS! **
+> # *********************
+> export FZF_DEFAULT_OPTS='--preview "bat --style=numbers --color=always --line-range :500 {}"'
+>
+> # bat doesn't work with any input other than the list of files
+> ps -ef | fzf
+> seq 100 | fzf
+> history | fzf
+> ```
 
 ### Previewing an image
 

--- a/install
+++ b/install
@@ -262,6 +262,12 @@ if [[ ! "\$PATH" == *$fzf_base_esc/bin* ]]; then
   PATH="\${PATH:+\${PATH}:}$fzf_base/bin"
 fi
 
+EOF
+
+  if [[ $auto_completion -eq 1 ]] && [[ $key_bindings -eq 1 ]]; then
+    echo "source <(fzf --$shell)" >> "$src"
+  else
+    cat >> "$src" << EOF
 # Auto-completion
 # ---------------
 $fzf_completion
@@ -270,6 +276,7 @@ $fzf_completion
 # ------------
 $fzf_key_bindings
 EOF
+  fi
   echo "OK"
 done
 

--- a/install
+++ b/install
@@ -288,18 +288,6 @@ if [[ "$shells" =~ fish ]]; then
   or set --universal fish_user_paths \$fish_user_paths "$fzf_base"/bin
 EOF
   [ $? -eq 0 ] && echo "OK" || echo "Failed"
-
-  mkdir -p "${fish_dir}/functions"
-  fish_binding="${fish_dir}/functions/fzf_key_bindings.fish"
-  if [ $key_bindings -ne 0 ]; then
-    echo -n "Symlink $fish_binding ... "
-    ln -sf "$fzf_base/shell/key-bindings.fish" \
-           "$fish_binding" && echo "OK" || echo "Failed"
-  else
-    echo -n "Removing $fish_binding ... "
-    rm -f "$fish_binding"
-    echo "OK"
-  fi
 fi
 
 append_line() {
@@ -362,12 +350,23 @@ done
 if [ $key_bindings -eq 1 ] && [[ "$shells" =~ fish ]]; then
   bind_file="${fish_dir}/functions/fish_user_key_bindings.fish"
   if [ ! -e "$bind_file" ]; then
+    mkdir -p "${fish_dir}/functions"
     create_file "$bind_file" \
       'function fish_user_key_bindings' \
-      '  fzf_key_bindings' \
+      '  fzf --fish | source' \
       'end'
   else
-    append_line $update_config "fzf_key_bindings" "$bind_file"
+    echo "Check $bind_file:"
+    lno=$(\grep -nF "fzf_key_bindings" "$bind_file" | sed 's/:.*//' | tr '\n' ' ')
+    if [[ -n $lno ]]; then
+      echo "  ** Found 'fzf_key_bindings' in line #$lno"
+      echo "  ** You have to replace the line to 'fzf --fish | source'"
+      echo
+    else
+      echo "  - Clear"
+      echo
+      append_line $update_config "fzf --fish | source" "$bind_file"
+    fi
   fi
 fi
 

--- a/install
+++ b/install
@@ -265,7 +265,7 @@ fi
 EOF
 
   if [[ $auto_completion -eq 1 ]] && [[ $key_bindings -eq 1 ]]; then
-    echo "source <(fzf --$shell)" >> "$src"
+    echo "eval \"\$(fzf --$shell)\"" >> "$src"
   else
     cat >> "$src" << EOF
 # Auto-completion

--- a/main.go
+++ b/main.go
@@ -30,16 +30,21 @@ func main() {
 	protector.Protect()
 	options := fzf.ParseOptions()
 	if options.Bash {
+		fmt.Println("### key-bindings.bash ###")
 		fmt.Println(string(bashKeyBindings))
+		fmt.Println("### completion.bash ###")
 		fmt.Println(string(bashCompletion))
 		return
 	}
 	if options.Zsh {
+		fmt.Println("### key-bindings.zsh ###")
 		fmt.Println(string(zshKeyBindings))
+		fmt.Println("### completion.zsh ###")
 		fmt.Println(string(zshCompletion))
 		return
 	}
 	if options.Fish {
+		fmt.Println("### key-bindings.fish ###")
 		fmt.Println(string(fishKeyBindings))
 		fmt.Println("fzf_key_bindings")
 		return

--- a/main.go
+++ b/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	_ "embed"
+	"fmt"
+
 	fzf "github.com/junegunn/fzf/src"
 	"github.com/junegunn/fzf/src/protector"
 )
@@ -8,7 +11,30 @@ import (
 var version string = "0.47"
 var revision string = "devel"
 
+//go:embed shell/key-bindings.bash
+var bashKeyBindings []byte
+
+//go:embed shell/completion.bash
+var bashCompletion []byte
+
+//go:embed shell/key-bindings.zsh
+var zshKeyBindings []byte
+
+//go:embed shell/completion.zsh
+var zshCompletion []byte
+
 func main() {
 	protector.Protect()
-	fzf.Run(fzf.ParseOptions(), version, revision)
+	options := fzf.ParseOptions()
+	if options.Bash {
+		fmt.Println(string(bashKeyBindings))
+		fmt.Println(string(bashCompletion))
+		return
+	}
+	if options.Zsh {
+		fmt.Println(string(zshKeyBindings))
+		fmt.Println(string(zshCompletion))
+		return
+	}
+	fzf.Run(options, version, revision)
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	_ "embed"
 	"fmt"
+	"strings"
 
 	fzf "github.com/junegunn/fzf/src"
 	"github.com/junegunn/fzf/src/protector"
@@ -26,26 +27,27 @@ var zshCompletion []byte
 //go:embed shell/key-bindings.fish
 var fishKeyBindings []byte
 
+func printScript(label string, content []byte) {
+	fmt.Println("### " + label + " ###")
+	fmt.Println(strings.TrimSpace(string(content)))
+	fmt.Println("### end: " + label + " ###")
+}
+
 func main() {
 	protector.Protect()
 	options := fzf.ParseOptions()
 	if options.Bash {
-		fmt.Println("### key-bindings.bash ###")
-		fmt.Println(string(bashKeyBindings))
-		fmt.Println("### completion.bash ###")
-		fmt.Println(string(bashCompletion))
+		printScript("key-bindings.bash", bashKeyBindings)
+		printScript("completion.bash", bashCompletion)
 		return
 	}
 	if options.Zsh {
-		fmt.Println("### key-bindings.zsh ###")
-		fmt.Println(string(zshKeyBindings))
-		fmt.Println("### completion.zsh ###")
-		fmt.Println(string(zshCompletion))
+		printScript("key-bindings.zsh", zshKeyBindings)
+		printScript("completion.zsh", zshCompletion)
 		return
 	}
 	if options.Fish {
-		fmt.Println("### key-bindings.fish ###")
-		fmt.Println(string(fishKeyBindings))
+		printScript("key-bindings.fish", fishKeyBindings)
 		fmt.Println("fzf_key_bindings")
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ var zshKeyBindings []byte
 //go:embed shell/completion.zsh
 var zshCompletion []byte
 
+//go:embed shell/key-bindings.fish
+var fishKeyBindings []byte
+
 func main() {
 	protector.Protect()
 	options := fzf.ParseOptions()
@@ -34,6 +37,11 @@ func main() {
 	if options.Zsh {
 		fmt.Println(string(zshKeyBindings))
 		fmt.Println(string(zshCompletion))
+		return
+	}
+	if options.Fish {
+		fmt.Println(string(fishKeyBindings))
+		fmt.Println("fzf_key_bindings")
 		return
 	}
 	fzf.Run(options, version, revision)

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -862,13 +862,13 @@ Note that most options have the opposite versions with \fB--no-\fR prefix.
 .B "--bash"
 Print script to set up Bash shell integration
 
-e.g. \fBsource <(fzf --bash)\fR
+e.g. \fBeval "$(fzf --bash)"\fR
 
 .TP
 .B "--zsh"
 Print script to set up Zsh shell integration
 
-e.g. \fBsource <(fzf --zsh)\fR
+e.g. \fBeval "$(fzf --zsh)"\fR
 
 .TP
 .B "--fish"

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -857,19 +857,24 @@ Display version information and exit
 .TP
 Note that most options have the opposite versions with \fB--no-\fR prefix.
 
-.SS Shell extension
+.SS Shell integration
 .TP
 .B "--bash"
-Print script to set up Bash shell extension
+Print script to set up Bash shell integration
 
 e.g. \fBsource <(fzf --bash)\fR
 
 .TP
 .B "--zsh"
-Print script to set up Zsh shell extension
+Print script to set up Zsh shell integration
 
 e.g. \fBsource <(fzf --zsh)\fR
 
+.TP
+.B "--fish"
+Print script to set up Fish shell integration
+
+e.g. \fBfzf --fish | source\fR
 
 .SH ENVIRONMENT VARIABLES
 .TP

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -857,6 +857,20 @@ Display version information and exit
 .TP
 Note that most options have the opposite versions with \fB--no-\fR prefix.
 
+.SS Shell extension
+.TP
+.B "--bash"
+Print script to set up Bash shell extension
+
+e.g. \fBsource <(fzf --bash)\fR
+
+.TP
+.B "--zsh"
+Print script to set up Zsh shell extension
+
+e.g. \fBsource <(fzf --zsh)\fR
+
+
 .SH ENVIRONMENT VARIABLES
 .TP
 .B FZF_DEFAULT_COMMAND

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -33,6 +33,10 @@ fzf [options]
 fzf is a general-purpose command-line fuzzy finder.
 
 .SH OPTIONS
+.SS Note
+.TP
+Most long options have the opposite version with \fB--no-\fR prefix.
+
 .SS Search mode
 .TP
 .B "-x, --extended"
@@ -878,10 +882,6 @@ The default value is the current working directory.
 .B "--walker-skip=DIRS"
 Comma-separated list of directory names to skip during the directory walk.
 The default value is \fB.git,node_modules\fR.
-
-.SS Note
-.TP
-Most options have the opposite versions with \fB--no-\fR prefix.
 
 .SS Shell integration
 .TP

--- a/src/options.go
+++ b/src/options.go
@@ -124,6 +124,10 @@ const usage = `usage: fzf [options]
                            (To allow remote process execution, use --listen-unsafe)
     --version              Display version information and exit
 
+  Shell extension
+    --bash                 Print script to set up Bash shell extension
+    --zsh                  Print script to set up Zsh shell extension
+
   Environment variables
     FZF_DEFAULT_COMMAND    Default command to use when input is tty
     FZF_DEFAULT_OPTS       Default options (e.g. '--layout=reverse --info=inline')
@@ -276,6 +280,8 @@ func firstLine(s string) string {
 
 // Options stores the values of command-line options
 type Options struct {
+	Bash         bool
+	Zsh          bool
 	Fuzzy        bool
 	FuzzyAlgo    algo.Algo
 	Scheme       string
@@ -351,6 +357,8 @@ func defaultPreviewOpts(command string) previewOpts {
 
 func defaultOptions() *Options {
 	return &Options{
+		Bash:         false,
+		Zsh:          false,
 		Fuzzy:        true,
 		FuzzyAlgo:    algo.FuzzyMatchV2,
 		Scheme:       "default",
@@ -1602,6 +1610,16 @@ func parseOptions(opts *Options, allArgs []string) {
 	for i := 0; i < len(allArgs); i++ {
 		arg := allArgs[i]
 		switch arg {
+		case "--bash":
+			opts.Bash = true
+			if opts.Zsh {
+				errorExit("cannot specify both --bash and --zsh")
+			}
+		case "--zsh":
+			opts.Zsh = true
+			if opts.Bash {
+				errorExit("cannot specify both --bash and --zsh")
+			}
 		case "-h", "--help":
 			help(exitOk)
 		case "-x", "--extended":

--- a/src/options.go
+++ b/src/options.go
@@ -124,9 +124,10 @@ const usage = `usage: fzf [options]
                            (To allow remote process execution, use --listen-unsafe)
     --version              Display version information and exit
 
-  Shell extension
-    --bash                 Print script to set up Bash shell extension
-    --zsh                  Print script to set up Zsh shell extension
+  Shell integration
+    --bash                 Print script to set up Bash shell integration
+    --zsh                  Print script to set up Zsh shell integration
+    --fish                 Print script to set up Fish shell integration
 
   Environment variables
     FZF_DEFAULT_COMMAND    Default command to use when input is tty
@@ -282,6 +283,7 @@ func firstLine(s string) string {
 type Options struct {
 	Bash         bool
 	Zsh          bool
+	Fish         bool
 	Fuzzy        bool
 	FuzzyAlgo    algo.Algo
 	Scheme       string
@@ -359,6 +361,7 @@ func defaultOptions() *Options {
 	return &Options{
 		Bash:         false,
 		Zsh:          false,
+		Fish:         false,
 		Fuzzy:        true,
 		FuzzyAlgo:    algo.FuzzyMatchV2,
 		Scheme:       "default",
@@ -1612,13 +1615,18 @@ func parseOptions(opts *Options, allArgs []string) {
 		switch arg {
 		case "--bash":
 			opts.Bash = true
-			if opts.Zsh {
-				errorExit("cannot specify both --bash and --zsh")
+			if opts.Zsh || opts.Fish {
+				errorExit("cannot specify --bash with --zsh or --fish")
 			}
 		case "--zsh":
 			opts.Zsh = true
-			if opts.Bash {
-				errorExit("cannot specify both --bash and --zsh")
+			if opts.Bash || opts.Fish {
+				errorExit("cannot specify --zsh with --bash or --fish")
+			}
+		case "--fish":
+			opts.Fish = true
+			if opts.Bash || opts.Zsh {
+				errorExit("cannot specify --fish with --bash or --zsh")
 			}
 		case "-h", "--help":
 			help(exitOk)

--- a/uninstall
+++ b/uninstall
@@ -94,6 +94,7 @@ done
 bind_file="${fish_dir}/functions/fish_user_key_bindings.fish"
 if [ -f "$bind_file" ]; then
   remove_line "$bind_file" "fzf_key_bindings"
+  remove_line "$bind_file" "fzf --fish | source"
 fi
 
 if [ -d "${fish_dir}/functions" ]; then


### PR DESCRIPTION
This simplifies the distribution, and the users are less likely to have problems caused by using incompatible scripts and binaries.

* bash
  ```sh
  # Set up fzf key bindings and fuzzy completion
  eval "$(fzf --bash)"
  ```
* zsh
  ```sh
  # Set up fzf key bindings and fuzzy completion
  eval "$(fzf --zsh)"
  ```
* fish
  ```fish
  # Set up fzf key bindings
  fzf --fish | source
  ```