### PR TITLE
[fish] Partly revert change of 0167691

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -57,8 +57,8 @@ function fzf_key_bindings
   function fzf-history-widget -d "Show command history"
     test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
     begin
-      set -l FISH_MAJOR (string split -f 1 -- '.' $version)
-      set -l FISH_MINOR (string split -f 2 -- '.' $version)
+      set -l FISH_MAJOR (string split -- '.' $version)[1]
+      set -l FISH_MINOR (string split -- '.' $version)[2]
 
       # merge history from other sessions before searching
       test -z "$fish_private_mode"; and builtin history merge


### PR DESCRIPTION
I remembered why I didn't use the `-f` switch of `string split` in my first PR: it was added in fish version 3.2.0, so it's not the right option for extracting the major/minor version number.