### PR TITLE
Update README.md: Add x-cmd method to install fzf

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Table of Contents
     * [Linux packages](#linux-packages)
     * [Windows packages](#windows-packages)
     * [Using git](#using-git)
+    * [Using x-cmd](#using-x-cmd)
     * [Binary releases](#binary-releases)
     * [Setting up shell integration](#setting-up-shell-integration)
     * [Vim/Neovim plugin](#vimneovim-plugin)
@@ -171,6 +172,14 @@ git clone --depth 1 https://github.com/junegunn/fzf.git ~/.fzf
 
 The install script will add lines to your shell configuration file to modify
 `$PATH` and set up shell integration.
+
+### Using x-cmd
+
+[x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
+
+```sh
+x env use fzf
+```
 
 ### Binary releases
 


### PR DESCRIPTION
- Hi, we have implemented a lightweight [package manager using shell and awk](https://www.x-cmd.com/pkg/). It helps you download fzf release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the fzf installation.md?**[The installation method for the x command](https://www.x-cmd.com/start/) and [fzf demo](https://www.x-cmd.com/1min/fzf).
  ```sh
  x env use fzf
  ```