### PR TITLE
Make the preview window resizable by mouse drag

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1679,7 +1679,13 @@ func (t *Terminal) resizeWindows(forcePreview bool) {
 					createPreviewWindow(marginInt[0]+height-pheight, marginInt[3], width, pheight)
 				}
 			case posLeft, posRight:
-				pwidth := calculateSize(width, previewOpts.size, minWidth, 5, 4)
+				pad := borderColumns(previewOpts.border, t.borderWidth)
+				if len(t.scrollbar) > 0 && !previewOpts.border.HasRight() {
+					// Need a column to show scrollbar
+					pad += 1
+				}
+				minPreviewWidth := 1 + pad
+				pwidth := calculateSize(width, previewOpts.size, minWidth, minPreviewWidth, pad)
 				if hasThreshold && pwidth < previewOpts.threshold {
 					t.activePreviewOpts = previewOpts.alternative
 					if forcePreview {
@@ -1718,9 +1724,6 @@ func (t *Terminal) resizeWindows(forcePreview bool) {
 						marginInt[0], marginInt[3], width-pwidth, height, false, noBorder)
 					// NOTE: fzf --preview 'cat {}' --preview-window border-left --border
 					x := marginInt[3] + width - pwidth
-					if !previewOpts.border.HasRight() && t.borderShape.HasRight() {
-						pwidth++
-					}
 					createPreviewWindow(marginInt[0], x, pwidth, height)
 				}
 			}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4722,7 +4722,18 @@ func (t *Terminal) Loop() error {
 				}
 
 				// Preview border dragging (resizing)
-				pborderDragging = me.Down && (pborderDragging || clicked && t.hasPreviewWindow() && t.pborder.Enclose(my, mx))
+				if !pborderDragging && clicked && t.hasPreviewWindow() && t.pborder.Enclose(my, mx) {
+					switch t.activePreviewOpts.position {
+					case posUp:
+						pborderDragging = my == t.pborder.Top()+t.pborder.Height()-1
+					case posDown:
+						pborderDragging = my == t.pborder.Top()
+					case posLeft:
+						pborderDragging = mx == t.pborder.Left()+t.pborder.Width()-1
+					case posRight:
+						pborderDragging = mx == t.pborder.Left()
+					}
+				}
 				if pborderDragging {
 					previewWidth := t.pwindow.Width() + borderColumns(t.activePreviewOpts.border, t.borderWidth)
 					previewHeight := t.pwindow.Height() + borderLines(t.activePreviewOpts.border)

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1648,7 +1648,11 @@ func (t *Terminal) resizeWindows(forcePreview bool) {
 			}
 			switch previewOpts.position {
 			case posUp, posDown:
-				pheight := calculateSize(height, previewOpts.size, minHeight, minPreviewHeight, verticalPad)
+				minWindowHeight := minHeight
+				if t.noSeparatorLine() {
+					minWindowHeight--
+				}
+				pheight := calculateSize(height, previewOpts.size, minWindowHeight, minPreviewHeight, verticalPad)
 				if hasThreshold && pheight < previewOpts.threshold {
 					t.activePreviewOpts = previewOpts.alternative
 					if forcePreview {

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4743,26 +4743,30 @@ func (t *Terminal) Loop() error {
 
 				if pborderDragging {
 					var newSize int
+					var prevSize int
 					switch t.activePreviewOpts.position {
 					case posLeft:
-						diff := t.pborder.Width() - t.pwindow.Width()
+						prevSize = t.pwindow.Width()
+						diff := t.pborder.Width() - prevSize
 						newSize = mx - t.pborder.Left() - diff + 1
 					case posUp:
-						diff := t.pborder.Height() - t.pwindow.Height()
+						prevSize = t.pwindow.Height()
+						diff := t.pborder.Height() - prevSize
 						newSize = my - t.pborder.Top() - diff + 1
 					case posDown:
+						prevSize = t.pwindow.Height()
 						offset := my - t.pborder.Top()
-						newSize = t.pwindow.Height() - offset
+						newSize = prevSize - offset
 					case posRight:
+						prevSize = t.pwindow.Width()
 						offset := mx - t.pborder.Left()
-						newSize = t.pwindow.Width() - offset
+						newSize = prevSize - offset
 					}
 					if newSize < 1 {
 						newSize = 1
 					}
 
-					// Don't update if the size did not change (e.g. off-axis movement)
-					if !t.activePreviewOpts.size.percent && t.activePreviewOpts.size.size == float64(newSize) {
+					if prevSize == newSize {
 						break
 					}
 

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -145,6 +145,7 @@ type previewer struct {
 	following  resumableState
 	spinner    string
 	bar        []bool
+	xw         [2]int
 }
 
 type previewed struct {
@@ -857,7 +858,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox, executor *util.Executor
 		initialPreviewOpts: opts.Preview,
 		previewOpts:        opts.Preview,
 		activePreviewOpts:  &opts.Preview,
-		previewer:          previewer{0, []string{}, 0, false, true, disabledState, "", []bool{}},
+		previewer:          previewer{0, []string{}, 0, false, true, disabledState, "", []bool{}, [2]int{0, 0}},
 		previewed:          previewed{0, 0, 0, false, false, false, false},
 		previewBox:         previewBox,
 		eventBox:           eventBox,
@@ -2842,10 +2843,12 @@ Loop:
 func (t *Terminal) renderPreviewScrollbar(yoff int, barLength int, barStart int) {
 	height := t.pwindow.Height()
 	w := t.pborder.Width()
+	xw := [2]int{t.pwindow.Left(), t.pwindow.Width()}
 	redraw := false
-	if len(t.previewer.bar) != height {
+	if len(t.previewer.bar) != height || t.previewer.xw != xw {
 		redraw = true
 		t.previewer.bar = make([]bool, height)
+		t.previewer.xw = xw
 	}
 	xshift := -1 - t.borderWidth
 	if !t.activePreviewOpts.border.HasRight() {

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4736,8 +4736,7 @@ func (t *Terminal) Loop() error {
 
 					previewLeft := t.pwindow.Left()
 					previewTop := t.pwindow.Top()
-					// Unlike window, pwindow does not include it's border, so
-					// Left and Top have to be adjusted.
+					// pwindow does not include it's border, so Left and Top have to be adjusted.
 					if t.activePreviewOpts.border.HasLeft() {
 						previewLeft -= 1 + t.borderWidth
 					}
@@ -4762,7 +4761,6 @@ func (t *Terminal) Loop() error {
 						// +1 since index to size
 						newSize = mx - left + 1
 					}
-					// TODO: should this allow a size of zero?
 					if newSize < 1 {
 						newSize = 1
 					}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1695,6 +1695,9 @@ func (t *Terminal) resizeWindows(forcePreview bool) {
 						marginInt[0], marginInt[3], width-pwidth, height, false, noBorder)
 					// NOTE: fzf --preview 'cat {}' --preview-window border-left --border
 					x := marginInt[3] + width - pwidth
+					if !previewOpts.border.HasRight() && t.borderShape.HasRight() {
+						pwidth++
+					}
 					createPreviewWindow(marginInt[0], x, pwidth, height)
 				}
 			}

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -410,6 +410,18 @@ type BorderStyle struct {
 type BorderCharacter int
 
 func MakeBorderStyle(shape BorderShape, unicode bool) BorderStyle {
+	if shape == BorderNone {
+		return BorderStyle{
+			shape:       BorderRounded,
+			top:         ' ',
+			bottom:      ' ',
+			left:        ' ',
+			right:       ' ',
+			topLeft:     ' ',
+			topRight:    ' ',
+			bottomLeft:  ' ',
+			bottomRight: ' '}
+	}
 	if !unicode {
 		return BorderStyle{
 			shape:       shape,
@@ -504,19 +516,6 @@ func MakeBorderStyle(shape BorderShape, unicode bool) BorderStyle {
 		bottomLeft:  '╰',
 		bottomRight: '╯',
 	}
-}
-
-func MakeTransparentBorder() BorderStyle {
-	return BorderStyle{
-		shape:       BorderRounded,
-		top:         ' ',
-		bottom:      ' ',
-		left:        ' ',
-		right:       ' ',
-		topLeft:     ' ',
-		topRight:    ' ',
-		bottomLeft:  ' ',
-		bottomRight: ' '}
 }
 
 type TermSize struct {

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -387,6 +387,14 @@ func (s BorderShape) HasTop() bool {
 	return true
 }
 
+func (s BorderShape) HasBottom() bool {
+	switch s {
+	case BorderNone, BorderLeft, BorderRight, BorderTop, BorderVertical: // No bottom
+		return false
+	}
+	return true
+}
+
 type BorderStyle struct {
 	shape       BorderShape
 	top         rune

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -2814,13 +2814,13 @@ class TestGoFZF < TestBase
     tmux.send_keys "seq 3 | fzf --height ~100% --border=vertical --preview 'seq {}' --preview-window left,5,border-right --padding 1 --exit-0 --header $'hello\\nworld' --header-lines=2", :Enter
     expected = <<~OUTPUT
       │
-      │  1       │ > 3
-      │  2       │   2
-      │  3       │   1
-      │          │   hello
-      │          │   world
-      │          │   1/1 ─
-      │          │ >
+      │  1     │ > 3
+      │  2     │   2
+      │  3     │   1
+      │        │   hello
+      │        │   world
+      │        │   1/1 ─
+      │        │ >
       │
     OUTPUT
     tmux.until { assert_block(expected, _1) }

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -3081,6 +3081,13 @@ class TestGoFZF < TestBase
     end
   end
 
+  def test_preview_window_width_exception
+    tmux.send_keys "seq 10 | #{FZF} --scrollbar --preview-window border-left --border --preview 'seq 1000'", :Enter
+    tmux.until do |lines|
+      assert lines[1]&.end_with?(' 1/1000││')
+    end
+  end
+
   def test_become
     tmux.send_keys "seq 100 | #{FZF} --bind 'enter:become:seq {} | #{FZF}'", :Enter
     tmux.until { |lines| assert_equal 100, lines.item_count }

--- a/test/test_go.rb
+++ b/test/test_go.rb
@@ -3073,6 +3073,14 @@ class TestGoFZF < TestBase
     tmux.until { |lines| assert_includes lines, '/1/1/' }
   end
 
+  def test_alternative_preview_window_opts
+    tmux.send_keys "seq 10 | #{FZF} --preview-window '~5,2,+0,<100000(~0,+100,wrap,noinfo)' --preview 'seq 1000'", :Enter
+    tmux.until { |lines| assert_equal 10, lines.item_count }
+    tmux.until do |lines|
+      assert_equal ['╭────╮', '│ 10 │', '│ 0  │', '│ 10 │', '│ 1  │'], lines.take(5).map(&:strip)
+    end
+  end
+
   def test_become
     tmux.send_keys "seq 100 | #{FZF} --bind 'enter:become:seq {} | #{FZF}'", :Enter
     tmux.until { |lines| assert_equal 100, lines.item_count }


### PR DESCRIPTION
This PR enables resizing the preview window by dragging its border with the mouse. This works with all border styles except for `none`. Counter-intuitively, having the border only on the opposite side of the window works too - dragging from it will first decrease the preview size to its minimum.

I tested this with quite a lot of different border configurations, although only on Linux. For this I used:

```
./bin/fzf --bind 'ctrl-space:change-preview-window(right,border-horizontal|right,border-left|right,border-right|down,border-rounded|down,border-vertical|down,border-down|down,border-top|left,border-rounded|left,border-horizontal|left,border-right|left,border-left|up,border-rounded|up,border-vertical|up,border-down|up,border-top)' --preview='cat {}'
```

with and without `--padding 2 --margin 3 --border` as well as `--no-scrollbar`.

---

While implementing this I found some issues, present already prior to my changes:

- The minimum window height decreases when no extra line for the horizontal separator is used (e.g. with `--info=inline --no-separator`). In this case the preview window should be able to occupy this extra line.
- When the chosen preview border shape has no left and/or right border, the minimum total preview window size decreases. But due to the hardcoded value for the size it could not be decreased further than 5.
- `--preview-window=99%,left --no-border` lets the preview window grow one cell too big
- Sometimes when the border style changes, some cells are not properly redrawn:
	- Changing the border shape let's the preview scrollbar disappear sometimes and leave parts of the old border:

	```
	fzf --preview='cat {}' --preview-window=border-horizontal --bind 'ctrl-space:change-preview-window(border-rounded|border-horizontal)'
	```

	- When changing the size and the border-shape of the preview, characters remain:

	```
	fzf --preview='cat {}' --preview-window=30%,left,border-rounded --bind 'ctrl-space:change-preview-window(50%,border-horizontal|30%)'
	```

This PR suffers a bit from the second and last one. The second results in an offset between the cursor and the border when dragging, since the preview window size after a resize is not the one "requested". The last one makes the scrollbar disappear when resizing and acts as if the preview window was one cell bigger (until one starts to scroll).

Since they are loosely related, I addressed the first two in separate commits, but will open issues for the rest. I'll happily split the commits in their own PR or discard them though, if you prefer it that way or have a different solution in mind.

In addition I de-duplicated and refactored a bit of code that could use the `Has{Top,Right,Bottom,Left}()` functions instead of "manual" switch cases. Here again, feel free to discard this, if not wanted.

## Related out-of-scope note:

At the moment `change-preview-window(...)` is the only way of resizing the preview window at "run-time", which is rather limited. This PR starts to fill this gap, but further implementing `resize-window(...)` or `{grow,shrink}(...)` actions that allow relative resizes via keystrokes, would probably make a lot of sense.
