### PR TITLE
feat: Add custom shell flag option for command execution

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -907,8 +907,18 @@ e.g. \fBfzf --fish | source\fR
 .TP
 .B FZF_DEFAULT_COMMAND
 Default command to use when input is tty. On *nix systems, fzf runs the command
-with \fB$SHELL -c\fR if \fBSHELL\fR is set, otherwise with \fBsh -c\fR, so in
-this case make sure that the command is POSIX-compliant.
+with \fB$SHELL $FZF_SHELL_FLAG\fR if \fBSHELL\fR and \fBFZF_SHELL_FLAGS\fR are set, otherwise with \fBsh -c\fR.
+
+.TP
+.B FZF_SHELL_FLAG
+Custom flag to pass to the shell when executing commands. If not set, fzf defaults to \fB-c\fR.
+.br
+e.g.
+    \fBSHELL=$(which bun) FZF_SHELL_FLAG="--print" \\
+      fzf --listen \\
+        --bind 'start:reload:(await Bun.$`ls`.text()).trim()' \\
+        --preview 'await fetch(`http://127.0.0.1:${process.env.FZF_PORT}`)'\fR
+
 .TP
 .B FZF_DEFAULT_OPTS
 Default options.

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -907,7 +907,7 @@ e.g. \fBfzf --fish | source\fR
 .TP
 .B FZF_DEFAULT_COMMAND
 Default command to use when input is tty. On *nix systems, fzf runs the command
-with \fB$SHELL $FZF_SHELL_FLAG\fR if \fBSHELL\fR and \fBFZF_SHELL_FLAGS\fR are set, otherwise with \fBsh -c\fR.
+with \fB$SHELL $FZF_SHELL_FLAG\fR if \fBSHELL\fR and \fBFZF_SHELL_FLAG\fR are set, otherwise with \fBsh -c\fR.
 
 .TP
 .B FZF_SHELL_FLAG

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -3375,6 +3375,10 @@ func (t *Terminal) Loop() {
 					if len(shell) == 0 {
 						shell = "sh"
 					}
+					shellFlag := os.Getenv("FZF_SHELL_FLAG")
+					if len(shellFlag) == 0 {
+						shellFlag = "-c"
+					}
 					shellPath, err := exec.LookPath(shell)
 					if err == nil {
 						t.tui.Close()
@@ -3390,7 +3394,7 @@ func (t *Terminal) Loop() {
 						*/
 						tui.TtyIn()
 						util.SetStdin(tui.TtyIn())
-						syscall.Exec(shellPath, []string{shell, "-c", command}, os.Environ())
+						syscall.Exec(shellPath, []string{shell, shellFlag, command}, os.Environ())
 					}
 				}
 			case actExecute, actExecuteSilent:

--- a/src/util/util_unix.go
+++ b/src/util/util_unix.go
@@ -10,18 +10,22 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// ExecCommand executes the given command with $SHELL
+// ExecCommand executes the given command with $SHELL $FZF_SHELL_FLAG 
 func ExecCommand(command string, setpgid bool) *exec.Cmd {
 	shell := os.Getenv("SHELL")
 	if len(shell) == 0 {
 		shell = "sh"
 	}
-	return ExecCommandWith(shell, command, setpgid)
+	shellFlag := os.Getenv("FZF_SHELL_FLAG")
+	if len(shellFlag) == 0 {
+		shellFlag = "-c"
+	}
+	return ExecCommandWith(shell, shellFlag, command, setpgid)
 }
 
-// ExecCommandWith executes the given command with the specified shell
-func ExecCommandWith(shell string, command string, setpgid bool) *exec.Cmd {
-	cmd := exec.Command(shell, "-c", command)
+// ExecCommandWith executes the given command with the specified shell and flag
+func ExecCommandWith(shell string, shellFlag string, command string, setpgid bool) *exec.Cmd {
+	cmd := exec.Command(shell, shellFlag, command)
 	if setpgid {
 		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	}

--- a/src/util/util_unix.go
+++ b/src/util/util_unix.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// ExecCommand executes the given command with $SHELL $FZF_SHELL_FLAG 
+// ExecCommand executes the given command with $SHELL $FZF_SHELL_FLAG
 func ExecCommand(command string, setpgid bool) *exec.Cmd {
 	shell := os.Getenv("SHELL")
 	if len(shell) == 0 {


### PR DESCRIPTION
### proposal
Ability to alter the flag that is passed to the `$SHELL` command.

---

For example, if the `-c` flag could be altered to `-e`, one could use `jsc` (JavaScriptCore) to execute JavaScript code without adding `jsc -e` to every line.


```bash
# List available globals in 'jsc' and preview their properties
# 'jsc' only comes by default on macOS
SHELL=/System/Library/Frameworks/JavaScriptCore.framework/Versions/A/Helpers/jsc \
  FZF_SHELL_FLAG="-e" \
  fzf \
  --bind 'start:reload:print(Object.getOwnPropertyNames(globalThis).join("\n"))' \
  --bind 'enter:become:print((![]+[])[+[]]+([][[]]+[])[+[]]+([][[]]+[])[+!![]])' \
  --preview 'const f = globalThis[{}]; if (f) { print(`{} Static Properties\n${Object.getOwnPropertyNames(f).sort().join("\n")}`); if (f.prototype) print(`\n{} Prototype Properties\n${Object.getOwnPropertyNames(f.prototype).sort().join("\n")}`)}'
```

<img src="https://github.com/junegunn/fzf/assets/92653266/9c66229f-f3a9-4aaf-aade-948ad8909723" width="800">

Another example using `bun` and `--print`.

```bash
# [bun] https://github.com/oven-sh/bun
# brew install oven-sh/bun/bun
# [gh] https://github.com/cli/cli
# Show starred repos and preview the date of the first commit in a Korean time format
user_name=gh api graphql -f query='{viewer{login}}' --jq '..|.login? // empty'
gh api users/${user_name}/starred \
  --jq '.[] | select(.visibility == "public") | .full_name' |
  SHELL="$(which bun)" FZF_SHELL_FLAG="--print" \
    fzf --prompt "Starred [${user_name}]" \
	--preview '((repo)=>fetch(`https://api.github.com/repos/${repo}/commits?per_page=1`).then((i)=>fetch(i.headers.get("link")?.match(/http[^>]+/g)?.at(-1)).then((t)=>t.json().then((S)=>`First commit: ${repo}\n${new Intl.DateTimeFormat("ko-Kr",{timeStyle:"full",dateStyle:"full"}).format(new Date(S[0].commit.author.date))}`))))({})'
```

<img src="https://github.com/junegunn/fzf/assets/92653266/b3dc4e80-1d98-4335-ac67-c0ee0b3c746a" width="800">


Pro:
- Enables the execution of commands without requiring the flag and command to be prepended on every
  line, which also diminishes the need for one round of quoting.


Con:
- It may lead to confusion and inconsistencies if not used carefully and documented clearly.



---

### Issues
- [ ] Writing tests
- [ ] `Windows` (not tested at all)
- [ ] Better documention
