### PR TITLE
Allow walking multiple root directories

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1005,8 +1005,8 @@ Determines the behavior of the built-in directory walker that is used when
 .br
 
 .TP
-.B "\-\-walker\-root=DIR"
-The root directory from which to start the built-in directory walker.
+.B "\-\-walker\-root=DIRS"
+Comma-separated list of directory names to start the built-in directory walker.
 The default value is the current working directory.
 
 .TP

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1005,8 +1005,8 @@ Determines the behavior of the built-in directory walker that is used when
 .br
 
 .TP
-.B "\-\-walker\-root=DIRS"
-Comma-separated list of directory names to start the built-in directory walker.
+.B "\-\-walker\-root=DIR [...]"
+List of directory names to start the built-in directory walker.
 The default value is the current working directory.
 
 .TP

--- a/src/options.go
+++ b/src/options.go
@@ -145,7 +145,7 @@ Usage: fzf [options]
 
   Directory traversal       (Only used when $FZF_DEFAULT_COMMAND is not set)
     --walker=OPTS           [file][,dir][,follow][,hidden] (default: file,follow,hidden)
-    --walker-root=DIR       Root directory from which to start walker (default: .)
+    --walker-root=DIRS      Comma-separated list of directories to walk (default: .)
     --walker-skip=DIRS      Comma-separated list of directory names to skip
                             (default: .git,node_modules)
 

--- a/src/options.go
+++ b/src/options.go
@@ -626,11 +626,16 @@ func optionalNextString(args []string, i *int) (bool, string) {
 	return false, ""
 }
 
+func isDir(path string) bool {
+	stat, err := os.Stat(path)
+	return err == nil && stat.IsDir()
+}
+
 func nextDirs(args []string, i *int) ([]string, error) {
 	dirs := []string{}
 	for *i < len(args)-1 {
 		arg := args[*i+1]
-		if stat, err := os.Stat(arg); err == nil && stat.IsDir() {
+		if isDir(arg) {
 			dirs = append(dirs, arg)
 			*i++
 		} else {
@@ -2702,6 +2707,9 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 					return err
 				}
 			} else if match, value := optString(arg, "--walker-root="); match {
+				if !isDir(value) {
+					return errors.New("not a directory: " + value)
+				}
 				dirs, _ := nextDirs(allArgs, &i)
 				opts.WalkerRoot = append([]string{value}, dirs...)
 			} else if match, value := optString(arg, "--walker-skip="); match {

--- a/src/reader.go
+++ b/src/reader.go
@@ -2,7 +2,6 @@ package fzf
 
 import (
 	"bytes"
-	"strings"
 	"context"
 	"io"
 	"io/fs"
@@ -121,7 +120,7 @@ func (r *Reader) readChannel(inputChan chan string) bool {
 }
 
 // ReadSource reads data from the default command or from standard input
-func (r *Reader) ReadSource(inputChan chan string, root string, opts walkerOpts, ignores []string, initCmd string, initEnv []string, readyChan chan bool) {
+func (r *Reader) ReadSource(inputChan chan string, roots []string, opts walkerOpts, ignores []string, initCmd string, initEnv []string, readyChan chan bool) {
 	r.startEventPoller()
 	var success bool
 	signalReady := func() {
@@ -138,7 +137,7 @@ func (r *Reader) ReadSource(inputChan chan string, root string, opts walkerOpts,
 		cmd := os.Getenv("FZF_DEFAULT_COMMAND")
 		if len(cmd) == 0 {
 			signalReady()
-			success = r.readFiles(root, opts, ignores)
+			success = r.readFiles(roots, opts, ignores)
 		} else {
 			success = r.readFromCommand(cmd, initEnv, signalReady)
 		}
@@ -266,7 +265,7 @@ func trimPath(path string) string {
 	return byteString(bytes)
 }
 
-func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string) bool {
+func (r *Reader) readFiles(roots []string, opts walkerOpts, ignores []string) bool {
 	conf := fastwalk.Config{
 		Follow: opts.follow,
 		// Use forward slashes when running a Windows binary under WSL or MSYS
@@ -302,10 +301,9 @@ func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string) bool 
 		}
 		return nil
 	}
-	roots := strings.Split(root, ",")
 	noerr := true
 	for _, root := range roots {
-	  noerr = noerr && (fastwalk.Walk(&conf, root, fn) == nil)
+		noerr = noerr && (fastwalk.Walk(&conf, root, fn) == nil)
 	}
 	return noerr
 }

--- a/src/reader.go
+++ b/src/reader.go
@@ -2,6 +2,7 @@ package fzf
 
 import (
 	"bytes"
+	"strings"
 	"context"
 	"io"
 	"io/fs"
@@ -301,7 +302,12 @@ func (r *Reader) readFiles(root string, opts walkerOpts, ignores []string) bool 
 		}
 		return nil
 	}
-	return fastwalk.Walk(&conf, root, fn) == nil
+	roots := strings.Split(root, ",")
+	noerr := true
+	for _, root := range roots {
+	  noerr = noerr && (fastwalk.Walk(&conf, root, fn) == nil)
+	}
+	return noerr
 }
 
 func (r *Reader) readFromCommand(command string, environ []string, signalReady func()) bool {


### PR DESCRIPTION
Hi,
I have been trying to search a file or directory with fzf on Windows on multiple drives.
I managed to do it by piping the output of `Get-ChildItem` cmdlet (slow) and then the output of `fd` (faster but not ideal).
It was not a satisfying solution to me so i started to look at the code of fzf and found a solution to this problem by using a comma separated list in the `--walker-root` argument.
I am not proficient in go so the implementation might not be what you are looking for, don't hesitate to guide me towards a solution that suits you.
Best regards,
Martin