### PR TITLE
docker: fix dockerfile warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,5 @@ RUN echo '. ~/.bashrc' >> ~/.bash_profile
 RUN rm -f /etc/bash.bashrc
 COPY . /fzf
 RUN cd /fzf && make install && ./install --all
-ENV LANG C.UTF-8
-CMD tmux new 'set -o pipefail; ruby /fzf/test/test_go.rb | tee out && touch ok' && cat out && [ -e ok ]
+ENV LANG=C.UTF-8
+CMD ["bash", "-ic", "tmux new 'set -o pipefail; ruby /fzf/test/test_go.rb | tee out && touch ok' && cat out && [ -e ok ]"]


### PR DESCRIPTION
The following warnings were emitted when running `make docker-test`:
```
 2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 11)
 - JSONArgsRecommended: JSON arguments recommended for CMD to prevent unintended behavior related to OS signals (line 12)
```

This change fixes both of these 2 trivial warnings.

I added the bash `-i` option just in case some of the tests/tools care about whether the shell is an interactive shell or not.  
Even though the tests passed successfully without that flag, I thought I'd add it just in case. It only added 0.5s to the total test time (64.8s -> 65.3s) so it's probably good to keep. Please let me know if you'd want me to remove it.