### PR TITLE
Update fzf.vim - support nushell

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -171,7 +171,14 @@ function s:get_version(bin)
   if has_key(s:versions, a:bin)
     return s:versions[a:bin]
   end
-  let command = (&shell =~ 'powershell\|pwsh' ? '&' : '') . s:fzf_call('shellescape', a:bin) . ' --version --no-height'
+  if &shell =~ 'powershell\|pwsh'
+    let command = '& ' . s:fzf_call('shellescape', a:bin) . ' --version --no-height'
+  elseif &shell =~# '\<nu\>$'
+    let command = [a:bin, '--version', '--no-height']
+  else
+    let command = s:fzf_call('shellescape', a:bin) . ' --version --no-height'
+  endif
+
   let output = systemlist(command)
   if v:shell_error || empty(output)
     return ''


### PR DESCRIPTION
This closes #4066, adding support for nushell in the fzf plugin.

I've taken care to ensure that behavior for other shells will not be modified.