### PR TITLE
Update fastwalk to v1.0.8 for better MSYS detection and sorting

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/junegunn/fzf
 
 require (
-	github.com/charlievieth/fastwalk v1.0.7-0.20240703190418-87029d931815
+	github.com/charlievieth/fastwalk v1.0.8
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/mattn/go-isatty v0.0.20
 	github.com/mattn/go-shellwords v1.0.12

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/charlievieth/fastwalk v1.0.7-0.20240703190418-87029d931815 h1:4PRbYm9OMgH0bcdZZqMXA/AoOvpGy4l0H6g9Au/kgGA=
-github.com/charlievieth/fastwalk v1.0.7-0.20240703190418-87029d931815/go.mod h1:rV19+IF9Y2TYQNy4MqEk5M/spNHjKsA0i71yrsv2p4E=
+github.com/charlievieth/fastwalk v1.0.8 h1:uaoH6cAKSk73aK7aKXqs0+bL+J3Txzd3NGH8tRXgHko=
+github.com/charlievieth/fastwalk v1.0.8/go.mod h1:yGy1zbxog41ZVMcKA/i8ojXLFsuayX5VvwhQVoj9PBI=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.7.4 h1:sg6/UnTM9jGpZU+oFYAsDahfchWAFW8Xx2yFinNSAYU=

--- a/src/reader.go
+++ b/src/reader.go
@@ -253,6 +253,7 @@ func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string) bool 
 		Follow: opts.follow,
 		// Use forward slashes when running a Windows binary under WSL or MSYS
 		ToSlash: fastwalk.DefaultToSlash(),
+		Sort:    fastwalk.SortFilesFirst,
 	}
 	fn := func(path string, de os.DirEntry, err error) error {
 		if err != nil {


### PR DESCRIPTION
**NOTE:** This PR needs to be updated to not use the slices package.

This commit updates [github.com/charlievieth/fastwalk](https://github.com/charlievieth/fastwalk) to [v1.0.7](https://github.com/charlievieth/fastwalk/releases/tag/v1.0.7) which improves MSYS detection and adds optional sorting of directory entries. It also updates fzf to use the SortFilesFirst sort mode which improves the output by making it a bit more sorted and grouped by directory previously entries were visited in directory order (which is basically random). The performance impact of sorting is minimal compared to the cost of the syscalls needed to read directories.

PRs Included:

  * https://github.com/charlievieth/fastwalk/pull/25
  * https://github.com/charlievieth/fastwalk/pull/27
  * https://github.com/charlievieth/fastwalk/pull/28