### PR TITLE
[fish] Leading characters: don't strip `.`, expand `~/`

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -150,6 +150,9 @@ function fzf_key_bindings
     set -l prefix (string match -r -- '^-[^\s=]+=' $commandline)
     set commandline (string replace -- "$prefix" '' $commandline)
 
+    # Enable home directory expansion of leading ~/
+    set commandline (string replace -r -- '^~/' '\$HOME/' $commandline)
+
     # escape special characters, except for the $ sign of valid variable names,
     # so that after eval, the original string is returned, but with the
     # variable names replaced by their values.

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -172,7 +172,7 @@ function fzf_key_bindings
       # BUG: on combined expressions, if a left argument is a single `!`, the
       # builtin test command of fish will treat it as the ! operator. To
       # overcome this, have the variable parts on the right.
-      if test "." = "$dir" -a "." != (string sub -l 1 -- $commandline)
+      if test "." = "$dir" -a "./" != (string sub -l 2 -- $commandline)
         # if $dir is "." but commandline is not a relative path, this means no file path found
         set fzf_query $commandline
       else

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -57,8 +57,8 @@ function fzf_key_bindings
   function fzf-history-widget -d "Show command history"
     test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
     begin
-      set -l FISH_MAJOR (string split '.' -- $version)[1]
-      set -l FISH_MINOR (string split '.' -- $version)[2]
+      set -l FISH_MAJOR (string split -f 1 -- '.' $version)
+      set -l FISH_MINOR (string split -f 2 -- '.' $version)
 
       # merge history from other sessions before searching
       test -z "$fish_private_mode"; and builtin history merge
@@ -157,13 +157,13 @@ function fzf_key_bindings
     # so that after eval, the original string is returned, but with the
     # variable names replaced by their values.
     set commandline (string escape -n -- $commandline)
-    set commandline (string replace -r -a '\x5c\$(?=[\w])' '\$' -- $commandline)
+    set commandline (string replace -r -a -- '\x5c\$(?=[\w])' '\$' $commandline)
 
     # eval is used to do shell expansion on paths
     eval set commandline $commandline
 
     # Combine multiple consecutive slashes into one
-    set commandline (string replace -r -a '/+' '/' -- $commandline)
+    set commandline (string replace -r -a -- '/+' '/' $commandline)
 
     if test -z "$commandline"
       # Default to current directory with no --query
@@ -180,7 +180,7 @@ function fzf_key_bindings
         set fzf_query $commandline
       else
         # Also remove trailing slash after dir, to "split" input properly
-        set fzf_query (string replace -r "^$dir/?" '' -- $commandline)
+        set fzf_query (string replace -r -- "^$dir/?" '' $commandline)
       end
     end
 
@@ -193,7 +193,7 @@ function fzf_key_bindings
     set dir $argv
 
     # Strip trailing slash, unless $dir is root dir (/)
-    set dir (string replace -r '(?<!^)/$' '' -- $dir)
+    set dir (string replace -r -- '(?<!^)/$' '' $dir)
 
     # Iteratively check if dir exists and strip tail end of path
     while test ! -d "$dir"


### PR DESCRIPTION
A couple of more changes to fish key bindings: A fix for a bug that removed the leading dot of the query, and an enhancement that enables the expansion of `~/` (more info in commit messages). There is also a small syntax modification to some commands (the position of `--` that marks the end of switches), for consistency with the rest of the code (no actual change).