### PR TITLE
Make it possible to disable `Ctrl+T` / `Alt+C` / completions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 CHANGELOG
 =========
 
+0.48.1
+------
+- CTRL-T and ALT-C bindings can be disabled by setting `FZF_CTRL_T_COMMAND` and `FZF_ALT_C_COMMAND` to empty strings respectively when sourcing the script
+    ```sh
+    # bash
+    FZF_CTRL_T_COMMAND= FZF_ALT_C_COMMAND= eval "$(fzf --bash)"
+
+    # zsh
+    FZF_CTRL_T_COMMAND= FZF_ALT_C_COMMAND= eval "$(fzf --zsh)"
+
+    # fish
+    fzf --fish | FZF_CTRL_T_COMMAND= FZF_ALT_C_COMMAND= source
+    ```
+    - Setting the variables after sourcing the script will have no effect
+- Bug fixes
+
 0.48.0
 ------
 - Shell integration scripts are now embedded in the fzf binary. This simplifies the distribution, and the users are less likely to have problems caused by using incompatible scripts and binaries.

--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ fish.
         --preview 'bat -n --color=always {}'
         --bind 'ctrl-/:change-preview-window(down|hidden|)'"
       ```
+    - Can be disabled by setting `FZF_CTRL_T_COMMAND` to an empty string when
+      sourcing the script
 - `CTRL-R` - Paste the selected command from history onto the command-line
     - If you want to see the commands in chronological order, press `CTRL-R`
       again which toggles sorting by relevance
@@ -462,6 +464,8 @@ fish.
         --walker-skip .git,node_modules,target
         --preview 'tree -C {}'"
       ```
+    - Can be disabled by setting `FZF_ALT_C_COMMAND` to an empty string when
+      sourcing the script
 
 If you're on a tmux session, you can start fzf in a tmux split-pane or in
 a tmux popup window by setting `FZF_TMUX_OPTS` (e.g. `export FZF_TMUX_OPTS='-p80%,60%'`).

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -10,7 +10,7 @@
 # - $FZF_COMPLETION_OPTS    (default: empty)
 
 [[ -o interactive ]] || return 0
-
+[[ "${FZF_COMPLETION_TRIGGER-x}" != "" ]] || return 0
 
 # Both branches of the following `if` do the same thing -- define
 # __fzf_completion_options such that `eval $__fzf_completion_options` sets

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -10,7 +10,6 @@
 # - $FZF_COMPLETION_OPTS    (default: empty)
 
 [[ -o interactive ]] || return 0
-[[ "${FZF_COMPLETION_TRIGGER-x}" != "" ]] || return 0
 
 # Both branches of the following `if` do the same thing -- define
 # __fzf_completion_options such that `eval $__fzf_completion_options` sets

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -11,6 +11,7 @@
 
 [[ -o interactive ]] || return 0
 
+
 # Both branches of the following `if` do the same thing -- define
 # __fzf_completion_options such that `eval $__fzf_completion_options` sets
 # all options to the same values they currently have. We'll do just that at

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -102,9 +102,11 @@ bind -m emacs-standard '"\C-z": vi-editing-mode'
 
 if (( BASH_VERSINFO[0] < 4 )); then
   # CTRL-T - Paste the selected file path into the command line
-  bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\er\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
-  bind -m vi-command '"\C-t": "\C-z\C-t\C-z"'
-  bind -m vi-insert '"\C-t": "\C-z\C-t\C-z"'
+  if [[ "${FZF_CTRL_T_COMMAND-x}" != "" ]]; then
+    bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\er\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f"'
+    bind -m vi-command '"\C-t": "\C-z\C-t\C-z"'
+    bind -m vi-insert '"\C-t": "\C-z\C-t\C-z"'
+  fi
 
   # CTRL-R - Paste the selected command from history into the command line
   bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\er"'
@@ -112,9 +114,11 @@ if (( BASH_VERSINFO[0] < 4 )); then
   bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
 else
   # CTRL-T - Paste the selected file path into the command line
-  bind -m emacs-standard -x '"\C-t": fzf-file-widget'
-  bind -m vi-command -x '"\C-t": fzf-file-widget'
-  bind -m vi-insert -x '"\C-t": fzf-file-widget'
+  if [[ "${FZF_CTRL_T_COMMAND-x}" != "" ]]; then
+    bind -m emacs-standard -x '"\C-t": fzf-file-widget'
+    bind -m vi-command -x '"\C-t": fzf-file-widget'
+    bind -m vi-insert -x '"\C-t": fzf-file-widget'
+  fi
 
   # CTRL-R - Paste the selected command from history into the command line
   bind -m emacs-standard -x '"\C-r": __fzf_history__'
@@ -123,6 +127,8 @@ else
 fi
 
 # ALT-C - cd into the selected directory
-bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
-bind -m vi-command '"\ec": "\C-z\ec\C-z"'
-bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
+if [[ "${FZF_ALT_C_COMMAND-x}" != "" ]]; then
+  bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\er\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d"'
+  bind -m vi-command '"\ec": "\C-z\ec\C-z"'
+  bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
+fi

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -104,14 +104,22 @@ function fzf_key_bindings
     end
   end
 
-  bind \ct fzf-file-widget
   bind \cr fzf-history-widget
-  bind \ec fzf-cd-widget
+  if not set -q FZF_CTRL_T_COMMAND; or test -n "$FZF_CTRL_T_COMMAND"
+    bind \ct fzf-file-widget
+  end
+  if not set -q FZF_ALT_C_COMMAND; or test -n "$FZF_ALT_C_COMMAND"
+    bind \ec fzf-cd-widget
+  end
 
   if bind -M insert > /dev/null 2>&1
-    bind -M insert \ct fzf-file-widget
     bind -M insert \cr fzf-history-widget
-    bind -M insert \ec fzf-cd-widget
+    if not set -q FZF_CTRL_T_COMMAND; or test -n "$FZF_CTRL_T_COMMAND"
+      bind -M insert \ct fzf-file-widget
+    end
+    if not set -q FZF_ALT_C_COMMAND; or test -n "$FZF_ALT_C_COMMAND"
+      bind -M insert \ec fzf-cd-widget
+    end
   end
 
   function __fzf_parse_commandline -d 'Parse the current command line token and return split of existing filepath, fzf query, and optional -option= prefix'

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -62,10 +62,12 @@ fzf-file-widget() {
   zle reset-prompt
   return $ret
 }
-zle     -N            fzf-file-widget
-bindkey -M emacs '^T' fzf-file-widget
-bindkey -M vicmd '^T' fzf-file-widget
-bindkey -M viins '^T' fzf-file-widget
+if [[ "${FZF_CTRL_T_COMMAND-x}" != "" ]]; then
+  zle     -N            fzf-file-widget
+  bindkey -M emacs '^T' fzf-file-widget
+  bindkey -M vicmd '^T' fzf-file-widget
+  bindkey -M viins '^T' fzf-file-widget
+fi
 
 # ALT-C - cd into the selected directory
 fzf-cd-widget() {
@@ -83,10 +85,12 @@ fzf-cd-widget() {
   zle reset-prompt
   return $ret
 }
-zle     -N             fzf-cd-widget
-bindkey -M emacs '\ec' fzf-cd-widget
-bindkey -M vicmd '\ec' fzf-cd-widget
-bindkey -M viins '\ec' fzf-cd-widget
+if [[ "${FZF_ALT_C_COMMAND-x}" != "" ]]; then
+  zle     -N             fzf-cd-widget
+  bindkey -M emacs '\ec' fzf-cd-widget
+  bindkey -M vicmd '\ec' fzf-cd-widget
+  bindkey -M viins '\ec' fzf-cd-widget
+fi
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -67,7 +67,7 @@ class Shell
     end
 
     def fish
-      UNSETS.map { |v| v + '= ' }.join + ' FZF_DEFAULT_OPTS=--no-scrollbar fish'
+      "unset #{UNSETS.join(' ')}; FZF_DEFAULT_OPTS=--no-scrollbar fish"
     end
   end
 end

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -18,7 +18,6 @@ UNSETS = %w[
   FZF_ALT_C_COMMAND
   FZF_ALT_C_OPTS FZF_CTRL_R_OPTS
   FZF_API_KEY
-  fish_history
 ].freeze
 DEFAULT_TIMEOUT = 10
 
@@ -67,7 +66,7 @@ class Shell
     end
 
     def fish
-      "unset #{UNSETS.join(' ')}; FZF_DEFAULT_OPTS=--no-scrollbar fish"
+      "unset #{UNSETS.join(' ')}; FZF_DEFAULT_OPTS=--no-scrollbar fish_history= fish"
     end
   end
 end


### PR DESCRIPTION
This makes it possible to skip one of the above key bindings or completions by setting a variable to an empty string. For example,

    FZF_CTRL_T_COMMAND= FZF_ALT_C_COMMAND= FZF_COMPLETION_TRIGGER= \
      eval "$(fzf --zsh)"

would leave only the history search. Makes it more convenient then producing the files and changing them myself to not include what I don't want.

This should be working, but for completeness it should also include at least some explaining comment at the top (since there's no docs about these vars?) and something equivalent for bash/fish.