### PR TITLE
fix: Move 'emulate' command outside interactive check

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -9,8 +9,6 @@
 # - $FZF_COMPLETION_TRIGGER (default: '**')
 # - $FZF_COMPLETION_OPTS    (default: empty)
 
-if [[ -o interactive ]]; then
-
 
 # Both branches of the following `if` do the same thing -- define
 # __fzf_completion_options such that `eval $__fzf_completion_options` sets
@@ -72,9 +70,13 @@ fi
 # sidestep this issue entirely.
 'builtin' 'emulate' 'zsh' && 'builtin' 'setopt' 'no_aliases'
 
+
 # This brace is the start of try-always block. The `always` part is like
 # `finally` in lesser languages. We use it to *always* restore user options.
 {
+# The 'emulate' command should not be placed inside the interactive if check;
+# placing it there fails to disable alias expansion. See #3731.
+if [[ -o interactive ]]; then
 
 # To use custom commands instead of find, override _fzf_compgen_{path,dir}
 #
@@ -345,11 +347,10 @@ fzf-completion() {
 
 zle     -N   fzf-completion
 bindkey '^I' fzf-completion
+fi
 
 } always {
   # Restore the original options.
   eval $__fzf_completion_options
   'unset' '__fzf_completion_options'
 }
-
-fi

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -70,7 +70,6 @@ fi
 # sidestep this issue entirely.
 'builtin' 'emulate' 'zsh' && 'builtin' 'setopt' 'no_aliases'
 
-
 # This brace is the start of try-always block. The `always` part is like
 # `finally` in lesser languages. We use it to *always* restore user options.
 {

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -11,8 +11,6 @@
 # - $FZF_ALT_C_COMMAND
 # - $FZF_ALT_C_OPTS
 
-if [[ -o interactive ]]; then
-
 
 # Key bindings
 # ------------
@@ -38,6 +36,7 @@ fi
 'builtin' 'emulate' 'zsh' && 'builtin' 'setopt' 'no_aliases'
 
 {
+if [[ -o interactive ]]; then
 
 # CTRL-T - Paste the selected file path(s) into the command line
 __fsel() {
@@ -114,10 +113,9 @@ zle     -N            fzf-history-widget
 bindkey -M emacs '^R' fzf-history-widget
 bindkey -M vicmd '^R' fzf-history-widget
 bindkey -M viins '^R' fzf-history-widget
+fi
 
 } always {
   eval $__fzf_key_bindings_options
   'unset' '__fzf_key_bindings_options'
 }
-
-fi


### PR DESCRIPTION
### description

https://github.com/junegunn/fzf/issues/3731#issuecomment-2060699426

Close #3731


Tested with

```bash
export FZF_DEFAULT_OPTS=""
export FZF_COMPLETION_TRIGGER=',,'
alias cat='bat --color=always --number'
source <path to file>

kill ,,
```
