### PR TITLE
fix(zsh): use the '=~' operator instead of grep

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -106,8 +106,8 @@ fi
 
 # CTRL-R - Paste the selected command from history into the command line
 fzf-history-widget() {
-  local selected num
-  setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases noglob 2> /dev/null
+  local selected
+  setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases noglob nobash_rematch 2> /dev/null
   # Ensure the associative history array, which maps event numbers to the full
   # history lines, is loaded, and that Perl is installed for multi-line output.
   if zmodload -F zsh/parameter p:history 2>/dev/null && (( ${#commands[perl]} )); then
@@ -122,8 +122,8 @@ fzf-history-widget() {
   fi
   local ret=$?
   if [ -n "$selected" ]; then
-    if num=$(awk '{print $1; exit}' <<< "$selected" | grep -o '^[1-9][0-9]*'); then
-      zle vi-fetch-history -n $num
+    if [[ $(awk '{print $1; exit}' <<< "$selected") =~ ^[1-9][0-9]* ]]; then
+      zle vi-fetch-history -n $MATCH
     else # selected is a custom query, not from history
       LBUFFER="$selected"
     fi


### PR DESCRIPTION
### description

Close #3904


Using Apple's default `grep` version and assigning the `GREP_OPTIONS` environment variable with `--color=always`, unintended ANSI escape sequences causing mischief in the correct retrieval of the history entry.


```sh
export GREP_OPTIONS="--color=always"
export PATH="/usr/bin:$PATH"
grep --version
# grep (BSD grep) 2.5.1-FreeBSD
source <(fzf --zsh)
```


### Solution

1. Use grep `--color=never`, or
2. use the `=~` operator coupled with `MATCH` to catch the matched string in case of a success.


```sh
man 1 zshmisc | less --pattern BASH_REMATCH
# string =~ regexp
#   true if string matches the regular expression regexp.  If the option RE_MATCH_PCRE is set regexp is tested as a PCRE regular expression
#   using the zsh/pcre module, else it is tested as a POSIX extended regular expression using the zsh/regex module.  Upon successful match,
#   some variables will be updated; no variables are changed if the matching fails.

#   If the option BASH_REMATCH is not set the scalar parameter MATCH is set to the substring that  matched  the  pattern  and  the  integer
#   parameters MBEGIN and MEND to the index of the start and end, respectively, of the match in string, such that if string is contained in
#   variable var the expression `${var[$MBEGIN,$MEND]}' is identical to `$MATCH'.  The setting  of  the  option  KSH_ARRAYS  is  respected.
#   Likewise,  the  array  match  is  set to the substrings that matched parenthesised subexpressions and the arrays mbegin and mend to the
#   indices of the start and end positions, respectively, of the substrings within string.  The arrays are not set if there were no  paren-
#   thesised subexpressions.  For example, if the string `a short string' is matched against the regular expression `s(...)t', then (assum-
#   ing the option KSH_ARRAYS is not set) MATCH, MBEGIN and MEND are `short', 3 and 7, respectively, while match, mbegin and mend are  sin-
#   gle entry arrays containing the strings `hor', `4' and `6', respectively.

#   If  the  option  BASH_REMATCH is set the array BASH_REMATCH is set to the substring that matched the pattern followed by the substrings
#   that matched parenthesised subexpressions within the pattern.
```
