### PR TITLE
[bash] Enable fuzzy path completion for all commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 CHANGELOG
 =========
 
+0.54.4
+------
+- [bash] Fuzzy path completion is enabled for all commands with no custom completion on bash 4+
+    - However, fuzzy completion for some commands can be "dynamically" disabled by the dynamic completion loader
+    - See the comment in `__fzf_default_completion` function for more information
+- Fixed `--tmux bottom` when the status line is not at the bottom
+- Fixed extra scroll offset in multi-line mode (`--read0` or `--wrap`)
+- Added fallback `ps` command for `kill` completion on Cygwin
+
 0.54.3
 ------
 - Fixed incompatibility of adaptive height specification and 'start:reload'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@ CHANGELOG
 
 0.54.4
 ------
-- [bash] Fuzzy path completion is enabled for all commands with no custom completion on bash 4+
+- [bash] Fuzzy path completion is enabled for all commands
+    - 1. If the default completion is not already set
+    - 2. And if the current bash supports `complete -D` option
     - However, fuzzy completion for some commands can be "dynamically" disabled by the dynamic completion loader
     - See the comment in `__fzf_default_completion` function for more information
 - Fixed `--tmux bottom` when the status line is not at the bottom

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -289,7 +289,7 @@ __fzf_generic_path_completion() {
   fi
   COMPREPLY=()
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
-  cur="${COMP_WORDS[COMP_CWORD]}"
+  [[ $COMP_CWORD -ge 0 ]] && cur="${COMP_WORDS[COMP_CWORD]}"
   if [[ "$cur" == *"$trigger" ]] && [[ $cur != *'$('* ]] && [[ $cur != *':='* ]] && [[ $cur != *'`'* ]]; then
     base=${cur:0:${#cur}-${#trigger}}
     eval "base=$base" 2> /dev/null || return

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -569,4 +569,21 @@ _fzf_setup_completion() {
   done
 }
 
+__fzf_default_completion() {
+  __fzf_generic_path_completion _fzf_compgen_path "-m" "" "$@"
+
+  # Dynamic completion loader has updated the completion for the command
+  if [[ $? -eq 124 ]]; then
+    # We trigger _fzf_setup_completion so that fuzzy completion for the command
+    # still works. However, loader can update the completion for multiple
+    # commands at once, and fuzzy completion will no longer work for those
+    # other commands. e.g. pytest -> py.test, pytest-2, pytest-3, etc
+    _fzf_setup_completion path "$1"
+    return 124
+  fi
+}
+
+# -D option is not available on bash 3
+complete -D -F __fzf_default_completion -o default -o bashdefault 2> /dev/null
+
 fi

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -481,19 +481,46 @@ complete -o default -F _fzf_opts_completion fzf
 # fzf-tmux specific options (like `-w WIDTH`) are left as a future patch.
 complete -o default -F _fzf_opts_completion fzf-tmux
 
+# Default path completion
+__fzf_default_completion() {
+  __fzf_generic_path_completion _fzf_compgen_path "-m" "" "$@"
+
+  # Dynamic completion loader has updated the completion for the command
+  if [[ $? -eq 124 ]]; then
+    # We trigger _fzf_setup_completion so that fuzzy completion for the command
+    # still works. However, loader can update the completion for multiple
+    # commands at once, and fuzzy completion will no longer work for those
+    # other commands. e.g. pytest -> py.test, pytest-2, pytest-3, etc
+    _fzf_setup_completion path "$1"
+    return 124
+  fi
+}
+
+if complete | command grep -q __fzf_default_completion; then
+  : # Default completion already set up. Do nothing.
+elif ! complete | command grep -- '-D$' | command grep -qv _comp_complete_load &&
+       complete -D -F __fzf_default_completion -o default -o bashdefault 2> /dev/null; then
+  a_cmds=""
+else
+  # We can't set up default completion,
+  # 1. if it's already set up by another script
+  # 2. or if the current version of bash doesn't support -D option
+  #
+  # NOTE: $FZF_COMPLETION_PATH_COMMANDS and $FZF_COMPLETION_VAR_COMMANDS are
+  # undocumented and subject to change in the future.
+  a_cmds="${FZF_COMPLETION_PATH_COMMANDS-"
+    awk bat cat code diff diff3
+    emacs emacsclient ex file ftp g++ gcc gvim head hg hx java
+    javac ld less more mvim nvim patch perl python ruby
+    sed sftp sort source tail tee uniq vi view vim wc xdg-open
+    basename bunzip2 bzip2 chmod chown curl cp dirname du
+    find git grep gunzip gzip hg jar
+    ln ls mv open rm rsync scp
+    svn tar unzip zip"}"
+fi
+
 d_cmds="${FZF_COMPLETION_DIR_COMMANDS-cd pushd rmdir}"
 
-# NOTE: $FZF_COMPLETION_PATH_COMMANDS and $FZF_COMPLETION_VAR_COMMANDS are
-# undocumented and subject to change in the future.
-a_cmds="${FZF_COMPLETION_PATH_COMMANDS-"
-  awk bat cat code diff diff3
-  emacs emacsclient ex file ftp g++ gcc gvim head hg hx java
-  javac ld less more mvim nvim patch perl python ruby
-  sed sftp sort source tail tee uniq vi view vim wc xdg-open
-  basename bunzip2 bzip2 chmod chown curl cp dirname du
-  find git grep gunzip gzip hg jar
-  ln ls mv open rm rsync scp
-  svn tar unzip zip"}"
 v_cmds="${FZF_COMPLETION_VAR_COMMANDS-export unset printenv}"
 
 # Preserve existing completion
@@ -568,22 +595,5 @@ _fzf_setup_completion() {
     esac
   done
 }
-
-__fzf_default_completion() {
-  __fzf_generic_path_completion _fzf_compgen_path "-m" "" "$@"
-
-  # Dynamic completion loader has updated the completion for the command
-  if [[ $? -eq 124 ]]; then
-    # We trigger _fzf_setup_completion so that fuzzy completion for the command
-    # still works. However, loader can update the completion for multiple
-    # commands at once, and fuzzy completion will no longer work for those
-    # other commands. e.g. pytest -> py.test, pytest-2, pytest-3, etc
-    _fzf_setup_completion path "$1"
-    return 124
-  fi
-}
-
-# -D option is not available on bash 3
-complete -D -F __fzf_default_completion -o default -o bashdefault 2> /dev/null
 
 fi


### PR DESCRIPTION
All commands with no custom completion defined by setting the default completion function.

Close #3957


```sh
# No completion is defined
complete | grep pytest

# Fuzzy completion works
pytest **<tab>

# Regular completion; triggers dynamic completion loader
pytest <tab>

# Completion function for pytest is loaded
complete | grep pytest
  # complete -F _comp_cmd_pytest py.test
  # complete -F _comp_cmd_pytest py.test-3
  # complete -F _comp_cmd_pytest py.test-2
  # complete -F _comp_cmd_pytest pytest-3
  # complete -F _comp_cmd_pytest pytest-2
  # complete -F _fzf_path_completion pytest

# Fuzzy completion still works
pytest **<tab>

# Regular completion also works
pytest <tab>

# However, fuzzy completion for pytest-2, pytest-3, etc stops working
pytest-2 **<tab>
```