### PR TITLE
fix zsh $+commands[perl] syntax does not work with setopt ksh_arrays

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -308,7 +308,7 @@ fzf-completion() {
   setopt localoptions noshwordsplit noksh_arrays noposixbuiltins
 
   # Check if at least one completion system (old or new) is active
-  if ! zmodload -F zsh/parameter p:functions 2>/dev/null || ! (( $+functions[compdef] )); then
+  if ! zmodload -F zsh/parameter p:functions 2>/dev/null || ! (( ${+functions[compdef]} )); then
     if ! zmodload -e zsh/compctl; then
       zmodload -i zsh/compctl
     fi

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -111,7 +111,7 @@ fzf-history-widget() {
   # Ensure the module is loaded if not already, and the required features, such
   # as the associative 'history' array, which maps event numbers to full history
   # lines, are set. Also, make sure Perl is installed for multi-line output.
-  if zmodload -F zsh/parameter p:{commands,history} 2>/dev/null && (( $+commands[perl] )); then
+  if zmodload -F zsh/parameter p:{commands,history} 2>/dev/null && (( ${+commands[perl]} )); then
     # Import commands from other shells if SHARE_HISTORY is enabled, as the
     # 'history' array only updates after executing a non-empty command.
     selected="$(


### PR DESCRIPTION
When `setopt ksh_arrays` in zsh, the syntax `$+commands[perl]` doesn't work properly and gives a syntax warning saying `fzf-history-widget:6: bad output format specification`

I think the everything else still actually works, just the warning is a bit annoying.

I have setopt ksh_arrays set in my zshrc.