### PR TITLE
Update fastwalk to v1.0.9 to fix handling of disk root paths on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/junegunn/fzf
 
 require (
-	github.com/charlievieth/fastwalk v1.0.8
+	github.com/charlievieth/fastwalk v1.0.9
 	github.com/gdamore/tcell/v2 v2.7.4
 	github.com/junegunn/go-shellwords v0.0.0-20240813092932-a62c48c52e97
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/charlievieth/fastwalk v1.0.8 h1:uaoH6cAKSk73aK7aKXqs0+bL+J3Txzd3NGH8tRXgHko=
-github.com/charlievieth/fastwalk v1.0.8/go.mod h1:yGy1zbxog41ZVMcKA/i8ojXLFsuayX5VvwhQVoj9PBI=
+github.com/charlievieth/fastwalk v1.0.9 h1:Odb92AfoReO3oFBfDGT5J+nwgzQPF/gWAw6E6/lkor0=
+github.com/charlievieth/fastwalk v1.0.9/go.mod h1:yGy1zbxog41ZVMcKA/i8ojXLFsuayX5VvwhQVoj9PBI=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=
 github.com/gdamore/encoding v1.0.0/go.mod h1:alR0ol34c49FCSBLjhosxzcPHQbf2trDkoo5dl+VrEg=
 github.com/gdamore/tcell/v2 v2.7.4 h1:sg6/UnTM9jGpZU+oFYAsDahfchWAFW8Xx2yFinNSAYU=


### PR DESCRIPTION
Update fastwalk to [v1.0.9](https://github.com/charlievieth/fastwalk/releases/tag/v1.0.9).

This fixes an issue on Windows when the argument to `--walker-root` was the root of a disk drive (e.g. `C:\`). Instead of walking the disk root `C:\` it walked the current directory. This occurred because we were transforming the fully qualified path `C:\` to the relative path `C:` which caused the current directory to be walked ([docs](https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file#fully-qualified-vs-relative-paths)).

Fixes: https://github.com/junegunn/fzf/issues/4027