### PR TITLE
chore: Update flags to include long-form options for case

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -46,10 +46,10 @@ it with \fB+x\fR or \fB--no-extended\fR.
 .B "-e, --exact"
 Enable exact-match
 .TP
-.B "-i"
+.B "-i, --ignore-case"
 Case-insensitive match (default: smart-case match)
 .TP
-.B "+i"
+.B "+i", "--no-ignore-case"
 Case-sensitive match
 .TP
 .B "--literal"

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -49,7 +49,7 @@ Enable exact-match
 .B "-i, --ignore-case"
 Case-insensitive match (default: smart-case match)
 .TP
-.B "+i", "--no-ignore-case"
+.B "+i, --no-ignore-case"
 Case-sensitive match
 .TP
 .B "--literal"

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -119,8 +119,8 @@ _fzf_opts_completion() {
     +s --no-sort
     --track
     --tac
-    -i
-    +i
+    -i --ignore-case
+    +i --no-ignore-case
     -m --multi
     --ansi
     --no-mouse

--- a/src/options.go
+++ b/src/options.go
@@ -22,8 +22,8 @@ const Usage = `usage: fzf [options]
     -x, --extended         Extended-search mode
                            (enabled by default; +x or --no-extended to disable)
     -e, --exact            Enable Exact-match
-    -i                     Case-insensitive match (default: smart-case match)
-    +i                     Case-sensitive match
+    -i, --ignore-case      Case-insensitive match (default: smart-case match)
+    +i, --no-ignore-case   Case-sensitive match
     --scheme=SCHEME        Scoring scheme [default|path|history]
     --literal              Do not normalize latin script letters before matching
     -n, --nth=N[,..]       Comma-separated list of field index expressions
@@ -1914,9 +1914,9 @@ func parseOptions(opts *Options, allArgs []string) error {
 			opts.Tac = true
 		case "--no-tac":
 			opts.Tac = false
-		case "-i":
+		case "-i", "--ignore-case":
 			opts.Case = CaseIgnore
-		case "+i":
+		case "+i", "--no-ignore-case":
 			opts.Case = CaseRespect
 		case "-m", "--multi":
 			if opts.Multi, err = optionalNumeric(allArgs, &i, maxMulti); err != nil {


### PR DESCRIPTION
### Description

Addition of long options for the existing `-i` and `+i` flags.

The rationale behind long options is their self-descriptive nature. Currently, these flags are outliers as they do not have corresponding long options. Introducing them would improve consistency across command-line flags.
