### PR TITLE
 feature: header-click event for reporting clicks within header

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1278,12 +1278,12 @@ e.g.
      \fBfzf --bind space:jump,jump:accept,jump-cancel:abort\fR
 .RE
 
-\fIheader-click\fR
+\fIclick-header\fR
 .RS
-Triggered when a mouse click occurs within the header. Sets \fBFZF_HEADERCLICK_LINE\fR and \fBFZF_HEADERCLICK_COLUMN\fR environment variables.
+Triggered when a mouse click occurs within the header. Sets \fBFZF_CLICK_HEADER_LINE\fR and \fBFZF_CLICK_HEADER_COLUMN\fR environment variables.
 
 e.g.
-     \fBprintf "head1\\nhead2" | fzf --header-lines=2 --bind header-click:transform-prompt:"printf \\${FZF_HEADERCLICK_LINE}x\\${FZF_HEADERCLICK_COLUMN}"\fR
+     \fBprintf "head1\\nhead2" | fzf --header-lines=2 --bind click-header:transform-prompt:"printf \\${FZF_CLICK_HEADER_LINE}x\\${FZF_CLICK_HEADER_COLUMN}"\fR
 
 .RE
 

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1283,7 +1283,7 @@ e.g.
 Triggered when a mouse click occurs within the header. Sets \fBFZF_CLICK_HEADER_LINE\fR and \fBFZF_CLICK_HEADER_COLUMN\fR environment variables.
 
 e.g.
-     \fBprintf "head1\\nhead2" | fzf --header-lines=2 --bind click-header:transform-prompt:"printf \\${FZF_CLICK_HEADER_LINE}x\\${FZF_CLICK_HEADER_COLUMN}"\fR
+     \fBprintf "head1\\nhead2" | fzf --header-lines=2 --bind 'click-header:transform-prompt:printf ${FZF_CLICK_HEADER_LINE}x${FZF_CLICK_HEADER_COLUMN}'\fR
 
 .RE
 

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1278,6 +1278,15 @@ e.g.
      \fBfzf --bind space:jump,jump:accept,jump-cancel:abort\fR
 .RE
 
+\fIheader-click\fR
+.RS
+Triggered when a mouse click occurs within the header. Sets \fBFZF_HEADERCLICK_LINE\fR and \fBFZF_HEADERCLICK_COLUMN\fR environment variables.
+
+e.g.
+     \fBprintf "head1\\nhead2" | fzf --header-lines=2 --bind header-click:transform-prompt:"printf \\${FZF_HEADERCLICK_LINE}x\\${FZF_HEADERCLICK_COLUMN}"\fR
+
+.RE
+
 .SS AVAILABLE ACTIONS:
 A key or an event can be bound to one or more of the following actions.
 

--- a/src/options.go
+++ b/src/options.go
@@ -708,8 +708,8 @@ func parseKeyChordsImpl(str string, message string, exit func(string)) map[tui.E
 			add(tui.Jump)
 		case "jump-cancel":
 			add(tui.JumpCancel)
-		case "header-click":
-			add(tui.HeaderClick)
+		case "click-header":
+			add(tui.ClickHeader)
 		case "alt-enter", "alt-return":
 			chords[tui.CtrlAltKey('m')] = key
 		case "alt-space":

--- a/src/options.go
+++ b/src/options.go
@@ -708,6 +708,8 @@ func parseKeyChordsImpl(str string, message string, exit func(string)) map[tui.E
 			add(tui.Jump)
 		case "jump-cancel":
 			add(tui.JumpCancel)
+		case "header-click":
+			add(tui.HeaderClick)
 		case "alt-enter", "alt-return":
 			chords[tui.CtrlAltKey('m')] = key
 		case "alt-space":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4018,15 +4018,15 @@ func (t *Terminal) Loop() {
 						lineOffset := 0
 						numLines := t.visibleHeaderLines()
 						if !t.headerFirst {
-                            // offset for info line
+							// offset for info line
 							if t.noSeparatorLine() {
 								lineOffset = 1
 							} else {
 								lineOffset = 2
 							}
 						} else {
-                            // adjust for too-small window
-                            numItems := t.areaLines - numLines
+							// adjust for too-small window
+							numItems := t.areaLines - numLines
 							if !t.noSeparatorLine() {
 								numItems -= 1
 							}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4037,8 +4037,8 @@ func (t *Terminal) Loop() {
 						my = util.Constrain(my-lineOffset, -1, numLines)
 						mx -= 2 // offset gutter
 						if my >= 0 && my < numLines && mx >= 0 {
-							t.clickHeaderLine = my
-							t.clickHeaderColumn = mx
+							t.clickHeaderLine = my + 1
+							t.clickHeaderColumn = mx + 1
 							evt := tui.ClickHeader
 							return doActions(actionsFor(evt))
 						}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -847,10 +847,6 @@ func (t *Terminal) environ() []string {
 	if t.listenPort != nil {
 		env = append(env, fmt.Sprintf("FZF_PORT=%d", *t.listenPort))
 	}
-	if t.clickHeaderLine > 0 {
-		env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_LINE=%d", t.clickHeaderLine))
-		env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_COLUMN=%d", t.clickHeaderColumn))
-	}
 	env = append(env, "FZF_QUERY="+string(t.input))
 	env = append(env, "FZF_ACTION="+t.lastAction.Name())
 	env = append(env, "FZF_KEY="+t.lastKey)
@@ -863,6 +859,8 @@ func (t *Terminal) environ() []string {
 	env = append(env, fmt.Sprintf("FZF_LINES=%d", t.areaLines))
 	env = append(env, fmt.Sprintf("FZF_COLUMNS=%d", t.areaColumns))
 	env = append(env, fmt.Sprintf("FZF_POS=%d", util.Min(t.merger.Length(), t.cy+1)))
+	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_LINE=%d", t.clickHeaderLine))
+	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_COLUMN=%d", t.clickHeaderColumn))
 	return env
 }
 
@@ -4041,11 +4039,7 @@ func (t *Terminal) Loop() {
 						if my >= 0 && my < numLines && mx >= 0 {
 							t.clickHeaderLine = my + 1
 							t.clickHeaderColumn = mx + 1
-							evt := tui.ClickHeader
-							res := doActions(actionsFor(evt))
-							t.clickHeaderLine = 0
-							t.clickHeaderColumn = 0
-							return res
+							return doActions(actionsFor(tui.ClickHeader))
 						}
 					}
 				}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -847,6 +847,10 @@ func (t *Terminal) environ() []string {
 	if t.listenPort != nil {
 		env = append(env, fmt.Sprintf("FZF_PORT=%d", *t.listenPort))
 	}
+	if t.clickHeaderLine > 0 {
+		env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_LINE=%d", t.clickHeaderLine))
+		env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_COLUMN=%d", t.clickHeaderColumn))
+	}
 	env = append(env, "FZF_QUERY="+string(t.input))
 	env = append(env, "FZF_ACTION="+t.lastAction.Name())
 	env = append(env, "FZF_KEY="+t.lastKey)
@@ -859,8 +863,6 @@ func (t *Terminal) environ() []string {
 	env = append(env, fmt.Sprintf("FZF_LINES=%d", t.areaLines))
 	env = append(env, fmt.Sprintf("FZF_COLUMNS=%d", t.areaColumns))
 	env = append(env, fmt.Sprintf("FZF_POS=%d", util.Min(t.merger.Length(), t.cy+1)))
-	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_LINE=%d", t.clickHeaderLine))
-	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_COLUMN=%d", t.clickHeaderColumn))
 	return env
 }
 
@@ -4040,7 +4042,10 @@ func (t *Terminal) Loop() {
 							t.clickHeaderLine = my + 1
 							t.clickHeaderColumn = mx + 1
 							evt := tui.ClickHeader
-							return doActions(actionsFor(evt))
+							res := doActions(actionsFor(evt))
+							t.clickHeaderLine = 0
+							t.clickHeaderColumn = 0
+							return res
 						}
 					}
 				}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -298,8 +298,8 @@ type Terminal struct {
 	areaLines          int
 	areaColumns        int
 	forcePreview       bool
-	headerClickLine    int
-	headerClickColumn  int
+	clickHeaderLine    int
+	clickHeaderColumn  int
 }
 
 type selectedItem struct {
@@ -859,8 +859,8 @@ func (t *Terminal) environ() []string {
 	env = append(env, fmt.Sprintf("FZF_LINES=%d", t.areaLines))
 	env = append(env, fmt.Sprintf("FZF_COLUMNS=%d", t.areaColumns))
 	env = append(env, fmt.Sprintf("FZF_POS=%d", util.Min(t.merger.Length(), t.cy+1)))
-	env = append(env, fmt.Sprintf("FZF_HEADERCLICK_LINE=%d", t.headerClickLine))
-	env = append(env, fmt.Sprintf("FZF_HEADERCLICK_COLUMN=%d", t.headerClickColumn))
+	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_LINE=%d", t.clickHeaderLine))
+	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_COLUMN=%d", t.clickHeaderColumn))
 	return env
 }
 
@@ -4037,9 +4037,9 @@ func (t *Terminal) Loop() {
 						my = util.Constrain(my-lineOffset, -1, numLines)
 						mx -= 2 // offset gutter
 						if my >= 0 && my < numLines && mx >= 0 {
-							t.headerClickLine = my
-							t.headerClickColumn = mx
-							evt := tui.HeaderClick
+							t.clickHeaderLine = my
+							t.clickHeaderColumn = mx
+							evt := tui.ClickHeader
 							return doActions(actionsFor(evt))
 						}
 					}

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -130,6 +130,7 @@ const (
 	Result
 	Jump
 	JumpCancel
+	HeaderClick
 )
 
 func (t EventType) AsEvent() Event {

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -130,7 +130,7 @@ const (
 	Result
 	Jump
 	JumpCancel
-	HeaderClick
+	ClickHeader
 )
 
 func (t EventType) AsEvent() Event {


### PR DESCRIPTION
Sets `FZF_HEADERCLICK_LINE` and `FZF_HEADERCLICK_COLUMN` env vars with coordinates of last click inside and relative to the header and fires header-click event.

`printf "header1\nheader2\nheader3\na\nb\nc" | fzf --header-lines=3 --bind "header-click:transform-prompt(echo \${FZF_HEADERCLICK_LINE}x\${FZF_HEADERCLICK_COLUMN})"`

Could be useful for eg. selecting a sort column. Could set a `FZF_HEADERCLICK_WORD` var as well if that is more useful to people.

[Here is a more complex demo with an interactive keyboard](https://gist.github.com/kuremu/4d1441828ebab9d2da67f1298102fc3f) (invoke like `cat /usr/share/dict/words | python keyboard.py`).