### PR TITLE
fix(zsh): handle backtick trigger edge case

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -126,7 +126,7 @@ __fzf_extract_command() {
   # Control completion with the "compstate" parameter, insert and list nothing
   compstate[insert]=
   compstate[list]=
-  cmd_word="${words[1]}"
+  cmd_word="${(Q)words[1]}"
 }
 
 __fzf_generic_path_completion() {
@@ -338,8 +338,8 @@ fzf-completion() {
   if [ ${#tokens} -gt 1 -a "$tail" = "$trigger" ]; then
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS-cd pushd rmdir})
 
-    # Move the cursor before the trigger to maintain word array elements when
-    # trigger characters like ';' or '`' reset the array.
+    # Move the cursor before the trigger to preserve word array elements when
+    # characters like ';' or '`' would otherwise reset the 'words' array.
     cursor_pos=$CURSOR
     CURSOR=$((cursor_pos - ${#trigger} - 1))
     # Make the 'cmd_word' global

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -303,6 +303,7 @@ _fzf_complete_kill_post() {
 }
 
 fzf-completion() {
+  typeset -g cmd_word
   trap 'unset cmd_word' EXIT
   local tokens prefix trigger tail matches lbuf d_cmds cursor_pos
   setopt localoptions noshwordsplit noksh_arrays noposixbuiltins
@@ -343,7 +344,7 @@ fzf-completion() {
       # Move the cursor before the trigger to preserve word array elements when
       # trigger chars like ';' or '`' would otherwise reset the 'words' array.
       CURSOR=$((cursor_pos - ${#trigger} - 1))
-      # Make the 'cmd_word' global
+      # Assign the extracted command to the global variable 'cmd_word'
       zle __fzf_extract_command
     } always {
       CURSOR=$cursor_pos

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -338,16 +338,13 @@ fzf-completion() {
   if [ ${#tokens} -gt 1 -a "$tail" = "$trigger" ]; then
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS-cd pushd rmdir})
 
+    # Move the cursor before the trigger to maintain word array elements when
+    # trigger characters like ';' or '`' reset the array.
+    cursor_pos=$CURSOR
+    CURSOR=$((cursor_pos - ${#trigger} - 1))
     # Make the 'cmd_word' global
-    if [[ $trigger =~ '[&;[`|]' ]]; then
-      # Move cursor before trigger to get word array elements of the command.
-      cursor_pos=$CURSOR
-      CURSOR=$((cursor_pos - ${#trigger} - 1))
-      zle __fzf_extract_command || :
-      CURSOR=$cursor_pos
-    else
-      zle __fzf_extract_command || :
-    fi
+    zle __fzf_extract_command || :
+    CURSOR=$cursor_pos
     [[ -z "$cmd_word" ]] && return
 
     [ -z "$trigger"      ] && prefix=${tokens[-1]} || prefix=${tokens[-1]:0:-${#trigger}}

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -323,7 +323,7 @@ fzf-completion() {
 
   # Explicitly allow for empty trigger.
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
-  [ -z "$trigger" -a ${LBUFFER[-1]} = ' ' ] && tokens+=("")
+  [[ -z $trigger && ${LBUFFER[-1]} == ' ' ]] && tokens+=("")
 
   # When the trigger starts with ';', it becomes a separate token
   if [[ ${LBUFFER} = *"${tokens[-2]-}${tokens[-1]}" ]]; then

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -345,7 +345,6 @@ fzf-completion() {
     # Make the 'cmd_word' global
     zle __fzf_extract_command || :
     CURSOR=$cursor_pos
-    [[ -z "$cmd_word" ]] && return
 
     [ -z "$trigger"      ] && prefix=${tokens[-1]} || prefix=${tokens[-1]:0:-${#trigger}}
     if [[ $prefix = *'$('* ]] || [[ $prefix = *'<('* ]] || [[ $prefix = *'>('* ]] || [[ $prefix = *':='* ]] || [[ $prefix = *'`'* ]]; then

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -338,13 +338,16 @@ fzf-completion() {
   if [ ${#tokens} -gt 1 -a "$tail" = "$trigger" ]; then
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS-cd pushd rmdir})
 
-    # Move the cursor before the trigger to preserve word array elements when
-    # characters like ';' or '`' would otherwise reset the 'words' array.
     cursor_pos=$CURSOR
-    CURSOR=$((cursor_pos - ${#trigger} - 1))
-    # Make the 'cmd_word' global
-    zle __fzf_extract_command || :
-    CURSOR=$cursor_pos
+    {
+      # Move the cursor before the trigger to preserve word array elements when
+      # trigger chars like ';' or '`' would otherwise reset the 'words' array.
+      CURSOR=$((cursor_pos - ${#trigger} - 1))
+      # Make the 'cmd_word' global
+      zle __fzf_extract_command
+    } always {
+      CURSOR=$cursor_pos
+    }
 
     [ -z "$trigger"      ] && prefix=${tokens[-1]} || prefix=${tokens[-1]:0:-${#trigger}}
     if [[ $prefix = *'$('* ]] || [[ $prefix = *'<('* ]] || [[ $prefix = *'>('* ]] || [[ $prefix = *':='* ]] || [[ $prefix = *'`'* ]]; then

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -339,20 +339,16 @@ fzf-completion() {
     d_cmds=(${=FZF_COMPLETION_DIR_COMMANDS-cd pushd rmdir})
 
     # Make the 'cmd_word' global
-
-    if [[ "$trigger" =~ '[&;[`|]' ]]; then
+    if [[ $trigger =~ '[&;[`|]' ]]; then
       # Move cursor before trigger to get word array elements of the command.
       cursor_pos=$CURSOR
-      CURSOR=$((cursor_pos - ${#trigger} -1 ))
+      CURSOR=$((cursor_pos - ${#trigger} - 1))
       zle __fzf_extract_command || :
       CURSOR=$cursor_pos
     else
       zle __fzf_extract_command || :
     fi
-    if [[ -z "$cmd_word" ]];then
-      zle -M "No command found to complete. Please report this at https://github.com/junegunn/fzf"
-      return
-    fi
+    [[ -z "$cmd_word" ]] && return
 
     [ -z "$trigger"      ] && prefix=${tokens[-1]} || prefix=${tokens[-1]:0:-${#trigger}}
     if [[ $prefix = *'$('* ]] || [[ $prefix = *'<('* ]] || [[ $prefix = *'>('* ]] || [[ $prefix = *':='* ]] || [[ $prefix = *'`'* ]]; then


### PR DESCRIPTION
### Description
- Resolve #4088

If a single backtick is used as a trigger, the `words` array fails to populate
with the command elements.

~~The idea here is to temporarily alter the `LBUFFER` before calling
`__fzf_extract_command` by escaping the backtick.~~

The idea is to move the `CURSOR` before the trigger.

This approach seems a bit hacky, which is why this PR is marked as a draft.

### Alternative A

Create a list of invalid triggers, since other characters have also been found
to cause the same issue:

Testing covered only ASCII values 32-126; others were excluded for simplicity.

| Symbol  | Common Name  | ASCII | Occurrences in Public Git Repos |
| ------- | ------------ | ----- | --------------------------------------- |
| `&`     | Ampersand    | 38    | 1                                       |
| `;`     | Semicolon    | 59    | ~25                                     |
| `[`     | Left Bracket | 91    | 1                                       |
| `` ` `` | Back-tick    | 96    | ~20                                     |
| `\|`    | Pipe         | 124   | 0                                       |



If the user attempts to use one, display a message using `zle -M [string]` to
indicate the error. This places the string below the command line, prompting the
user to choose a different trigger character.

### Alternative B
Fall back to the old extraction method if the words array is empty and the
`LBUFFER` is not empty, with the downside that it would only work for the first
command.

```diff
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -123,9 +123,20 @@ __fzf_comprun() {
 # Extract the name of the command. e.g. ls; foo=1 ssh **<tab>
 __fzf_extract_command() {
+  local token tokens
   setopt localoptions noksh_arrays
-  # Control completion with the "compstate" parameter, insert and list noting
+  # Control completion with the "compstate" parameter, insert and list nothing
   compstate[insert]=
   compstate[list]=
   cmd_word="${words[1]}"
+  [[ -n $cmd_word ]] && return
+  tokens=(${(z)LBUFFER})
+  for token in $tokens; do
+    token=${(Q)token}
+    if [[ "$token" =~ [[:alnum:]] && ! "$token" =~ "=" ]]; then
+      cmd_word="$token"
+      return
+    fi
+  done
+  cmd_word="${tokens[1]}"
 }

@@ -341,5 +352,4 @@ fzf-completion() {
     # Make the 'cmd_word' global
     zle __fzf_extract_command || :
-    [[ -z "$cmd_word" ]] && return

     [ -z "$trigger"      ] && prefix=${tokens[-1]} || prefix=${tokens[-1]:0:-${#trigger}}
```

---

Alternative B might be the best option. If a user encounters an issue like the
one described in #1992, simply suggest using a different trigger?
