### PR TITLE
Implement native tmux integration

### DIFF
--- a/README-VIM.md
+++ b/README-VIM.md
@@ -294,7 +294,7 @@ The following table summarizes the available options.
 | `options`                  | string/list   | Options to fzf                                                        |
 | `dir`                      | string        | Working directory                                                     |
 | `up`/`down`/`left`/`right` | number/string | (Layout) Window position and size (e.g. `20`, `50%`)                  |
-| `tmux`                     | string        | (Layout) fzf-tmux options (e.g. `-p90%,60%`)                          |
+| `tmux`                     | string        | (Layout) `--tmux` options (e.g. `90%,70%`)                            |
 | `window` (Vim 8 / Neovim)  | string        | (Layout) Command to open fzf window (e.g. `vertical aboveleft 30new`) |
 | `window` (Vim 8 / Neovim)  | dict          | (Layout) Popup window settings (e.g. `{'width': 0.9, 'height': 0.6}`) |
 
@@ -457,12 +457,13 @@ let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
 ```
 
 Alternatively, you can make fzf open in a tmux popup window (requires tmux 3.2
-or above) by putting fzf-tmux options in `tmux` key.
+or above) by putting `--tmux` option value in `tmux` key.
 
 ```vim
-" See `man fzf-tmux` for available options
+" See `--tmux` option in `man fzf` for available options
+" [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]
 if exists('$TMUX')
-  let g:fzf_layout = { 'tmux': '-p90%,60%' }
+  let g:fzf_layout = { 'tmux': '90%,70%' }
 else
   let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
 endif

--- a/README.md
+++ b/README.md
@@ -32,10 +32,9 @@ Pros
 
 - Portable, no dependencies
 - Blazingly fast
-- The most comprehensive feature set
-- Flexible layout
+- Extremely versatile
 - Batteries included
-    - Vim/Neovim plugin, key bindings, and fuzzy auto-completion
+    - bash/zsh/fish integration, tmux integration, Vim/Neovim plugin
 
 Sponsors ❤️
 -----------
@@ -53,22 +52,24 @@ Table of Contents
 
 * [Installation](#installation)
     * [Using Homebrew](#using-homebrew)
+    * [Linux packages](#linux-packages)
+    * [Windows packages](#windows-packages)
     * [Using git](#using-git)
-    * [Using Linux package managers](#using-linux-package-managers)
-    * [Windows](#windows)
+    * [Binary releases](#binary-releases)
     * [Setting up shell integration](#setting-up-shell-integration)
-    * [As Vim plugin](#as-vim-plugin)
+    * [Vim/Neovim plugin](#vimneovim-plugin)
 * [Upgrading fzf](#upgrading-fzf)
 * [Building fzf](#building-fzf)
 * [Usage](#usage)
     * [Using the finder](#using-the-finder)
-    * [Layout](#layout)
+    * [Display modes](#display-modes)
+        * [`--height` mode](#--height-mode)
+        * [`--tmux` mode](#--tmux-mode)
     * [Search syntax](#search-syntax)
     * [Environment variables](#environment-variables)
     * [Options](#options)
     * [Demo](#demo)
 * [Examples](#examples)
-* [`fzf-tmux` script](#fzf-tmux-script)
 * [Key bindings for command-line](#key-bindings-for-command-line)
 * [Fuzzy completion for bash and zsh](#fuzzy-completion-for-bash-and-zsh)
     * [Files and directories](#files-and-directories)
@@ -101,28 +102,12 @@ Table of Contents
 Installation
 ------------
 
-fzf project consists of the following components:
-
-- `fzf` executable
-- `fzf-tmux` script for launching fzf in a tmux pane
-- Shell integration
-    - Key bindings (`CTRL-T`, `CTRL-R`, and `ALT-C`) (bash, zsh, fish)
-    - Fuzzy completion (bash, zsh)
-- Vim/Neovim plugin
-
-You can [download fzf executable][bin] alone if you don't need the extra
-stuff.
-
-[bin]: https://github.com/junegunn/fzf/releases
-
 ### Using Homebrew
 
-You can use [Homebrew](https://brew.sh/) (on macOS or Linux)
-to install fzf.
+You can use [Homebrew](https://brew.sh/) (on macOS or Linux) to install fzf.
 
 ```sh
 brew install fzf
-  # To build fzf from the latest source: brew install --HEAD fzf
 ```
 
 > [!IMPORTANT]
@@ -133,20 +118,7 @@ fzf is also available [via MacPorts][portfile]: `sudo port install fzf`
 
 [portfile]: https://github.com/macports/macports-ports/blob/master/sysutils/fzf/Portfile
 
-### Using git
-
-Alternatively, you can "git clone" this repository to any directory and run
-[install](https://github.com/junegunn/fzf/blob/master/install) script.
-
-```sh
-git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
-~/.fzf/install
-```
-
-The install script will add lines to your shell configuration file to modify
-`$PATH` and set up shell integration.
-
-### Using Linux package managers
+### Linux packages
 
 | Package Manager | Linux Distribution      | Command                            |
 | --------------- | ----------------------- | ---------------------------------- |
@@ -170,10 +142,10 @@ The install script will add lines to your shell configuration file to modify
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/fzf.svg)](https://repology.org/project/fzf/versions)
 
-### Windows
+### Windows packages
 
-Pre-built binaries for Windows can be downloaded [here][bin]. fzf is also
-available via [Chocolatey][choco], [Scoop][scoop], [Winget][winget], and [MSYS2][msys2]:
+On Windows, fzf is available via [Chocolatey][choco], [Scoop][scoop],
+[Winget][winget], and [MSYS2][msys2]:
 
 | Package manager | Command                               |
 | --------------- | ------------------------------------- |
@@ -187,10 +159,24 @@ available via [Chocolatey][choco], [Scoop][scoop], [Winget][winget], and [MSYS2]
 [winget]: https://github.com/microsoft/winget-pkgs/tree/master/manifests/j/junegunn/fzf
 [msys2]: https://packages.msys2.org/base/mingw-w64-fzf
 
-Known issues and limitations on Windows can be found on [the wiki
-page][windows-wiki].
+### Using git
 
-[windows-wiki]: https://github.com/junegunn/fzf/wiki/Windows
+Alternatively, you can "git clone" this repository to any directory and run
+[install](https://github.com/junegunn/fzf/blob/master/install) script.
+
+```sh
+git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
+~/.fzf/install
+```
+
+The install script will add lines to your shell configuration file to modify
+`$PATH` and set up shell integration.
+
+### Binary releases
+
+You can download the official fzf binaries from the releases page.
+
+* https://github.com/junegunn/fzf/releases
 
 ### Setting up shell integration
 
@@ -231,20 +217,26 @@ Add the following line to your shell configuration file.
 >
 > Setting the variables after sourcing the script will have no effect.
 
-### As Vim plugin
+### Vim/Neovim plugin
 
-If you use
-[vim-plug](https://github.com/junegunn/vim-plug), add this line to your Vim
-configuration file:
+If you use [vim-plug](https://github.com/junegunn/vim-plug), add this to
+your Vim configuration file:
 
 ```vim
 Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
+Plug 'junegunn/fzf.vim'
 ```
 
-`fzf#install()` makes sure that you have the latest binary, but it's optional,
-so you can omit it if you use a plugin manager that doesn't support hooks.
+* `junegunn/fzf` provides the basic library functions
+    * `fzf#install()` makes sure that you have the latest binary
+* `junegunn/fzf.vim` is [a separate project](https://github.com/junegunn/fzf.vim)
+  that provides a variety of useful commands
 
-For more installation options, see [README-VIM.md](README-VIM.md).
+To learn more about the Vim integration, see [README-VIM.md](README-VIM.md).
+
+> [!TIP]
+> If you use Neovim and prefer Lua-based plugins, check out
+> [fzf-lua](https://github.com/ibhagwan/fzf-lua).
 
 Upgrading fzf
 -------------
@@ -312,28 +304,70 @@ vim $(fzf)
 - Mouse: scroll, click, double-click; shift-click and shift-scroll on
   multi-select mode
 
-### Layout
+### Display modes
 
-fzf by default starts in fullscreen mode, but you can make it start below the
-cursor with `--height` option.
+fzf by default runs in fullscreen mode, but there are other display modes.
 
-```sh
-vim $(fzf --height 40%)
-```
+#### `--height` mode
 
-Also, check out `--reverse` and `--layout` options if you prefer
-"top-down" layout instead of the default "bottom-up" layout.
+With `--height HEIGHT[%]`, fzf will start below the cursor with the given height.
 
 ```sh
-vim $(fzf --height 40% --reverse)
+fzf --height 40%
 ```
 
-You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
-default. For example,
+`reverse` layout and `--border` goes well with this option.
 
 ```sh
-export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
+fzf --height 40% --layout reverse --border
 ```
+
+By prepending `~` to the height, you're setting the maximum height.
+
+```sh
+# Will take as few lines as possible to display the list
+seq 3 | fzf --height ~100%
+seq 3000 | fzf --height ~100%
+```
+
+Height value can be a negative number.
+
+```sh
+# Screen height - 3
+fzf --height -3
+```
+
+#### `--tmux` mode
+
+With `--tmux` option, fzf will start in a tmux popup.
+
+```sh
+# --tmux [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]
+
+fzf --tmux center         # Center, 50% width and height
+fzf --tmux 80%            # Center, 80% width and height
+fzf --tmux 100%,50%       # Center, 100% width and 50% height
+fzf --tmux left,40%       # Left, 40% width
+fzf --tmux left,40%,90%   # Left, 40% width, 90% height
+fzf --tmux top,40%        # Top, 40% height
+fzf --tmux bottom,80%,40% # Bottom, 80% height, 40% height
+```
+
+`--tmux` is silently ignored when you're not on tmux.
+
+> [!NOTE]
+> If you're stuck with an old version of tmux that doesn't support popup,
+> or if you want to open fzf in a regular tmux pane, check out
+> [fzf-tmux](bin/fzf-tmux) script.
+
+> [!TIP]
+> You can add these options to `$FZF_DEFAULT_OPTS` so that they're applied by
+> default. For example,
+>
+> ```sh
+> # Open in tmux popup if on tmux, otherwise use --height mode
+> export FZF_DEFAULT_OPTS='--tmux bottom,40% --height 40% --layout reverse --border'
+> ```
 
 ### Search syntax
 
@@ -406,34 +440,6 @@ Examples
       and are not thoroughly tested*
 * [Advanced fzf examples](https://github.com/junegunn/fzf/blob/master/ADVANCED.md)
 
-`fzf-tmux` script
------------------
-
-[fzf-tmux](bin/fzf-tmux) is a bash script that opens fzf in a tmux pane.
-
-```sh
-# usage: fzf-tmux [LAYOUT OPTIONS] [--] [FZF OPTIONS]
-
-# See available options
-fzf-tmux --help
-
-# select git branches in horizontal split below (15 lines)
-git branch | fzf-tmux -d 15
-
-# select multiple words in vertical split on the left (20% of screen width)
-cat /usr/share/dict/words | fzf-tmux -l 20% --multi --reverse
-```
-
-It will still work even when you're not on tmux, silently ignoring `-[pudlr]`
-options, so you can invariably use `fzf-tmux` in your scripts.
-
-Alternatively, you can use `--height HEIGHT[%]` option not to start fzf in
-fullscreen mode.
-
-```sh
-fzf --height 40%
-```
-
 Key bindings for command-line
 -----------------------------
 
@@ -482,9 +488,9 @@ fish.
     - Can be disabled by setting `FZF_ALT_C_COMMAND` to an empty string when
       sourcing the script
 
-If you're on a tmux session, you can start fzf in a tmux split-pane or in
-a tmux popup window by setting `FZF_TMUX_OPTS` (e.g. `export FZF_TMUX_OPTS='-p80%,60%'`).
-See `fzf-tmux --help` for available options.
+Display modes for these bindings can be separately configured via
+`FZF_{CTRL_T,CTRL_R,ALT_C}_OPTS` or globally via `FZF_DEFAULT_OPTS`.
+(e.g. `FZF_CTRL_R_OPTS='--tmux bottom,60% --height 60%'`)
 
 More tips can be found on [the wiki page](https://github.com/junegunn/fzf/wiki/Configuring-shell-key-bindings).
 

--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -132,8 +132,10 @@ if [[ -z "$TMUX" ]]; then
   exit $?
 fi
 
-# --height option is not allowed. CTRL-Z is also disabled.
-args=("${args[@]}" "--no-height" "--bind=ctrl-z:ignore")
+# * --height option is not allowed
+# * CTRL-Z is also disabled
+# * fzf-tmux script is not compatible with --tmux option in fzf 0.53.0 or later
+args=("${args[@]}" "--no-height" "--bind=ctrl-z:ignore" "--no-tmux")
 
 # Handle zoomed tmux pane without popup options by moving it to a temp window
 if [[ ! "$opt" =~ "-E" ]] && tmux list-panes -F '#F' | grep -q Z; then

--- a/doc/fzf.txt
+++ b/doc/fzf.txt
@@ -311,7 +311,7 @@ The following table summarizes the available options.
   `options`                   | string/list   | Options to fzf
   `dir`                       | string        | Working directory
   `up` / `down` / `left` / `right`  | number/string | (Layout) Window position and size (e.g.  `20` ,  `50%` )
-  `tmux`                      | string        | (Layout) fzf-tmux options (e.g.  `-p90%,60%` )
+  `tmux`                      | string        | (Layout) `--tmux` options (e.g.  `90%,70%` )
   `window`  (Vim 8 / Neovim)  | string        | (Layout) Command to open fzf window (e.g.  `vertical aboveleft 30new` )
   `window`  (Vim 8 / Neovim)  | dict          | (Layout) Popup window settings (e.g.  `{'width': 0.9, 'height': 0.6}` )
  ---------------------------+---------------+----------------------------------------------------------------------
@@ -469,11 +469,12 @@ in Neovim.
     let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
 <
 Alternatively, you can make fzf open in a tmux popup window (requires tmux 3.2
-or above) by putting fzf-tmux options in `tmux` key.
+or above) by putting `--tmux` options in `tmux` key.
 >
-    " See `man fzf-tmux` for available options
+    " See `--tmux` option in `man fzf` for available options
+    " [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]
     if exists('$TMUX')
-      let g:fzf_layout = { 'tmux': '-p90%,60%' }
+      let g:fzf_layout = { 'tmux': '90%,70%' }
     else
       let g:fzf_layout = { 'window': { 'width': 0.9, 'height': 0.6 } }
     endif

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ func printScript(label string, content []byte) {
 }
 
 func exit(code int, err error) {
-	if err != nil {
+	if code == fzf.ExitError {
 		fmt.Fprintln(os.Stderr, err.Error())
 	}
 	os.Exit(code)

--- a/man/man1/fzf-tmux.1
+++ b/man/man1/fzf-tmux.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf-tmux 1 "May 2024" "fzf 0.52.1" "fzf-tmux - open fzf in tmux split pane"
+.TH fzf-tmux 1 "May 2024" "fzf 0.53.0" "fzf-tmux - open fzf in tmux split pane"
 
 .SH NAME
 fzf-tmux - open fzf in tmux split pane

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -21,7 +21,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 ..
-.TH fzf 1 "May 2024" "fzf 0.52.1" "fzf - a command-line fuzzy finder"
+.TH fzf 1 "May 2024" "fzf 0.53.0" "fzf - a command-line fuzzy finder"
 
 .SH NAME
 fzf - a command-line fuzzy finder
@@ -215,6 +215,24 @@ compatible with a negative height value.
 .BI "--min-height=" "HEIGHT"
 Minimum height when \fB--height\fR is given in percent (default: 10).
 Ignored when \fB--height\fR is not specified.
+.TP
+.BI "--tmux=" "[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]"
+Start fzf in a tmux popup. Requires tmux 3.3 or later. This option is ignored
+if you are not running fzf inside tmux.
+
+e.g.
+  \fB# Popup in the center with 80% width height
+  fzf --tmux 80%
+
+  # Popup on the left with 40% width and 100% height
+  fzf --tmux right,40%
+
+  # Popup on the bottom with 100% width and 30% height
+  fzf --tmux bottom,30%
+
+  # Popup on the top with 80% width and 40% height
+  fzf --tmux top,80%,40%\fR
+
 .TP
 .BI "--layout=" "LAYOUT"
 Choose the layout (default: default)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -573,19 +573,21 @@ function! s:fzf_tmux(dict)
   if empty(size)
     for o in ['up', 'down', 'left', 'right']
       if s:present(a:dict, o)
-        let spec = a:dict[o]
-        if (o == 'up' || o == 'down') && spec[0] == '~'
-          let size = '-'.o[0].s:calc_size(&lines, spec, a:dict)
-        else
-          " Legacy boolean option
-          let size = '-'.o[0].(spec == 1 ? '' : substitute(spec, '^\~', '', ''))
-        endif
+        let size = o . ',' . a:dict[o]
         break
       endif
     endfor
   endif
-  return printf('LINES=%d COLUMNS=%d %s %s %s --',
-    \ &lines, &columns, fzf#shellescape(s:fzf_tmux), size, (has_key(a:dict, 'source') ? '' : '-'))
+
+  " Legacy fzf-tmux options
+  if size =~ '-'
+    return printf('LINES=%d COLUMNS=%d %s %s %s --',
+          \ &lines, &columns, fzf#shellescape(s:fzf_tmux), size, (has_key(a:dict, 'source') ? '' : '-'))
+  end
+
+  " Using native --tmux option
+  let in = (has_key(a:dict, 'source') ? '' : ' < /dev/tty')
+  return printf('%s --tmux %s%s', fzf#shellescape(fzf#exec()), size, in)
 endfunction
 
 function! s:splittable(dict)

--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -537,10 +537,10 @@ try
     let use_term = 0
   endif
   if use_term
-    let optstr .= ' --no-height'
+    let optstr .= ' --no-height --no-tmux'
   elseif use_height
     let height = s:calc_size(&lines, dict.down, dict)
-    let optstr .= ' --height='.height
+    let optstr .= ' --no-tmux --height='.height
   endif
   " Respect --border option given in $FZF_DEFAULT_OPTS and 'options'
   let optstr = join([s:border_opt(get(dict, 'window', 0)), s:extract_option($FZF_DEFAULT_OPTS, 'border'), optstr])

--- a/src/constants.go
+++ b/src/constants.go
@@ -67,9 +67,9 @@ const (
 )
 
 const (
-	ExitCancel    = -1
 	ExitOk        = 0
 	ExitNoMatch   = 1
 	ExitError     = 2
+	ExitBecome    = 126
 	ExitInterrupt = 130
 )

--- a/src/core.go
+++ b/src/core.go
@@ -2,6 +2,7 @@
 package fzf
 
 import (
+	"os"
 	"sync"
 	"time"
 
@@ -19,6 +20,10 @@ Matcher  -> EvtHeader         -> Terminal (update header)
 
 // Run starts fzf
 func Run(opts *Options) (int, error) {
+	if opts.Tmux != nil && len(os.Getenv("TMUX")) > 0 {
+		return runTmux(os.Args[1:], opts)
+	}
+
 	if err := postProcessOptions(opts); err != nil {
 		return ExitError, err
 	}

--- a/src/functions.go
+++ b/src/functions.go
@@ -7,7 +7,7 @@ import (
 )
 
 func writeTemporaryFile(data []string, printSep string) string {
-	f, err := os.CreateTemp("", "fzf-preview-*")
+	f, err := os.CreateTemp("", "fzf-temp-*")
 	if err != nil {
 		// Unable to create temporary file
 		// FIXME: Should we terminate the program?

--- a/src/options.go
+++ b/src/options.go
@@ -381,6 +381,7 @@ type Options struct {
 	Input        chan string
 	Output       chan string
 	Tmux         *tmuxOptions
+	TmuxScript   string
 	Bash         bool
 	Zsh          bool
 	Fish         bool
@@ -1882,6 +1883,10 @@ func parseOptions(opts *Options, allArgs []string) error {
 			}
 		case "--no-tmux":
 			opts.Tmux = nil
+		case "--tmux-script":
+			if opts.TmuxScript, err = nextString(allArgs, &i, ""); err != nil {
+				return err
+			}
 		case "-x", "--extended":
 			opts.Extended = true
 		case "-e", "--exact":

--- a/src/tmux.go
+++ b/src/tmux.go
@@ -1,0 +1,149 @@
+package fzf
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/junegunn/fzf/src/tui"
+	"github.com/junegunn/fzf/src/util"
+)
+
+func escapeSingleQuote(str string) string {
+	return "'" + strings.ReplaceAll(str, "'", "'\\''") + "'"
+}
+
+func runTmux(args []string, opts *Options) (int, error) {
+	ns := time.Now().UnixNano()
+
+	output := filepath.Join(os.TempDir(), fmt.Sprintf("fzf-tmux-output-%d", ns))
+	if err := mkfifo(output, 0666); err != nil {
+		return ExitError, err
+	}
+	defer os.Remove(output)
+
+	// Find fzf executable
+	fzf := "fzf"
+	if found, err := os.Executable(); err == nil {
+		fzf = found
+	}
+
+	// Prepare arguments
+	args = append([]string{"--bind=ctrl-z:ignore"}, args...)
+	if opts.BorderShape == tui.BorderUndefined {
+		args = append(args, "--border")
+	}
+	args = append(args, "--no-height")
+	args = append(args, "--no-tmux")
+	argStr := ""
+	for _, arg := range args {
+		// %q formatting escapes $'foo\nbar' to "foo\nbar"
+		argStr += " " + escapeSingleQuote(arg)
+	}
+
+	// Build command
+	var command string
+	if opts.Input == nil && util.IsTty() {
+		command = fmt.Sprintf(`%q%s > %q`, fzf, argStr, output)
+	} else {
+		input := filepath.Join(os.TempDir(), fmt.Sprintf("fzf-tmux-input-%d", ns))
+		if err := mkfifo(input, 0644); err != nil {
+			return ExitError, err
+		}
+		defer os.Remove(input)
+
+		go func() {
+			inputFile, err := os.OpenFile(input, os.O_WRONLY, 0)
+			if err != nil {
+				return
+			}
+			if opts.Input == nil {
+				io.Copy(inputFile, os.Stdin)
+			} else {
+				for item := range opts.Input {
+					fmt.Fprint(inputFile, item+opts.PrintSep)
+				}
+			}
+			inputFile.Close()
+		}()
+
+		command = fmt.Sprintf(`%q%s < %q > %q`, fzf, argStr, input, output)
+	}
+
+	// Get current directory
+	dir, err := os.Getwd()
+	if err != nil {
+		dir = "."
+	}
+
+	// Set tmux options for popup placement
+	// C        Both    The centre of the terminal
+	// R        -x      The right side of the terminal
+	// P        Both    The bottom left of the pane
+	// M        Both    The mouse position
+	// W        Both    The window position on the status line
+	// S        -y      The line above or below the status line
+	tmuxArgs := []string{"display-popup", "-E", "-B", "-d", dir}
+	switch opts.Tmux.position {
+	case posUp:
+		tmuxArgs = append(tmuxArgs, "-xC", "-y0")
+	case posDown:
+		tmuxArgs = append(tmuxArgs, "-xC", "-yS")
+	case posLeft:
+		tmuxArgs = append(tmuxArgs, "-x0", "-yC")
+	case posRight:
+		tmuxArgs = append(tmuxArgs, "-xR", "-yC")
+	case posCenter:
+		tmuxArgs = append(tmuxArgs, "-xC", "-yC")
+	}
+	tmuxArgs = append(tmuxArgs, "-w"+opts.Tmux.width.String())
+	tmuxArgs = append(tmuxArgs, "-h"+opts.Tmux.height.String())
+
+	// To ensure that the options are processed by a POSIX-compliant shell,
+	// we need to write the command to a temporary file and execute it with sh.
+	exports := os.Environ()
+	for idx, pairStr := range exports {
+		pair := strings.SplitN(pairStr, "=", 2)
+		exports[idx] = fmt.Sprintf("export %s=%s", pair[0], escapeSingleQuote(pair[1]))
+	}
+	temp := writeTemporaryFile(append(exports, command), "\n")
+	defer os.Remove(temp)
+	tmuxArgs = append(tmuxArgs, "sh", temp)
+
+	// Take the output
+	go func() {
+		outputFile, err := os.OpenFile(output, os.O_RDONLY, 0)
+		if err != nil {
+			return
+		}
+		if opts.Output == nil {
+			io.Copy(os.Stdout, outputFile)
+		} else {
+			reader := bufio.NewReader(outputFile)
+			sep := opts.PrintSep[0]
+			for {
+				item, err := reader.ReadString(sep)
+				if err != nil {
+					break
+				}
+				opts.Output <- item
+			}
+		}
+
+		outputFile.Close()
+	}()
+
+	cmd := exec.Command("tmux", tmuxArgs...)
+	if err := cmd.Run(); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return exitError.ExitCode(), err
+		}
+	}
+
+	return ExitOk, nil
+}

--- a/src/tmux_unix.go
+++ b/src/tmux_unix.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package fzf
+
+import "golang.org/x/sys/unix"
+
+func mkfifo(path string, mode uint32) error {
+	return unix.Mkfifo(path, mode)
+}

--- a/src/tmux_windows.go
+++ b/src/tmux_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package fzf
+
+import (
+	"os/exec"
+	"strconv"
+)
+
+func mkfifo(path string, mode uint32) error {
+	m := strconv.FormatUint(uint64(mode), 8)
+	cmd := exec.Command("mkfifo", "-m", m, path)
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return nil
+}

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -356,7 +356,8 @@ type MouseEvent struct {
 type BorderShape int
 
 const (
-	BorderNone BorderShape = iota
+	BorderUndefined BorderShape = iota
+	BorderNone
 	BorderRounded
 	BorderSharp
 	BorderBold


### PR DESCRIPTION
Add native `--tmux` option to replace fzf-tmux script.

## Usage

```
# --tmux [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]

# Center, 50% width 50% height
fzf --tmux center

# Center, 80% width and height
fzf --tmux 80%

# Center ,100% width and 50% height
fzf --tmux 100%,50%

# Left, 40% width
fzf --tmux left,40%

# Left, 40% width, 90% height
fzf --tmux left,40%,90%

# Top, 40% height
fzf --tmux top,40%

# Top, 90% height, 40% height
fzf --tmux top,90%,40%
```

## Pros

* Simpler and more robust implementation
* Simpler distribution
* Easier to use
* Handles `become` inside tmux popup better
* Properly propagates environment variables

## Cons

* Requires tmux 3.3 or later
* Only opens in a popup which cannot be zoomed