### PR TITLE
Allow specifying '{n}' as the OFFSET in the preview-window flag

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -805,7 +805,7 @@ e.g. \fBborder\-rounded\fR (border with rounded edges, default),
 * \fB[:+SCROLL[OFFSETS][/DENOM]]\fR determines the initial scroll offset of the
 preview window.
 
-  - \fBSCROLL\fR can be either a numeric integer or a single-field index expression that refers to a numeric integer.
+  - \fBSCROLL\fR can be either a numeric integer or a single-field index expression that refers to a numeric integer or {n} to refer to the zero-based ordinal index of the current item.
 
   - The optional \fBOFFSETS\fR part is for adjusting the base offset. It should be given as a series of signed integers (\fB\-INTEGER\fR or \fB+INTEGER\fR).
 

--- a/src/options.go
+++ b/src/options.go
@@ -1726,7 +1726,7 @@ func parsePreviewWindowImpl(opts *previewOpts, input string) error {
 	var err error
 	tokenRegex := regexp.MustCompile(`[:,]*(<([1-9][0-9]*)\(([^)<]+)\)|[^,:]+)`)
 	sizeRegex := regexp.MustCompile("^[0-9]+%?$")
-	offsetRegex := regexp.MustCompile(`^(\+{-?[0-9]+})?([+-][0-9]+)*(-?/[1-9][0-9]*)?$`)
+	offsetRegex := regexp.MustCompile(`^(\+{(-?[0-9]+|n)})?([+-][0-9]+)*(-?/[1-9][0-9]*)?$`)
 	headerRegex := regexp.MustCompile("^~(0|[1-9][0-9]*)$")
 	tokens := tokenRegex.FindAllStringSubmatch(input, -1)
 	var alternative string


### PR DESCRIPTION
This feature can be useful in scrolling to the selected line in the preview window.

For example, it can be used to use fzf as a quick filtering tool for large files while keeping an eye on the selected line as it shows up in the original file.

Example usage:
```bash
man fzf | tee /tmp/tmp.log | fzf \
  --reverse \
  --exact \
  --query 'position' \
  --preview 'bat --force-colorization /tmp/tmp.log --highlight-line $(({n}+1))' \
  --preview-window '+{n}/2'
```