### PR TITLE
fix(fish): handle dash in fzf key bindings

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -104,11 +104,7 @@ function fzf_key_bindings
       eval (__fzfcmd)' +m --query "'$fzf_query'"' | read -l result
 
       if [ -n "$result" ]
-        if string match --quiet -- '-*' $result
-            cd ./$result
-        else
-            cd $result
-        end
+        cd -- $result
 
         # Remove last token from commandline.
         commandline -t ""

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -104,7 +104,11 @@ function fzf_key_bindings
       eval (__fzfcmd)' +m --query "'$fzf_query'"' | read -l result
 
       if [ -n "$result" ]
-        builtin cd -- $result
+        if string match --quiet -- '-*' $result
+            cd ./$result
+        else
+            cd $result
+        end
 
         # Remove last token from commandline.
         commandline -t ""


### PR DESCRIPTION
### description

> harkabeeparolus: If you use standard vanilla fish shell, without any third-party plugins, by default the builtin cd command is wrapped by a function that provides Directory History. This function maintains the dirprev and dirnext lists, which is what enables fish shells's Directory History (cdh and dirh commands, as well as the Alt-Left and Alt-Right hotkeys) to work as intended. When fzf bypasses this function with builtin cd, the previous directory is never saved to the Directory History, and this information is lost to the user.
>
> Source: https://github.com/junegunn/fzf/pull/3830#issuecomment-2230054172


Unfortuantely, we can't use the safe `cd -- …` syntax as there is a small bug in `zoxide`.

> The underlying problem between zoxide and fzf is caused by zoxide actually being incompatible with the default cd command in fish. Regular cd can handle the safer syntax cd -- newdirectory #2659, but zoxide can not ajeetdsouza/zoxide#332. The zoxide people tried to work around this by modifying fzf #2799, which caused fzf Alt-C to break fish shell's default Directory History and cd -.
>
> Source: https://github.com/junegunn/fzf/issues/3826#issuecomment-2230161845

Therefore, a check for a leading dash has been added, and the prepended `builtin` command has been removed.

Thanks to @harkabeeparolus for the investigation.

