### PR TITLE
Implement exact-boundary match type

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -36,7 +36,7 @@ jobs:
       run: sudo apt-get install --yes zsh fish tmux
 
     - name: Install Ruby gems
-      run: sudo gem install --no-document minitest:5.17.0 rubocop:1.43.0 rubocop-minitest:0.25.1 rubocop-performance:1.15.2
+      run: sudo gem install --no-document minitest:5.25.1 rubocop:1.65.0 rubocop-minitest:0.35.1 rubocop-performance:1.21.1
 
     - name: Rubocop
       run: rubocop --require rubocop-minitest --require rubocop-performance

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ Lint/ShadowingOuterLocalVariable:
   Enabled: false
 Style/MethodCallWithArgsParentheses:
   Enabled: true
-  IgnoredMethods:
+  AllowedMethods:
     - assert
     - exit
     - paste
@@ -15,7 +15,7 @@ Style/MethodCallWithArgsParentheses:
     - refute
     - require
     - send_keys
-  IgnoredPatterns:
+  AllowedPatterns:
     - ^assert_
     - ^refute_
 Style/NumericPredicate:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ CHANGELOG
 
 0.55.0
 ------
+- Added `exact-boundary-match` type to the search syntax. When a search term is single-quoted, fzf will search for the exact occurrences of the string with both ends at word boundaries.
+  ```sh
+  fzf --query "'here'" << EOF
+  come here
+  not there
+  EOF
+  ```
 - [bash] Fuzzy path completion is enabled for all commands
     - 1. If the default completion is not already set
     - 2. And if the current bash supports `complete -D` option

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ endif
 all: target/$(BINARY)
 
 test: $(SOURCES)
-	[ -z "$$(gofmt -s -d src)" ] || (gofmt -s -d src; exit 1)
 	SHELL=/bin/sh GOOS= $(GO) test -v -tags "$(TAGS)" \
 				github.com/junegunn/fzf/src \
 				github.com/junegunn/fzf/src/algo \
@@ -86,6 +85,10 @@ test: $(SOURCES)
 
 bench:
 	cd src && SHELL=/bin/sh GOOS= $(GO) test -v -tags "$(TAGS)" -run=Bench -bench=. -benchmem
+
+lint: $(SOURCES) test/test_go.rb
+	[ -z "$$(gofmt -s -d src)" ] || (gofmt -s -d src; exit 1)
+	rubocop --require rubocop-minitest --require rubocop-performance
 
 install: bin/fzf
 
@@ -184,4 +187,4 @@ update:
 	$(GO) get -u
 	$(GO) mod tidy
 
-.PHONY: all generate build release test bench install clean docker docker-test update
+.PHONY: all generate build release test bench lint install clean docker docker-test update

--- a/README.md
+++ b/README.md
@@ -376,15 +376,16 @@ Unless otherwise specified, fzf starts in "extended-search mode" where you can
 type in multiple search terms delimited by spaces. e.g. `^music .mp3$ sbtrkt
 !fire`
 
-| Token     | Match type                 | Description                          |
-| --------- | -------------------------- | ------------------------------------ |
-| `sbtrkt`  | fuzzy-match                | Items that match `sbtrkt`            |
-| `'wild`   | exact-match (quoted)       | Items that include `wild`            |
-| `^music`  | prefix-exact-match         | Items that start with `music`        |
-| `.mp3$`   | suffix-exact-match         | Items that end with `.mp3`           |
-| `!fire`   | inverse-exact-match        | Items that do not include `fire`     |
-| `!^music` | inverse-prefix-exact-match | Items that do not start with `music` |
-| `!.mp3$`  | inverse-suffix-exact-match | Items that do not end with `.mp3`    |
+| Token     | Match type                              | Description                                  |
+| --------- | --------------------------------------  | ------------------------------------------   |
+| `sbtrkt`  | fuzzy-match                             | Items that match `sbtrkt`                    |
+| `'wild`   | exact-match (quoted)                    | Items that include `wild`                    |
+| `'wild'`  | exact-boundary-match (quoted both ends) | Items that include `wild` at word boundaries |
+| `^music`  | prefix-exact-match                      | Items that start with `music`                |
+| `.mp3$`   | suffix-exact-match                      | Items that end with `.mp3`                   |
+| `!fire`   | inverse-exact-match                     | Items that do not include `fire`             |
+| `!^music` | inverse-prefix-exact-match              | Items that do not start with `music`         |
+| `!.mp3$`  | inverse-suffix-exact-match              | Items that do not end with `.mp3`            |
 
 If you don't prefer fuzzy matching and do not wish to "quote" every word,
 start fzf with `-e` or `--exact` option. Note that when  `--exact` is set,

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1146,6 +1146,22 @@ A term can be prefixed by \fB^\fR, or suffixed by \fB$\fR to become an
 anchored-match term. Then fzf will search for the lines that start with or end
 with the given string. An anchored-match term is also an exact-match term.
 
+.SS Exact\-boundary\-match (quoted both ends)
+A single-quoted term is interpreted as an "exact\-boundary\-match". fzf will
+search for the exact occurrences of the string with both ends at the word
+boundaries. Unlike in regular expressions, this also sees an underscore as
+a word boundary. But the words around underscores are ranked lower and appear
+later in the result than the other words around the other types of word
+boundaries.
+
+1. xxx foo xxx (highest score)
+.br
+2. xxx foo_xxx
+.br
+3. xxx_foo xxx
+.br
+4. xxx_foo_xxx (lowest score)
+
 .SS Negation
 If a term is prefixed by \fB!\fR, fzf will exclude the lines that satisfy the
 term from the result. In this case, fzf performs exact match by default.

--- a/src/algo/algo.go
+++ b/src/algo/algo.go
@@ -798,6 +798,14 @@ func FuzzyMatchV1(caseSensitive bool, normalize bool, forward bool, text *util.C
 // The solution is much cheaper since there is only one possible alignment of
 // the pattern.
 func ExactMatchNaive(caseSensitive bool, normalize bool, forward bool, text *util.Chars, pattern []rune, withPos bool, slab *util.Slab) (Result, *[]int) {
+	return exactMatchNaive(caseSensitive, normalize, forward, false, text, pattern, withPos, slab)
+}
+
+func ExactMatchBoundary(caseSensitive bool, normalize bool, forward bool, text *util.Chars, pattern []rune, withPos bool, slab *util.Slab) (Result, *[]int) {
+	return exactMatchNaive(caseSensitive, normalize, forward, true, text, pattern, withPos, slab)
+}
+
+func exactMatchNaive(caseSensitive bool, normalize bool, forward bool, boundaryCheck bool, text *util.Chars, pattern []rune, withPos bool, slab *util.Slab) (Result, *[]int) {
 	if len(pattern) == 0 {
 		return Result{0, 0, 0}, nil
 	}
@@ -832,10 +840,19 @@ func ExactMatchNaive(caseSensitive bool, normalize bool, forward bool, text *uti
 		}
 		pidx_ := indexAt(pidx, lenPattern, forward)
 		pchar := pattern[pidx_]
-		if pchar == char {
+		ok := pchar == char
+		if ok {
 			if pidx_ == 0 {
 				bonus = bonusAt(text, index_)
 			}
+			if boundaryCheck {
+				ok = bonus >= bonusBoundary
+				if ok && pidx_ == len(pattern)-1 {
+					ok = index_ == lenRunes-1 || charClassOf(text.Get(index_+1)) <= charDelimiter
+				}
+			}
+		}
+		if ok {
 			pidx++
 			if pidx == lenPattern {
 				if bonus > bestBonus {

--- a/src/pattern.go
+++ b/src/pattern.go
@@ -195,13 +195,9 @@ func parseTerms(fuzzy bool, caseMode Case, normalize bool, str string) []termSet
 			text = text[:len(text)-1]
 		}
 
-		if fuzzy && len(text) > 2 && strings.HasPrefix(text, "'") && strings.HasSuffix(text, "'") ||
-			!fuzzy && !strings.HasPrefix(text, "'") && strings.HasSuffix(text, "'") {
+		if len(text) > 2 && strings.HasPrefix(text, "'") && strings.HasSuffix(text, "'") {
 			typ = termExactBoundary
-			if fuzzy {
-				text = text[1:]
-			}
-			text = text[:len(text)-1]
+			text = text[1 : len(text)-1]
 		} else if strings.HasPrefix(text, "'") {
 			// Flip exactness
 			if fuzzy && !inv {

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -3366,6 +3366,14 @@ class TestGoFZF < TestBase
     tmux.send_keys :Space
     tmux.until { |lines| assert_includes lines[-3], 'bar' }
   end
+
+  def test_boundary_match
+    # Underscore boundaries should be ranked lower
+    assert_equal(
+      %w[[x] -x- -x_ _x- _x_],
+      `printf -- 'xxx\n-xx\nxx-\n_x_\n_x-\n-x_\n[x]\n-x-\n' | #{FZF} -f"'x'"`.lines(chomp: true)
+    )
+  end
 end
 
 module TestShell

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -3369,10 +3369,14 @@ class TestGoFZF < TestBase
 
   def test_boundary_match
     # Underscore boundaries should be ranked lower
-    assert_equal(
-      %w[[x] -x- -x_ _x- _x_],
-      `printf -- 'xxx\n-xx\nxx-\n_x_\n_x-\n-x_\n[x]\n-x-\n' | #{FZF} -f"'x'"`.lines(chomp: true)
-    )
+    {
+      default: [' x '] + %w[/x/ [x] -x- -x_ _x- _x_],
+      path: ['/x/', ' x '] + %w[[x] -x- -x_ _x- _x_],
+      history: ['[x]', '-x-', ' x '] + %w[/x/ -x_ _x- _x_]
+    }.each do |scheme, expected|
+      result = `printf -- 'xxx\n-xx\nxx-\n_x_\n_x-\n-x_\n[x]\n-x-\n x \n/x/\n' | #{FZF} -f"'x'" --scheme=#{scheme}`.lines(chomp: true)
+      assert_equal expected, result
+    end
   end
 end
 


### PR DESCRIPTION
Close #3963

This implements the `exact-boundary` match type, which finds exact matches for a search term where both ends are at word boundaries. `Exact-boundary` term should start with `'` and end with `'`.

* I specifically didn't choose `"TERM"` because I often use such patterns to search for string literals in the source code.
    * We couldn't do the same with `'TERM'` before, so we're not breaking a use case here.
* In `--exact` mode, `'` prefix enables fuzzy matching, so `exact-boundary` term should be in `TERM'` form.
   * This is not ideal, considering cases where you type `it's`.
* Should we allow partial boundary matches? i.e. only one end at a word boundary.