### PR TITLE
Add support for Alacritty preview in ANSI Format

### DIFF
--- a/bin/fzf-preview.sh
+++ b/bin/fzf-preview.sh
@@ -57,7 +57,12 @@ if [[ $KITTY_WINDOW_ID ]]; then
 
 # 2. Use chafa with Sixel output
 elif command -v chafa > /dev/null; then
-  chafa -f sixel -s "$dim" "$file"
+  # Alacritty doesn't support sixels
+  if [[ $ALACRITTY_WINDOW_ID ]]; then
+    chafa --colors 256 -s "$dim" "$file"
+  else
+    chafa -f sixel -s "$dim" "$file"
+  fi  
   # Add a new line character so that fzf can display multiple images in the preview window
   echo
 


### PR DESCRIPTION
## Change 

Modification to `fzf-preview.sh` to support Alacritty which doesn't have [sixel support](https://github.com/alacritty/alacritty/issues/910)

<img width="950" alt="image" src="https://github.com/junegunn/fzf/assets/6491743/d5fed0d0-4a3b-4c81-bffb-813d0d2ee788">

- **Alacritty** black bg
- **Wezterm** Blue bg

Alacritty doesn't support SIXELS but `chafa` can still work

