### PR TITLE
[zsh] Prevent glob expansion in history widget

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -107,7 +107,7 @@ fi
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
   local selected num
-  setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases 2> /dev/null
+  setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases noglob 2> /dev/null
   # Ensure the associative history array, which maps event numbers to the full
   # history lines, is loaded, and that Perl is installed for multi-line output.
   if zmodload -F zsh/parameter p:history 2>/dev/null && (( ${#commands[perl]} )); then


### PR DESCRIPTION
I have some lines in my history that break the new multiline history widget, when pressing ctrl+r I get
```
zsh: no matches found: cd \M-cÂ\M-+クシ\M-c~ィ\M-c\nイズ
```
and no prompt is shown, the issue is with the expansion of the history array, since when I run `echo "${(vk)history[@]}"`, I get the same error.

zsh is trying to expand the (improperly) encoded line for some reason, which can be fixed by setting the `noglob` option.

I am not sure if any of the other widgets would need this option too, or if the issue only arises from zsh's [metafied](https://www.zsh.org/mla/users/2011/msg00154.html) format for history files.