### PR TITLE
fix zsh ${(@)history} syntax does not work with ksh_arrays

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -111,7 +111,7 @@ fzf-history-widget() {
   # Ensure the associative history array, which maps event numbers to the full
   # history lines, is loaded, and that Perl is installed for multi-line output.
   if zmodload -F zsh/parameter p:history 2>/dev/null && (( ${#commands[perl]} )); then
-    selected="$(printf '%s\t%s\000' "${(@kv)history}" |
+    selected="$(printf '%s\t%s\000' "${(kv)history[@]}" |
       perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
       FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \
       FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd))"


### PR DESCRIPTION
When `setopt ksh_arrays` in zsh, `${(@kv)history}` gives only the first entry rather than all.

This is breaking the zsh control-r history widget to show only the latest history entry rather than all (which isn't very useful).

I have `setopt ksh_arrays` set in my zshrc.

I believe this is caused by https://github.com/junegunn/fzf/pull/3882/files#diff-c1d0c74baf2323d5dc27290b500868528b9a80be6a0844e998eefb2f9f6ab968R114
specifically the change from `${(kv)history[@]}` to `${(@kv)history}` does not seem to work when you have `setopt ksh_arrays` (it gives back only the one latest history entry).

This fixes it for me, but a potentially better fix could be to add something like `emulate -LR zsh`  at the start of all widgets