### PR TITLE
Add 'FZF_GLOBAL_POS' environment variable

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1106,7 +1106,9 @@ fzf exports the following environment variables to its child processes.
 .br
 .BR FZF_SELECT_COUNT "    Number of selected items"
 .br
-.BR FZF_POS "             Vertical position of the cursor in the list starting from 1"
+.BR FZF_POS "             Vertical position of the cursor in the filtered list starting from 1"
+.br
+.BR FZF_GLOBAL_POS "      Vertical position of the cursor in the original (unfiltered) list starting from 1"
 .br
 .BR FZF_QUERY "           Current query string"
 .br

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -956,6 +956,12 @@ func (t *Terminal) environ() []string {
 	if t.listenPort != nil {
 		env = append(env, fmt.Sprintf("FZF_PORT=%d", *t.listenPort))
 	}
+	var global_pos string
+	if t.currentIndex() >= 0 {
+		global_pos = strconv.Itoa(int(t.currentIndex() + 1))
+	} else {
+		global_pos = ""
+	}
 	env = append(env, "FZF_QUERY="+string(t.input))
 	env = append(env, "FZF_ACTION="+t.lastAction.Name())
 	env = append(env, "FZF_KEY="+t.lastKey)
@@ -968,6 +974,7 @@ func (t *Terminal) environ() []string {
 	env = append(env, fmt.Sprintf("FZF_LINES=%d", t.areaLines))
 	env = append(env, fmt.Sprintf("FZF_COLUMNS=%d", t.areaColumns))
 	env = append(env, fmt.Sprintf("FZF_POS=%d", util.Min(t.merger.Length(), t.cy+1)))
+	env = append(env, fmt.Sprintf("FZF_GLOBAL_POS=%s", global_pos))
 	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_LINE=%d", t.clickHeaderLine))
 	env = append(env, fmt.Sprintf("FZF_CLICK_HEADER_COLUMN=%d", t.clickHeaderColumn))
 	return env

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -3292,6 +3292,17 @@ class TestGoFZF < TestBase
     tmux.until { |lines| assert(lines.any? { |line| line.include?('0 / 0') }) }
   end
 
+  def test_fzf_global_pos
+    tmux.send_keys "seq 100 | #{FZF} --query '9$' --preview 'echo Global:${FZF_GLOBAL_POS}:'", :Enter
+    tmux.until { |lines| assert(lines.any? { |line| line.include?('Global:9:') }) }
+    tmux.send_keys :Up
+    tmux.until { |lines| assert(lines.any? { |line| line.include?('Global:19:') }) }
+    tmux.send_keys :Up
+    tmux.until { |lines| assert(lines.any? { |line| line.include?('Global:29:') }) }
+    tmux.send_keys :BSpace, :BSpace, "invalid"
+    tmux.until { |lines| assert(lines.any? { |line| line.include?('Global::') }) }
+  end
+
   def test_fzf_multi_line
     tmux.send_keys %[(echo -en '0\\0'; echo -en '1\\n2\\0'; seq 1000) | fzf --read0 --multi --bind load:select-all --border rounded], :Enter
     block = <<~BLOCK


### PR DESCRIPTION
This env variable can be helpful in a variety of cases for example, for highlighting the original line as part of the preview panel.  

The current `FZF_POS` variable only tracks the index of the selected item _as part of the filtered-down list_ instead of the index in the original list/file. That's why `FZF_GLOBAL_POS` is added, which adds the ability to track the original index.

Changes: 
- Added support to the Terminal source file
- Added tests and man page snippets.

Please let me know if you have any coding/style feedback especially regarding the `global_pos` string variable in `terminal.go`