### PR TITLE
feature: set FZF_SELECTION env var containing text of selected item

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -992,6 +992,8 @@ fzf exports the following environment variables to its child processes.
 .br
 .BR FZF_POS "             Vertical position of the cursor in the list starting from 1"
 .br
+.BR FZF_SELECTION "       Text of currently selected line"
+.br
 .BR FZF_QUERY "           Current query string"
 .br
 .BR FZF_PROMPT "          Prompt string"

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -869,6 +869,11 @@ func (t *Terminal) environ() []string {
 	if t.listenPort != nil {
 		env = append(env, fmt.Sprintf("FZF_PORT=%d", *t.listenPort))
 	}
+	if t.merger.Length() > 0 {
+		env = append(env, "FZF_SELECTION="+t.merger.Get(util.Min(t.merger.Length(), t.cy)).item.AsString(true))
+	} else {
+		env = append(env, "FZF_SELECTION=")
+	}
 	env = append(env, "FZF_QUERY="+string(t.input))
 	env = append(env, "FZF_ACTION="+t.lastAction.Name())
 	env = append(env, "FZF_KEY="+t.lastKey)


### PR DESCRIPTION
Sets `FZF_SELECTION` to the ansi-stripped text of the currently selected item in t.environ(), essentially inserting the value of `{}` into the environment. If there is nothing in the list, `FZF_SELECTION` is set to an empty string.

`fzf --bind "focus:transform-prompt(echo \${FZF_SELECTION}\>\ )"`

This would be useful to me as my reload/transform calls have become pretty complex, and I'm already capturing the other FZF env vars.