### PR TITLE
Add Flox to list of installation methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The install script will add lines to your shell configuration file to modify
 | Spack           |                         | `spack install fzf`                |
 | XBPS            | Void Linux              | `sudo xbps-install -S fzf`         |
 | Zypper          | openSUSE                | `sudo zypper install fzf`          |
+| Flox            |                         | `flox install fzf`                 |
 
 > [!IMPORTANT]
 > To set up shell integration (key bindings and fuzzy completion),


### PR DESCRIPTION
`fzf` seems to be available and working in [Flox] today!
Thought I'd add it to the list of installation methods. 😁

[Flox]: https://flox.dev/docs/ 