### PR TITLE
chore: Add new option in issue checklist and modify requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.yml
+++ b/.github/ISSUE_TEMPLATE/issue_template.yml
@@ -15,6 +15,8 @@ body:
           required: true
         - label: I have searched through the existing issues
           required: true
+        - label: For bug reports, I have checked if the bug is reproducible in the latest version of fzf
+          required: false
 
   - type: input
     attributes:


### PR DESCRIPTION

### description

- PR #3687 removed the checkbox that asked the user to verify they have the latest version of
  fzf. This was due to the introduction of the new `input` field for the 'Output of "fzf
  --version"', which made the checkbox seem redundant.
```txt
- [ ] I have the latest version of fzf
```

- However, there were minor bug reports where simply updating to a later `fzf` version resolved the
  issue. Therefore, it might be beneficial to reintroduce this checkbox, but set the validation to
  `false`.

- We could also consider setting the validation for reading the `man` page to `false`. This would
  prevent users from being forced to tick the box to open a report, even if they haven't done what
  the box suggests. Currently, the `man` page is approximately 20-30 PDF pages long, so it's
  understandable if not everything has been read.

```bash
# open 'fzf' man page as a PDF

# macos Ventura+
mandoc -T pdf "$(man -w fzf)" | open -fa Preview
# prior to Ventura
man -t fzf | open -fa "Preview"
```
