### PR TITLE
Add wpath and dpath pledges on OpenBSD to make --tmux work

### DIFF
--- a/src/protector/protector_openbsd.go
+++ b/src/protector/protector_openbsd.go
@@ -6,5 +6,5 @@ import "golang.org/x/sys/unix"
 
 // Protect calls OS specific protections like pledge on OpenBSD
 func Protect() {
-	unix.PledgePromises("stdio rpath tty proc exec inet tmppath")
+	unix.PledgePromises("stdio dpath wpath rpath tty proc exec inet tmppath")
 }


### PR DESCRIPTION
```
vm:~$ uname -a
OpenBSD vm.lab.local 7.5 GENERIC.MP#139 amd64
vm:~$ fzf --version
0.53.0
```

```
vm:~$ fzf --tmux 70%
fzf[30951]: pledge "dpath", syscall 132
zsh: abort (core dumped)  fzf --tmux 70%
```
after adding 'dpath' pledge above test case begins to work, but the next one still fails:

```
vm:/tmp/fzf (master)$ ls | ./fzf --tmux 70%
fzf[17234]: pledge "wpath", syscall 5
zsh: done                 ls -F |
zsh: abort (core dumped)  ./fzf --tmux 70%
```

Solution - add 'dpath' and 'wpath' pledges, after that both test cases work fine.