### PR TITLE
refactor: simplify command extraction in zsh completion

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -308,8 +308,10 @@ fzf-completion() {
   setopt localoptions noshwordsplit noksh_arrays noposixbuiltins
 
   # Check if at least one completion system (old or new) is active
-  if ! zmodload -e zsh/compctl || ! (( $+functions[compdef] )); then
-    zmodload -i zsh/compctl
+  if ! zmodload -F zsh/parameter p:functions 2>/dev/null || ! (( $+functions[compdef] )); then
+    if ! zmodload -e zsh/compctl; then
+      zmodload -i zsh/compctl
+    fi
   fi
   # http://zsh.sourceforge.net/FAQ/zshfaq03.html
   # http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion-Flags

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -307,10 +307,9 @@ fzf-completion() {
   local tokens prefix trigger tail matches lbuf d_cmds
   setopt localoptions noshwordsplit noksh_arrays noposixbuiltins
 
-  # TODO: To successfully complete 'test_dir_completion', add an explanation!
-  # It has to do with the presence of 'zle -C …' 
-  if ! zmodload -Fe zsh/{complete,compctl}; then
-    zmodload -i zsh/{complete,compctl}
+  # Check if at least one completion system (old or new) is active
+  if ! zmodload -e zsh/compctl || ! (( $+functions[compdef] )); then
+    zmodload -i zsh/compctl
   fi
   # http://zsh.sourceforge.net/FAQ/zshfaq03.html
   # http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion-Flags

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -307,6 +307,11 @@ fzf-completion() {
   local tokens prefix trigger tail matches lbuf d_cmds
   setopt localoptions noshwordsplit noksh_arrays noposixbuiltins
 
+  # TODO: To successfully complete 'test_dir_completion', add an explanation!
+  # It has to do with the presence of 'zle -C …' 
+  if ! zmodload -Fe zsh/{complete,compctl}; then
+    zmodload -i zsh/{complete,compctl}
+  fi
   # http://zsh.sourceforge.net/FAQ/zshfaq03.html
   # http://zsh.sourceforge.net/Doc/Release/Expansion.html#Parameter-Expansion-Flags
   tokens=(${(z)LBUFFER})

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -120,25 +120,19 @@ __fzf_comprun() {
   fi
 }
 
-# Extract the name of the command. e.g. foo=1 bar baz**<tab>
+# Extract the name of the command. e.g. ls; foo=1 ssh **<tab>
 __fzf_extract_command() {
-  local token tokens
-  tokens=(${(z)1})
-  for token in $tokens; do
-    token=${(Q)token}
-    if [[ "$token" =~ [[:alnum:]] && ! "$token" =~ "=" ]]; then
-      echo "$token"
-      return
-    fi
-  done
-  echo "${tokens[1]}"
+  setopt localoptions noksh_arrays
+  # Control completion with the "compstate" parameter, insert and list noting
+  compstate[insert]=
+  compstate[list]=
+  cmd_word="${words[1]}"
 }
 
 __fzf_generic_path_completion() {
-  local base lbuf cmd compgen fzf_opts suffix tail dir leftover matches
+  local base lbuf compgen fzf_opts suffix tail dir leftover matches
   base=$1
   lbuf=$2
-  cmd=$(__fzf_extract_command "$lbuf")
   compgen=$3
   fzf_opts=$4
   suffix=$5
@@ -161,7 +155,7 @@ __fzf_generic_path_completion() {
         FZF_DEFAULT_OPTS=$(__fzf_defaults "--reverse --scheme=path" "${FZF_COMPLETION_OPTS-}")
         unset FZF_DEFAULT_COMMAND FZF_DEFAULT_OPTS_FILE
         if declare -f "$compgen" > /dev/null; then
-          eval "$compgen $(printf %q "$dir")" | __fzf_comprun "$cmd" ${(Q)${(Z+n+)fzf_opts}} -q "$leftover"
+          eval "$compgen $(printf %q "$dir")" | __fzf_comprun "$cmd_word" ${(Q)${(Z+n+)fzf_opts}} -q "$leftover"
         else
           if [[ $compgen =~ dir ]]; then
             walker=dir,follow
@@ -170,7 +164,7 @@ __fzf_generic_path_completion() {
             walker=file,dir,follow,hidden
             rest=${FZF_COMPLETION_PATH_OPTS-}
           fi
-          __fzf_comprun "$cmd" ${(Q)${(Z+n+)fzf_opts}} -q "$leftover" --walker "$walker" --walker-root="$dir" ${(Q)${(Z+n+)rest}} < /dev/tty
+          __fzf_comprun "$cmd_word" ${(Q)${(Z+n+)fzf_opts}} -q "$leftover" --walker "$walker" --walker-root="$dir" ${(Q)${(Z+n+)rest}} < /dev/tty
         fi | while read -r item; do
           item="${item%$suffix}$suffix"
           echo -n -E "${(q)item} "
@@ -227,10 +221,9 @@ _fzf_complete() {
     rest=("$@")
   fi
 
-  local fifo lbuf cmd matches post
+  local fifo lbuf matches post
   fifo="${TMPDIR:-/tmp}/fzf-complete-fifo-$$"
   lbuf=${rest[0]}
-  cmd=$(__fzf_extract_command "$lbuf")
   post="${funcstack[1]}_post"
   type $post > /dev/null 2>&1 || post=cat
 
@@ -238,7 +231,7 @@ _fzf_complete() {
   matches=$(
     FZF_DEFAULT_OPTS=$(__fzf_defaults "--reverse" "${FZF_COMPLETION_OPTS-} $str_arg") \
     FZF_DEFAULT_OPTS_FILE='' \
-      __fzf_comprun "$cmd" "${args[@]}" -q "${(Q)prefix}" < "$fifo" | $post | tr '\n' ' ')
+      __fzf_comprun "$cmd_word" "${args[@]}" -q "${(Q)prefix}" < "$fifo" | $post | tr '\n' ' ')
   if [ -n "$matches" ]; then
     LBUFFER="$lbuf$matches"
   fi
@@ -310,7 +303,8 @@ _fzf_complete_kill_post() {
 }
 
 fzf-completion() {
-  local tokens cmd prefix trigger tail matches lbuf d_cmds
+  trap 'unset cmd_word' EXIT
+  local tokens prefix trigger tail matches lbuf d_cmds
   setopt localoptions noshwordsplit noksh_arrays noposixbuiltins
 
   # http://zsh.sourceforge.net/FAQ/zshfaq03.html
@@ -320,8 +314,6 @@ fzf-completion() {
     zle ${fzf_default_completion:-expand-or-complete}
     return
   fi
-
-  cmd=$(__fzf_extract_command "$LBUFFER")
 
   # Explicitly allow for empty trigger.
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
@@ -340,16 +332,20 @@ fzf-completion() {
   if [ ${#tokens} -gt 1 -a "$tail" = "$trigger" ]; then
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS-cd pushd rmdir})
 
+    # Make the 'cmd_word' global
+    zle __fzf_extract_command || :
+    [[ -z "$cmd_word" ]] && return
+
     [ -z "$trigger"      ] && prefix=${tokens[-1]} || prefix=${tokens[-1]:0:-${#trigger}}
     if [[ $prefix = *'$('* ]] || [[ $prefix = *'<('* ]] || [[ $prefix = *'>('* ]] || [[ $prefix = *':='* ]] || [[ $prefix = *'`'* ]]; then
       return
     fi
     [ -n "${tokens[-1]}" ] && lbuf=${lbuf:0:-${#tokens[-1]}}
 
-    if eval "type _fzf_complete_${cmd} > /dev/null"; then
-      prefix="$prefix" eval _fzf_complete_${cmd} ${(q)lbuf}
+    if eval "type _fzf_complete_${cmd_word} > /dev/null"; then
+      prefix="$prefix" eval _fzf_complete_${cmd_word} ${(q)lbuf}
       zle reset-prompt
-    elif [ ${d_cmds[(i)$cmd]} -le ${#d_cmds} ]; then
+    elif [ ${d_cmds[(i)$cmd_word]} -le ${#d_cmds} ]; then
       _fzf_dir_completion "$prefix" "$lbuf"
     else
       _fzf_path_completion "$prefix" "$lbuf"
@@ -366,6 +362,9 @@ fzf-completion() {
   unset binding
 }
 
+# Completion widget to gain access to the 'words' array (man zshcompwid)
+zle     -C   __fzf_extract_command .complete-word __fzf_extract_command
+# Normal widget
 zle     -N   fzf-completion
 bindkey '^I' fzf-completion
 fi

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -111,7 +111,7 @@ fzf-history-widget() {
   # Ensure the module is loaded if not already, and the required features, such
   # as the associative 'history' array, which maps event numbers to full history
   # lines, are set. Also, make sure Perl is installed for multi-line output.
-  if zmodload -F zsh/parameter p:{commands,history} 2>/dev/null && (( ${#commands[perl]} )); then
+  if zmodload -F zsh/parameter p:{commands,history} 2>/dev/null && (( $+commands[perl] )); then
     # Import commands from other shells if SHARE_HISTORY is enabled, as the
     # 'history' array only updates after executing a non-empty command.
     selected="$(


### PR DESCRIPTION
### Description

- Resolve #1992

The idea is to gain acces to the `words` array.

```bash
man 1 zshcompwid | less --pattern="^\s+words"
#   words  This  array  contains the words present on the command line currently being edited.
```

The great thing about this array is that the first element contains the name of
the command. The only downside is that the `words` array is available only in
`user-defined completion widgets`, which are created with `zle -C`, as opposed
to `user-defined widgets` created with `zle -N`.

In a command like `ls; foo=bar kill **[TAB]`, `words[1]` will be `kill`.

To understand how the `words` array is constructed, one must read the `zsh`
source code[^1].

> […] the completion system has already done the hard job (and that's not an
> overstatement, I can tell you) of deciding what makes up a word on the command
> line, taking into account quoting and special characters. The array of words
> is stored, unsurprisingly, in the array $words.[…]
>
> **Source:** A User's Guide to the Z-Shell - Chapter 6: Completion[^2]

---

### Notes

Does that mean the user has to run `autoload -Uz compinit && compinit` in their
setup to use `fzf`'s completion from now on?

**NO.**

The **new zsh completion system** basically relies on shell functions, and all
of them become available as soon as the user calls `compinit`. Since we don't
use any of these functions here, nothing in the setup changes.

The `fzf` completion system is designed to be quite minimal for a couple of
commands, like `kill`, and to be easily extended with a shell function.

> Zsh's system has become more and more sophisticated, and in version 3.1.6 a
> new completion system appeared which is supposed to do everything for you: you
> simply call a function, compinit, from an initialization file, after which zsh
> knows, for example, that gunzip should be followed by files ending in .gz. The
> new system is based on shell functions, an added bonus since they are
> extremely flexible and you already know the syntax. However, given the
> complexity it's quite difficult to get started writing your own completions
> now, and hard enough to know what to do to change the settings the way you
> like.
>
> **Source:** A User's Guide to the Z-Shell - Chapter 6: Completion[^2]

There is a very nice debug hotkey one can press, `control-X + ?`, and it will
list the function calls in a debug file.

```bash
man 1 zshcompsys | less --pattern _complete_debug
```

In the debug example below, we actually see that `zsh` also relies on the
`words` array in their `_set_command`[^3] function to extract the command that
shall be completed, and this is where the entire idea for this patch came from.

```bash
command env -i HOME=$HOME TERM=$TERM USER=$USER PATH=$PATH PAGER=$PAGER zsh -f
autoload -Uz compinit && compinit

# Enter a command, for example 'ls' and press 'control-X + ?'
ls [^X?]
# Trace output left in /tmp/zsh58725ls1 (up-history to view)
# ...

less /tmp/zsh58725ls1 ;: 'ls '
# ...
#   +_normal:37> _set_command
#    +_set_command:6> local command
#    +_set_command:8> command=ls
# ...
```

[^1]: [zsh/Code - Src/Zle/complete.c](https://sourceforge.net/p/zsh/code/ci/master/tree/Src/Zle/complete.c#l1249)
[^2]: [A User's Guide to the Z-Shell - Chapter 6: Completion, old and new](https://zsh.sourceforge.io/Guide/zshguide06.html)
[^3]: [zsh/Code - Completion/Base/Utility/_set_command](https://sourceforge.net/p/zsh/code/ci/master/tree/Completion/Base/Utility/_set_command)
