### PR TITLE
fix(zsh): move 'fc -RI' inside command substitution

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -111,10 +111,13 @@ fzf-history-widget() {
   # Ensure the module is loaded if not already, and the required features, such
   # as the associative 'history' array, which maps event numbers to full history
   # lines, are set. Also, make sure Perl is installed for multi-line output.
-  if zmodload -F zsh/parameter p:{commands,history,options} 2>/dev/null && (( ${#commands[perl]} )); then
+  if zmodload -F zsh/parameter p:{commands,history} 2>/dev/null && (( ${#commands[perl]} )); then
     # Import commands from other shells if SHARE_HISTORY is enabled, as the
     # 'history' array only updates after executing a non-empty command.
-    selected="$([[ "${options[sharehistory]}" == "on" ]] && fc -RI
+    selected="$(
+      if [[ -o sharehistory ]]; then
+        fc -RI
+      fi
       printf '%s\t%s\000' "${(kv)history[@]}" |
         perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
         FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -114,11 +114,11 @@ fzf-history-widget() {
   if zmodload -F zsh/parameter p:{commands,history,options} 2>/dev/null && (( ${#commands[perl]} )); then
     # Import commands from other shells if SHARE_HISTORY is enabled, as the
     # 'history' array only updates after executing a non-empty command.
-    [[ "${options[sharehistory]}" == "on" ]] && fc -RI
-    selected="$(printf '%s\t%s\000' "${(kv)history[@]}" |
-      perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
-      FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \
-      FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd))"
+    selected="$([[ "${options[sharehistory]}" == "on" ]] && fc -RI
+      printf '%s\t%s\000' "${(kv)history[@]}" |
+        perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
+        FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \
+        FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd))"
   else
     selected="$(fc -rl 1 | awk '{ cmd=$0; sub(/^[ \t]*[0-9]+\**[ \t]+/, "", cmd); if (!seen[cmd]++) print $0 }' |
       FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m") \


### PR DESCRIPTION
### description
- hotfix for #4071

When the selection of <kbd>⌃</kbd><kbd>R</kbd> is aborted with <kbd>Escape</kbd>, the widget assigned to the <kbd>↑</kbd> (up arrow key), which is by default `up-line-or-history`, ignores any input.

I don't have an explanation for why this occurs, and why it only happens in combination with the `-I` flag on the `fc` builtin command.

Moving it inside the command substitution alleviates the issue.

Related widget with `fc -RI` usage:
https://zsh.org/mla/users/2021/msg00186.html

---

### to reproduce the issue

1. Start a new session and paste the following:

```bash
test-widget() {
	fc -RI
}
zle -N test-widget

bindkey '^p' test-widget
bindkey '^[[A' up-line-or-history
```

2. Press <kbd>⌃</kbd><kbd>P</kbd>.
3. Press <kbd>↑</kbd>; notice that nothing happens.

The issue doesn't occur in an environment where the `HISTFILE` is undefined or the assigned file is empty.
