### PR TITLE
chore(shell): Separate declaration and assignment for zsh legacy versions

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -157,7 +157,9 @@ __fzf_generic_path_completion() {
       [ -z "$dir" ] && dir='.'
       [ "$dir" != "/" ] && dir="${dir/%\//}"
       matches=$(
-        export FZF_DEFAULT_OPTS=$(__fzf_defaults "--reverse --scheme=path" "${FZF_COMPLETION_OPTS-}")
+        # Declare and assign separately for older zsh versions.
+        export FZF_DEFAULT_OPTS
+        FZF_DEFAULT_OPTS=$(__fzf_defaults "--reverse --scheme=path" "${FZF_COMPLETION_OPTS-}")
         unset FZF_DEFAULT_COMMAND FZF_DEFAULT_OPTS_FILE
         if declare -f "$compgen" > /dev/null; then
           eval "$compgen $(printf %q "$dir")" | __fzf_comprun "$cmd" ${(Q)${(Z+n+)fzf_opts}} -q "$leftover"
@@ -264,13 +266,14 @@ _fzf_complete_telnet() {
 # The first and the only argument is the LBUFFER without the current word that contains the trigger.
 # The current word without the trigger is in the $prefix variable passed from the caller.
 _fzf_complete_ssh() {
-  local tokens=(${(z)1})
+  local -a tokens
+  tokens=(${(z)1})
   case ${tokens[-1]} in
     -i|-F|-E)
       _fzf_path_completion "$prefix" "$1"
       ;;
     *)
-      local user=
+      local user
       [[ $prefix =~ @ ]] && user="${prefix%%@*}@"
       _fzf_complete +m -- "$@" < <(__fzf_list_hosts | awk -v user="$user" '{print user $0}')
       ;;


### PR DESCRIPTION
### description

Close #3841

`zsh` versions prior to **5.1** deal with assignments differently on builtins like `declare, export, local, readonly and typeset`

```sh
❯ ~/.local/zsh-test/bin/zsh-5.0.2 -fxvc 'local scalar=$(echo one word)'
+zsh:1> echo one word
+zsh:1> local 'scalar=one' word

❯ ~/.local/zsh-test/bin/zsh-5.1 -fxvc 'local scalar=$(echo one word)'
local scalar=$(echo one word)
+zsh:1> echo one word
+zsh:1> local scalar='one word'
```

```sh
❯ ~/.local/zsh-test/bin/zsh-5.0.2 -fxvc 'local -a array=(several words)'
zsh:1: missing end of string

❯ ~/.local/zsh-test/bin/zsh-5.1 -fxvc 'local -a array=(several words)'
local -a array=(several words)
+zsh:1> local -a array=( several words )
```

To ensure compatibility with older `zsh` versions, split assignment and declaration when using multiple values or arrays.

```sh
❯ ~/.local/zsh-test/bin/zsh-5.0.2 -fxvc 'local scalar;scalar=$(echo one word)'
+zsh:1> local scalar
+zsh:1> scalar=+zsh:1> echo one word
+zsh:1> scalar='one word'
```

```sh
❯ ~/.local/zsh-test/bin/zsh-5.0.2 -fxvc 'local -a array;array=(several words)'
+zsh:1> local -a array
+zsh:1> array=( several words )
```

Lines like `local ret=$?` should be fine.

```sh
❯ ~/.local/zsh-test/bin/zsh-5.0.2 -fxvc '$RANDOM; local ret=$?'
+zsh:1> 29160
zsh:1: command not found: 29160
+zsh:1> local 'ret=127'
```
