### PR TITLE
fix(shell): add (?s) modifier to perl command

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -112,7 +112,7 @@ fzf-history-widget() {
   # history lines, is loaded, and that Perl is installed for multi-line output.
   if zmodload -F zsh/parameter p:history 2>/dev/null && (( ${#commands[perl]} )); then
     selected="$(printf '%1$s\t%2$s\000' "${(vk)history[@]}" |
-      perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\s+(.*)/, $1)}++) { s/\n/\n\t/gm; print; }' |
+      perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\s+((?s).*)/, $1)}++) { s/\n/\n\t/gm; print; }' |
       FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \
       FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd))"
   else


### PR DESCRIPTION
### description

Close #3881

The syntax is described under: `man perlre | less --pattern "embedded pattern-match modifiers"`

The modifiers are explained under: `man perlre | less --pattern "Modifiers"`

Details for `.` (dot) under: `man perlrecharclass | less --pattern "The dot"`
