### PR TITLE
reader: Fixed race condition

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -299,6 +299,7 @@ func Run(opts *Options) (int, error) {
 		itemIndex = 0
 		inputRevision.bumpMajor()
 		header = make([]string, 0, opts.HeaderLines)
+		reader.reset()
 		go reader.restart(command, environ)
 	}
 


### PR DESCRIPTION
reader: Fixed race condition where reader would be terminated before it was properly initialized.

Currently, when reloading input very quickly (happens when updating the prompt quickly with 'reload' bound to 'change') it is possible for the reader's terminate method to be called before readFromCommand properly spawns the new reader process. This means the process is never killed and input is not reloaded until the process completes naturally or another 'EvtSearchNew' is triggered.

An example where this becomes a problem is when using fzf with rg integration and searching a large directory. Occasionally, the query being processed by rg is not the same as the query displayed by fzf and only after further modifying the query or waiting until rg finishes will the input reload to the correct state. This commit introduces a 'started' condition that the terminate method will wait for before trying to kill the process. The 'started' condition is signalled only when the reader reaches a state where it can be safely terminated.