### PR TITLE
fix(zsh): history loading with shared option

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -108,9 +108,13 @@ fi
 fzf-history-widget() {
   local selected
   setopt localoptions noglobsubst noposixbuiltins pipefail no_aliases noglob nobash_rematch 2> /dev/null
-  # Ensure the associative history array, which maps event numbers to the full
-  # history lines, is loaded, and that Perl is installed for multi-line output.
-  if zmodload -F zsh/parameter p:history 2>/dev/null && (( ${#commands[perl]} )); then
+  # Ensure the module is loaded if not already, and the required features, such
+  # as the associative 'history' array, which maps event numbers to full history
+  # lines, are set. Also, make sure Perl is installed for multi-line output.
+  if zmodload -F zsh/parameter p:{commands,history,options} 2>/dev/null && (( ${#commands[perl]} )); then
+    # Import commands from other shells if SHARE_HISTORY is enabled, as the
+    # 'history' array only updates after executing a non-empty command.
+    [[ "${options[sharehistory]}" == "on" ]] && fc -RI
     selected="$(printf '%s\t%s\000' "${(kv)history[@]}" |
       perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
       FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \


### PR DESCRIPTION
### description

One of the `zsh` maintainers confirmed the use of `fc -RI` to resolve #4061.

Tested on 5.9 (latest release) and 5.0.1.

There is a bit of peculiarity, as the `history` array stands out as the only one among the history-related commands and widgets that needs a non-empty command to be entered in order to be updated.

https://zsh.org/mla/users/2024/msg00692.html

---

The changes should be sufficiently explained by the comments and the variable names themselves. Alternatively, the man pages for reading up on the syntax are listed below, and important aspects were extracted for ease of review.

```sh
# explains 'fc -RI'
man 1 zshbuiltins | less --pattern fc
# […] If the -I option is  added  to  -R,  onlythose  events that are
# not already contained within the internal history list are added.[…]

# explains 'zmodload -F … p:{…,…}
man 1 zshbuiltins | less --pattern zmodload
# Performs operations relating to zsh's loadable modules.  Loading
# of  modules  while the shell is running (`dynamical loading') is
# not available on all operating systems, or on all  installations
# on  a particular operating system […]

# zmodload  -F  allows more selective control over the fea-
# tures provided by modules.  With no  options  apart  from
# -F,  the  module  named  module  is loaded, if it was not
# already loaded, and the list of features is  set  to  the
# required state.  If no features are specified, the module
# is loaded, if it was not already loaded, but the state of
# features is unchanged.  Each feature may be preceded by a
# + to turn the feature on, or - to turn it off; the  +  is
# assumed if neither character is present.  Any feature not
# explicitly mentioned is left in its current state; if the
# module was not previously loaded this means any such fea-
# tures will remain disabled.  The return status is zero if
# all  features  were  set, 1 if the module failed to load,
# and 2 if some features could not be set […]

# The standard features are builtins,  conditions,  parame-
# ters  and math functions; these are indicated by the pre-
# fix `b:', `c:' (`C:' for an infix  condition),  `p:'  and
# `f:',  respectively, followed by the name that the corre-
# sponding feature would have in the shell.   For  example,
# `b:strftime'  indicates  a  builtin  named  strftime  and
# p:EPOCHSECONDS indicates a parameter named  EPOCHSECONDS.

# lists the cool things this module gives us
man 1 zshmodules | less --pattern "THE ZSH/PARAMETER MODULE"

# more context to the option
man 1 zshoptions | less --pattern SHARE_HISTORY
```

---

PS: It's possible for a user to explicitly disable a feature in their shell setup, which I can't imagine why anyone would ever do this.

```sh
# the module is loaded but the 'history' feature is disabled
zmodload -F zsh/parameter -p:history
zmodload -Fe zsh/parameter +p:history || echo "feature disabled"
# feature disabled
```

Currently, the code loads the module if not already, and the features are set. If this causes issues, which I currently don't foresee, we could modify the command to only check if the modules and features are enabled without enabling them:

```sh
if zmodload -Fe zsh/parameter +p:{commands,history,options} && …
  …
```
