### PR TITLE
Update charlievieth/fastwalk to use forward-slashes on WSL and MSYS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/junegunn/fzf
 
 require (
-	github.com/charlievieth/fastwalk v1.0.6
+	github.com/charlievieth/fastwalk v1.0.7-0.20240703190418-87029d931815
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/junegunn/fzf
 
 require (
-	github.com/charlievieth/fastwalk v1.0.4
+	github.com/charlievieth/fastwalk v1.0.6
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/charlievieth/fastwalk v1.0.6 h1:C7nXgxQIjEkpKWT1fbXGFzQiblwqq2ZsxrR0ohh5IRs=
-github.com/charlievieth/fastwalk v1.0.6/go.mod h1:rV19+IF9Y2TYQNy4MqEk5M/spNHjKsA0i71yrsv2p4E=
+github.com/charlievieth/fastwalk v1.0.7-0.20240703190418-87029d931815 h1:4PRbYm9OMgH0bcdZZqMXA/AoOvpGy4l0H6g9Au/kgGA=
+github.com/charlievieth/fastwalk v1.0.7-0.20240703190418-87029d931815/go.mod h1:rV19+IF9Y2TYQNy4MqEk5M/spNHjKsA0i71yrsv2p4E=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.7.4 h1:sg6/UnTM9jGpZU+oFYAsDahfchWAFW8Xx2yFinNSAYU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/charlievieth/fastwalk v1.0.4 h1:EG3y5L1XBa8VftvpONuQlfe5sNuf1xzGpm59bdgCDwo=
-github.com/charlievieth/fastwalk v1.0.4/go.mod h1:JSfglY/gmL/rqsUS1NCsJTocB5n6sSl9ApAqif4CUbs=
+github.com/charlievieth/fastwalk v1.0.6 h1:C7nXgxQIjEkpKWT1fbXGFzQiblwqq2ZsxrR0ohh5IRs=
+github.com/charlievieth/fastwalk v1.0.6/go.mod h1:rV19+IF9Y2TYQNy4MqEk5M/spNHjKsA0i71yrsv2p4E=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.7.4 h1:sg6/UnTM9jGpZU+oFYAsDahfchWAFW8Xx2yFinNSAYU=

--- a/src/reader.go
+++ b/src/reader.go
@@ -233,6 +233,20 @@ func isSymlinkToDir(path string, de os.DirEntry) bool {
 	return false
 }
 
+func trimPath(path string) string {
+	if len(path) == 0 {
+		return "."
+	}
+
+	bytes := stringBytes(path)
+
+	for len(bytes) > 1 && bytes[0] == '.' && (bytes[1] == '/' || bytes[1] == '\\') {
+		bytes = bytes[2:]
+	}
+
+	return byteString(bytes)
+}
+
 func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string) bool {
 	r.killed = false
 	conf := fastwalk.Config{
@@ -244,7 +258,7 @@ func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string) bool 
 		if err != nil {
 			return nil
 		}
-		path = filepath.Clean(path)
+		path = trimPath(path)
 		if path != "." {
 			isDir := de.IsDir()
 			if isDir || opts.follow && isSymlinkToDir(path, de) {

--- a/src/reader.go
+++ b/src/reader.go
@@ -234,14 +234,14 @@ func isSymlinkToDir(path string, de os.DirEntry) bool {
 }
 
 func trimPath(path string) string {
-	if len(path) == 0 {
-		return "."
-	}
-
 	bytes := stringBytes(path)
 
 	for len(bytes) > 1 && bytes[0] == '.' && (bytes[1] == '/' || bytes[1] == '\\') {
 		bytes = bytes[2:]
+	}
+
+	if len(bytes) == 0 {
+		return "."
 	}
 
 	return byteString(bytes)

--- a/src/reader.go
+++ b/src/reader.go
@@ -237,7 +237,7 @@ func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string) bool 
 	r.killed = false
 	conf := fastwalk.Config{
 		Follow: opts.follow,
-		// Use forward slashes when running a Windows binary under WSL.
+		// Use forward slashes when running a Windows binary under WSL or MSYS
 		ToSlash: fastwalk.DefaultToSlash(),
 	}
 	fn := func(path string, de os.DirEntry, err error) error {

--- a/src/reader.go
+++ b/src/reader.go
@@ -258,7 +258,7 @@ func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string, sep b
 					}
 				}
 			}
-			if ((opts.file && !isDir) || (opts.dir && isDir)) && r.pusher([]byte(path)) {
+			if ((opts.file && !isDir) || (opts.dir && isDir)) && r.pusher(stringBytes(path)) {
 				atomic.StoreInt32(&r.event, int32(EvtReadNew))
 			}
 		}


### PR DESCRIPTION
This commit changes FZF to enforce that all paths are joined with forward-slashes when running on WSL (Windows Subsystem for Linux) even when the FZF binary was compiled for Windows.

Update: github.com/charlievieth/fastwalk to v1.0.5
Fixes:  https://github.com/junegunn/fzf/issues/3859