### PR TITLE
Add support for --tmux-title option

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -78,6 +78,7 @@ Usage: fzf [options]
     --tmux[=OPTS]            Start fzf in a tmux popup (requires tmux 3.3+)
                              [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]
                              (default: center,50%)
+    --tmux-title=STR         Add given title to tmux popup (requires tmux 3.3+)
     --layout=LAYOUT          Choose layout: [default|reverse|reverse-list]
     --border[=STYLE]         Draw border around the finder
                              [rounded|sharp|bold|block|thinblock|double|horizontal|vertical|
@@ -457,6 +458,7 @@ type Options struct {
 	Output           chan string
 	NoWinpty         bool
 	Tmux             *tmuxOptions
+	TmuxTitle        string
 	ForceTtyIn       bool
 	ProxyScript      string
 	Bash             bool
@@ -2674,6 +2676,8 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 				if opts.Tmux, err = parseTmuxOptions(value, index); err != nil {
 					return err
 				}
+			} else if match, value := optString(arg, "--tmux-title="); match {
+				opts.TmuxTitle = value
 			} else if match, value := optString(arg, "--scheme="); match {
 				opts.Scheme = strings.ToLower(value)
 			} else if match, value := optString(arg, "-q", "--query="); match {

--- a/src/tmux.go
+++ b/src/tmux.go
@@ -33,7 +33,7 @@ func runTmux(args []string, opts *Options) (int, error) {
 	// M        Both    The mouse position
 	// W        Both    The window position on the status line
 	// S        -y      The line above or below the status line
-	tmuxArgs := []string{"display-popup", "-E", "-B", "-d", dir}
+	tmuxArgs := []string{"display-popup", "-E", "-d", dir}
 	switch opts.Tmux.position {
 	case posUp:
 		tmuxArgs = append(tmuxArgs, "-xC", "-y0")
@@ -48,6 +48,12 @@ func runTmux(args []string, opts *Options) (int, error) {
 	}
 	tmuxArgs = append(tmuxArgs, "-w"+opts.Tmux.width.String())
 	tmuxArgs = append(tmuxArgs, "-h"+opts.Tmux.height.String())
+
+	if opts.TmuxTitle != "" {
+		tmuxArgs = append(tmuxArgs, "-T"+opts.TmuxTitle)
+	} else {
+		tmuxArgs = append(tmuxArgs, "-B")
+	}
 
 	return runProxy(argStr, func(temp string, needBash bool) (*exec.Cmd, error) {
 		sh, err := sh(needBash)


### PR DESCRIPTION
Personally I see value in adding support for a `--tmux-title` option, with which a title for the tmux popup can be set (see `-T` option of `display-popup` command in [tmux(1)](https://man.openbsd.org/OpenBSD-current/man1/tmux.1#display-popup)). This option would only work in combination with the `--tmux` option and look better if the `--no-border` option is set as to avoid rendering two borders: one from fzf and one from tmux, rendering the tmux border is required in order to display the title.

Please note that this is just a minimal working proof-of-concept. If the maintainers and folks using fzf find this useful and would consider this for inclusion, I'd be happy to elaborate on this PR; ideally with some guidance from the maintainers given that I'm rather unfamiliar with fzf's codebase.

