### PR TITLE
fix: support comments in FZF_DEFAULT_OPTS_FILE by sanitizing content

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -2928,7 +2928,16 @@ func ParseOptions(useDefaults bool, args []string) (*Options, error) {
 				return nil, errors.New("$FZF_DEFAULT_OPTS_FILE: " + err.Error())
 			}
 
-			words, parseErr := shellwords.Parse(string(bytes))
+			// Remove comments and blank lines
+			var sanitized strings.Builder
+			lines := strings.Split(string(bytes), "\n")
+			for _, line := range lines {
+				if !strings.HasPrefix(line, "#") && strings.TrimSpace(line) != "" {
+					sanitized.WriteString(line + "\n")
+				}
+			}
+
+			words, parseErr := shellwords.Parse(sanitized.String())
 			if parseErr != nil {
 				return nil, errors.New(path + ": " + parseErr.Error())
 			}


### PR DESCRIPTION
Added a sanitization step to the `FZF_DEFAULT_OPTS_FILE` processing, allowing users to include comments in their configuration.

The sanitizer skips empty lines and lines starting with a `#`, inserting the remaining options into a buffer that will be passed to the parser.

Inline comments are not supported. Additionally, any argument that includes a `#` should remain unaffected by this change.