### PR TITLE
Change the full path logic for Windows to include backslash.

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -327,7 +327,7 @@ function! s:common_sink(action, lines) abort
     " the execution (e.g. `set autochdir` or `autocmd BufEnter * lcd ...`)
     let cwd = exists('w:fzf_pushd') ? w:fzf_pushd.dir : expand('%:p:h')
     for item in a:lines
-      if item[0] != '~' && item !~ (s:is_win ? '^[A-Z]:\' : '^/')
+      if ! (item =~ '^\~' || item =~ '^/' || item =~ '^\([A-Z]:\)*\')
         let sep = s:is_win ? '\' : '/'
         let item = join([cwd, item], cwd[len(cwd)-1] == sep ? '' : sep)
       endif


### PR DESCRIPTION
On Windows paths starting with "\" are prepended with the value of "cwd", which does not make sense. This commit to address this issue and treat  paths starting with "\" the same way as "^[A-Z]:\".