### PR TITLE
Let toggle-track disable track action

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -3772,6 +3772,8 @@ func (t *Terminal) Loop() {
 				req(reqPrompt)
 			case actToggleTrack:
 				switch t.track {
+				case trackCurrent:
+					fallthrough
 				case trackEnabled:
 					t.track = trackDisabled
 				case trackDisabled:


### PR DESCRIPTION
Currently the `toggle-track` action does not toggle off the tracking of the current selection started by the `track` action. The only way of disabling it is by changing the focus.

Change this by treating `trackCurrent` like `trackEnabled`.