### PR TITLE
Add arguments to disable loading keybindings or completion

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,18 +37,28 @@ func main() {
 	protector.Protect()
 	options := fzf.ParseOptions()
 	if options.Bash {
-		printScript("key-bindings.bash", bashKeyBindings)
-		printScript("completion.bash", bashCompletion)
+		if options.KeyBindings {
+			printScript("key-bindings.bash", bashKeyBindings)
+		}
+		if options.Completion {
+			printScript("completion.bash", bashCompletion)
+		}
 		return
 	}
 	if options.Zsh {
-		printScript("key-bindings.zsh", zshKeyBindings)
-		printScript("completion.zsh", zshCompletion)
+		if options.KeyBindings {
+			printScript("key-bindings.zsh", zshKeyBindings)
+		}
+		if options.Completion {
+			printScript("completion.zsh", zshCompletion)
+		}
 		return
 	}
 	if options.Fish {
-		printScript("key-bindings.fish", fishKeyBindings)
-		fmt.Println("fzf_key_bindings")
+		if options.KeyBindings {
+			printScript("key-bindings.fish", fishKeyBindings)
+			fmt.Println("fzf_key_bindings")
+		}
 		return
 	}
 	fzf.Run(options, version, revision)

--- a/src/options.go
+++ b/src/options.go
@@ -131,6 +131,8 @@ const usage = `usage: fzf [options]
                            (default: .git,node_modules)
 
   Shell integration
+    --no-completion        Do not print the shell integration for completion
+    --no-key-bindings      Do not print the shell integration for key bindings
     --bash                 Print script to set up Bash shell integration
     --zsh                  Print script to set up Zsh shell integration
     --fish                 Print script to set up Fish shell integration
@@ -290,6 +292,8 @@ type walkerOpts struct {
 
 // Options stores the values of command-line options
 type Options struct {
+	Completion   bool
+	KeyBindings  bool
 	Bash         bool
 	Zsh          bool
 	Fish         bool
@@ -381,6 +385,8 @@ func defaultPreviewOpts(command string) previewOpts {
 
 func defaultOptions() *Options {
 	return &Options{
+		Completion:   true,
+		KeyBindings:  true,
 		Bash:         false,
 		Zsh:          false,
 		Fish:         false,
@@ -1677,6 +1683,16 @@ func parseOptions(opts *Options, allArgs []string) {
 	for i := 0; i < len(allArgs); i++ {
 		arg := allArgs[i]
 		switch arg {
+		case "--no-completion":
+			opts.Completion = false
+			if !opts.KeyBindings {
+				errorExit("cannot specify --no-completion and --no-key-bindings")
+			}
+		case "--no-key-bindings":
+			opts.KeyBindings = false
+			if !opts.Completion {
+				errorExit("cannot specify --no-completion and --no-key-bindings")
+			}
 		case "--bash":
 			opts.Bash = true
 			if opts.Zsh || opts.Fish {


### PR DESCRIPTION
NixOS switched (https://github.com/NixOS/nixpkgs/pull/298692) to the new way of loading the completion files which was added in #3675 but that removes support for not loading the completion, so I just added options for that.