### PR TITLE
fix: Add fallback for cygwin ps

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -410,7 +410,8 @@ _fzf_complete_kill() {
 _fzf_proc_completion() {
   _fzf_complete -m --header-lines=1 --no-preview --wrap -- "$@" < <(
     command ps -eo user,pid,ppid,start,time,command 2> /dev/null ||
-      command ps -eo user,pid,ppid,time,args # For BusyBox
+      command ps -eo user,pid,ppid,time,args 2> /dev/null || # For BusyBox
+      command ps --everyone --full --windows # For cygwin
   )
 }
 

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -300,7 +300,8 @@ _fzf_complete_unalias() {
 _fzf_complete_kill() {
   _fzf_complete -m --header-lines=1 --no-preview --wrap -- "$@" < <(
     command ps -eo user,pid,ppid,start,time,command 2> /dev/null ||
-      command ps -eo user,pid,ppid,time,args # For BusyBox
+      command ps -eo user,pid,ppid,time,args 2> /dev/null || # For BusyBox
+      command ps --everyone --full --windows # For cygwin
   )
 }
 


### PR DESCRIPTION
Description
=======

Add fallback for cygwin version of `ps` command. This should fix the `ps: unknown option -- o` error displayed currently when completing `kill **<tab>`.

![WindowsTerminal_B8BnDksiwt](https://github.com/user-attachments/assets/a5535e23-bcc2-4001-ad04-f3d53f60677c)

Fixes: https://github.com/junegunn/fzf/issues/3924

## Notes

I tried to test the change in zsh completion and the error is indeed gone however I noticed that it doesn't show any content in fzf. I dig a bit and it seems like all of the completions that use `_fzf_complete` have the same issue on my machine, this includes `export **<tab>`, `unalias **<tab>`, `unset **<tab>`, etc.

A cause I can think of is that `mkfifo` is not working the same in windows and that seems to be the mayor difference I see between the bash and zsh completions.

