### PR TITLE
Don't include the file name in type information

### DIFF
--- a/bin/fzf-preview.sh
+++ b/bin/fzf-preview.sh
@@ -14,7 +14,7 @@ if [[ $# -ne 1 ]]; then
 fi
 
 file=${1/#\~\//$HOME/}
-type=$(file --dereference --mime -- "$file")
+type=$(file --brief --dereference --mime -- "$file")
 
 if [[ ! $type =~ image/ ]]; then
   if [[ $type =~ =binary ]]; then


### PR DESCRIPTION
Reduce the changes of misjudging the type, e.g., when file is under an `image/`
directory.