### PR TITLE
revert(zsh): remove 'fc -RI' call in the history widget

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -112,16 +112,10 @@ fzf-history-widget() {
   # as the associative 'history' array, which maps event numbers to full history
   # lines, are set. Also, make sure Perl is installed for multi-line output.
   if zmodload -F zsh/parameter p:{commands,history} 2>/dev/null && (( ${+commands[perl]} )); then
-    # Import commands from other shells if SHARE_HISTORY is enabled, as the
-    # 'history' array only updates after executing a non-empty command.
-    selected="$(
-      if [[ -o sharehistory ]]; then
-        fc -RI
-      fi
-      printf '%s\t%s\000' "${(kv)history[@]}" |
-        perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
-        FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \
-        FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd))"
+    selected="$(printf '%s\t%s\000' "${(kv)history[@]}" |
+      perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
+      FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m --read0") \
+      FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd))"
   else
     selected="$(fc -rl 1 | awk '{ cmd=$0; sub(/^[ \t]*[0-9]+\**[ \t]+/, "", cmd); if (!seen[cmd]++) print $0 }' |
       FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '\t↳ ' --highlight-line ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} +m") \


### PR DESCRIPTION
### Description
- Resolve #4091
- Reopen #4061

Intentionally added to solve an issue with updating the `history` array, which
only updated after the user ran a non-empty command[^1][^2].

There were a couple of issues:

One issue was that executing `fc -RI` seemed to prevent access to recent history
when canceling the `fzf` window with `esc` or `ctrl-c`. Pressing `up` did not
retrieve the expected history. This was mitigated by placing it inside the
command substitution[^3]. However, this led to the issue described in the
referenced ticket.

In the past[^4], it was even reported that there was an unbearable delay when
using `fc -RI`.

[^1]: [ctrl+r no longer pulling from shared history until a command is run succesfully · Issue #4061 · junegunn/fzf · GitHub](https://github.com/junegunn/fzf/issues/4061)
[^2]: [fix(zsh): history loading with shared option by LangLangBart · Pull Request #4071 · junegunn/fzf · GitHub](https://github.com/junegunn/fzf/pull/4071)
[^3]: [fix(zsh): move 'fc -RI' inside command substitution by LangLangBart · Pull Request #4073 · junegunn/fzf · GitHub](https://github.com/junegunn/fzf/pull/4073)
[^4]: [[zsh] Reload shared history before searching by mpolden · Pull Request #2251 · junegunn/fzf · GitHub](https://github.com/junegunn/fzf/pull/2251)
