### PR TITLE
CTRL-R: Show timestamp and syntax highlighted command

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -54,7 +54,45 @@ __fzf_cd__() {
   ) && printf 'builtin cd -- %q' "$(builtin unset CDPATH && builtin cd -- "$dir" && builtin pwd)"
 }
 
-if command -v perl > /dev/null; then
+if command -v ruby > /dev/null; then
+  __fzf_history__() {
+    local n output
+    builtin history -w /tmp/fzf-bash-history
+    output=$(
+      ruby -e '
+        fmt = begin
+          require "rouge"
+          formatter = Rouge::Formatters::Terminal256.new(Rouge::Themes::Monokai.new)
+          lexer = Rouge::Lexers::Shell.new
+          lambda { |c| formatter.format(lexer.lex(c)) }
+        rescue LoadError
+          lambda { |c| c }
+        end
+
+        h = {}
+        i = 0
+        File.read("/tmp/fzf-bash-history").scan(/^#([0-9]+)$\n(.*?)\n(?=^#[0-9]+$|\z)/m) do |t, c|
+          next if c.empty?
+          h.delete(c)
+          h[c] = [i += 1, t]
+        end
+        h.to_a.reverse.each do |c, it|
+          i, t = it
+          print "\x1b[33m#{i}\t\x1b[32m#{Time.at(t.to_i).strftime(%[%F %T])}\x1b[m  "
+          print fmt[c.gsub("\n", "\n\t")]
+          print "\0"
+        end
+      ' | FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n1,4.. --ansi --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '"$'\t'"↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} +m --read0") \
+          FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd) --query "$READLINE_LINE" --bind 'enter:become:echo {4..}'
+    ) || return
+    READLINE_LINE=$(command perl -pe 's/^\d*\t//' <<< "$output")
+    if [[ -z "$READLINE_POINT" ]]; then
+      echo "$READLINE_LINE"
+    else
+      READLINE_POINT=0x7fffffff
+    fi
+  }
+elif command -v perl > /dev/null; then
   __fzf_history__() {
     local output script
     script='BEGIN { getc; $/ = "\n\t"; $HISTCOUNT = $ENV{last_hist} + 1 } s/^[ *]//; s/\n/\n\t/gm; print $HISTCOUNT - $. . "\t$_" if !$seen{$_}++'


### PR DESCRIPTION
Close #1049
Close #3836

This is a proof-of-concept implementation of enhanced CTRL-R binding for bash.

## Screenshot

<img width="1516" alt="image" src="https://github.com/user-attachments/assets/703ca41e-7c72-40e8-b51c-954979a5f058">

## Technicals

### HISTTIMEFORMAT performance

```sh
$ HISTTIMEFORMAT='%F %T: '
$ time history | wc -l
   18295

real    0m1.132s
user    0m0.190s
sys     0m0.975s

$ time history > /dev/null

real    0m0.034s
user    0m0.024s
sys     0m0.009s
```

For some reason, `$HISTTIMEFORMAT` makes piping `history` extremely slow. Strangely, there is no slowdown when redirecting the output to another file.

So we can work around this performance problem by writing it to a temp file and then reading it. But...

### Syntax-highlighting of each command

We need to syntax-highlight each command, however, it's not viable to execute an external process such as `bat` for each command.

```sh
# This is extremely slow
while read line; do
  bat --style=plain --no-pager --language=bash <<< "$line"
done < ~/.bash_history
```

It's much faster to pass the whole file to `bat` at once,

```sh
bat --style=plain --no-pager --language=bash ~/.bash_history
```

However, syntax-highlighting quickly breaks down due to malformed commands in history.

### Complexity of the code

The Perl and Awk scripts for de-duplicating the list and handling multi-line commands is already quite complex and not easy to read and maintain. Adding timestamp and syntax-highlighting to it would bring too much complexity.

## Solution

I used Ruby script to implement the enhanced CTRL-R binding. [rouge](https://github.com/rouge-ruby/rouge) gem was used for syntax-highlighting. The code isn't short, but I'd argue that it's still more readable.

## Drawbacks

* Unavailability of Ruby on some systems.
* Yet another dependency: `rouge` gem required for syntax-highlighting.
* Performance. Slow to syntax-highlight many commands.

## Alternatives

* Should we write an external tool for formatting the history file? It would yield better performance, but it's a hard dependency users have to install.
* Embed the functionality in fzf. This avoids an extra dependency, but this is a bad design choice.

## TODO

* How about other shells?