### PR TITLE
Use realpath for fzf cd

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -41,7 +41,7 @@ __fzf_cd__() {
   opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore --reverse --walker=dir,follow,hidden --scheme=path ${FZF_DEFAULT_OPTS-} ${FZF_ALT_C_OPTS-} +m"
   dir=$(
     FZF_DEFAULT_COMMAND=${FZF_ALT_C_COMMAND:-} FZF_DEFAULT_OPTS="$opts" $(__fzfcmd)
-  ) && printf 'builtin cd -- %q' "$dir"
+    ) && printf 'builtin cd -- %q' "$(realpath "$dir")"
 }
 
 if command -v perl > /dev/null; then

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -41,7 +41,7 @@ __fzf_cd__() {
   opts="--height ${FZF_TMUX_HEIGHT:-40%} --bind=ctrl-z:ignore --reverse --walker=dir,follow,hidden --scheme=path ${FZF_DEFAULT_OPTS-} ${FZF_ALT_C_OPTS-} +m"
   dir=$(
     FZF_DEFAULT_COMMAND=${FZF_ALT_C_COMMAND:-} FZF_DEFAULT_OPTS="$opts" $(__fzfcmd)
-    ) && printf 'builtin cd -- %q' "$(realpath "$dir")"
+  ) && printf 'builtin cd -- %q' "$(builtin unset CDPATH && builtin cd -- "$dir" && builtin pwd)"
 }
 
 if command -v perl > /dev/null; then

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -78,7 +78,7 @@ fzf-cd-widget() {
     return 0
   fi
   zle push-line # Clear buffer. Auto-restored on next prompt.
-  BUFFER="builtin cd -- ${(q)dir}"
+  BUFFER="builtin cd -- $(realpath "${(q)dir}")"
   zle accept-line
   local ret=$?
   unset dir # ensure this doesn't end up appearing in prompt expansion

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -78,7 +78,7 @@ fzf-cd-widget() {
     return 0
   fi
   zle push-line # Clear buffer. Auto-restored on next prompt.
-  BUFFER="builtin cd -- $(realpath "${(q)dir}")"
+  BUFFER="builtin cd -- ${(q)dir:a}"
   zle accept-line
   local ret=$?
   unset dir # ensure this doesn't end up appearing in prompt expansion


### PR DESCRIPTION
Rationale: this way the resulting cd command that ends up in the shell history can be can be reused to get to the same location regardless of present working directory.