### PR TITLE
feature: header-click event for reporting clicks within header

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -708,6 +708,8 @@ func parseKeyChordsImpl(str string, message string, exit func(string)) map[tui.E
 			add(tui.Jump)
 		case "jump-cancel":
 			add(tui.JumpCancel)
+		case "header-click":
+			add(tui.HeaderClick)
 		case "alt-enter", "alt-return":
 			chords[tui.CtrlAltKey('m')] = key
 		case "alt-space":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -298,6 +298,8 @@ type Terminal struct {
 	areaLines          int
 	areaColumns        int
 	forcePreview       bool
+	headerClickLine    int
+	headerClickColumn  int
 }
 
 type selectedItem struct {
@@ -857,6 +859,8 @@ func (t *Terminal) environ() []string {
 	env = append(env, fmt.Sprintf("FZF_LINES=%d", t.areaLines))
 	env = append(env, fmt.Sprintf("FZF_COLUMNS=%d", t.areaColumns))
 	env = append(env, fmt.Sprintf("FZF_POS=%d", util.Min(t.merger.Length(), t.cy+1)))
+	env = append(env, fmt.Sprintf("FZF_HEADERCLICK_LINE=%d", t.headerClickLine))
+	env = append(env, fmt.Sprintf("FZF_HEADERCLICK_COLUMN=%d", t.headerClickColumn))
 	return env
 }
 
@@ -3989,10 +3993,10 @@ func (t *Terminal) Loop() {
 				}
 
 				if me.Down {
-					mx = util.Constrain(mx-t.promptLen, 0, len(t.input))
-					if my == t.promptLine() && mx >= 0 {
+					mx_cons := util.Constrain(mx-t.promptLen, 0, len(t.input))
+					if my == t.promptLine() && mx_cons >= 0 {
 						// Prompt
-						t.cx = mx + t.xoffset
+						t.cx = mx_cons + t.xoffset
 					} else if my >= min {
 						t.vset(t.offset + my - min)
 						req(reqList)
@@ -4007,6 +4011,35 @@ func (t *Terminal) Loop() {
 							}
 						}
 						return doActions(actionsFor(evt))
+					} else {
+						// Header
+						lineOffset := 0
+						numLines := t.visibleHeaderLines()
+						if !t.headerFirst {
+							// header line offset
+							if t.noSeparatorLine() {
+								lineOffset = 1
+							} else {
+								lineOffset = 2
+							}
+						} else {
+							// adjust numLines for too-small window
+							numItems := t.areaLines - numLines
+							if !t.noSeparatorLine() {
+								numItems -= 1
+							}
+							if numItems < 0 {
+								numLines += numItems
+							}
+						}
+						my = util.Constrain(my-lineOffset, -1, numLines)
+						mx -= 2 // gutter
+						if my >= 0 && my < numLines && mx >= 0 {
+							t.headerClickLine = my
+							t.headerClickColumn = mx
+							evt := tui.HeaderClick
+							return doActions(actionsFor(evt))
+						}
 					}
 				}
 			case actReload, actReloadSync:

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -130,6 +130,7 @@ const (
 	Result
 	Jump
 	JumpCancel
+	HeaderClick
 )
 
 func (t EventType) AsEvent() Event {


### PR DESCRIPTION
Sets `FZF_HEADERCLICK_ROW` and `FZF_HEADERCLICK_LINE` env vars with coordinates of last click inside and relative to the header.

`printf "header1\nheader2\nheader3\na\nb\nc" | fzf --header-lines=3 --bind "header-click:transform-prompt(echo \${FZF_HEADERCLICK_LINE}x\${FZF_HEADERCLICK_COLUMN})"`

Could be useful for eg. selecting a sort column. I think it could just as easily add a `FZF_HEADERCLICK_WORD` var as well.

[Here is a more complex demo with an interactive keyboard](https://gist.github.com/kuremu/4d1441828ebab9d2da67f1298102fc3f) (invoke like `cat /usr/share/dict/words | python keyboard.py`).