### PR TITLE
add `border-native` option to `--tmux` flag

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -128,7 +128,7 @@ fzf  --height 70% --tmux 70%
 You can also specify the position, width, and height of the popup window in
 the following format:
 
-* `[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]`
+* `[center|top|bottom|left|right][,SIZE[%]][,SIZE[%][,border-native]]`
 
 ```sh
 # 100% width and 60% height

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ fzf --height -3
 With `--tmux` option, fzf will start in a tmux popup.
 
 ```sh
-# --tmux [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]
+# --tmux [center|top|bottom|left|right][,SIZE[%]][,SIZE[%][,border-native]]
 
 fzf --tmux center         # Center, 50% width and height
 fzf --tmux 80%            # Center, 80% width and height

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -271,7 +271,7 @@ Adaptive height has the following limitations:
 Minimum height when \fB\-\-height\fR is given in percent (default: 10).
 Ignored when \fB\-\-height\fR is not specified.
 .TP
-.BI "\-\-tmux" "[=[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]]"
+.BI "\-\-tmux" "[=[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]][,border-native]]"
 Start fzf in a tmux popup (default \fBcenter,50%\fR). Requires tmux 3.3 or
 later. This option is ignored if you are not running fzf inside tmux.
 
@@ -286,7 +286,11 @@ e.g.
   fzf \-\-tmux bottom,30%
 
   # Popup on the top with 80% width and 40% height
-  fzf \-\-tmux top,80%,40%\fR
+  fzf \-\-tmux top,80%,40%
+  
+  # Popup with a native window border in the center
+  # with 80% width and 50% height.
+  fzf \-\-tmux center,80%,50%,border-native\fR
 
 .TP
 .BI "\-\-layout=" "LAYOUT"

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -287,10 +287,9 @@ e.g.
 
   # Popup on the top with 80% width and 40% height
   fzf \-\-tmux top,80%,40%
-  
-  # Popup with a native window border in the center
-  # with 80% width and 50% height.
-  fzf \-\-tmux center,80%,50%,border-native\fR
+
+  # Popup with a native tmux border in the center with 80% width and height
+  fzf \-\-tmux center,80%,border\-native\fR
 
 .TP
 .BI "\-\-layout=" "LAYOUT"

--- a/src/options.go
+++ b/src/options.go
@@ -310,8 +310,7 @@ func defaultTmuxOptions(index int) *tmuxOptions {
 		position: posCenter,
 		width:    sizeSpec{50, true},
 		height:   sizeSpec{50, true},
-		index:    index,
-	}
+		index:    index}
 }
 
 func parseTmuxOptions(arg string, index int) (*tmuxOptions, error) {
@@ -660,8 +659,7 @@ func defaultOptions() *Options {
 		WalkerRoot:   []string{"."},
 		WalkerSkip:   []string{".git", "node_modules"},
 		Help:         false,
-		Version:      false,
-	}
+		Version:      false}
 }
 
 func optString(arg string, prefixes ...string) (bool, string) {
@@ -1736,7 +1734,7 @@ func strLines(str string) []string {
 }
 
 func parseSize(str string, maxPercent float64, label string) (sizeSpec, error) {
-	spec := sizeSpec{}
+	var spec = sizeSpec{}
 	var val float64
 	var err error
 	percent := strings.HasSuffix(str, "%")
@@ -1822,8 +1820,7 @@ func parseInfoStyle(str string) (infoStyle, string, error) {
 	}
 	for _, spec := range []infoSpec{
 		{"inline", infoInline},
-		{"inline-right", infoInlineRight},
-	} {
+		{"inline-right", infoInlineRight}} {
 		if strings.HasPrefix(str, spec.name+":") {
 			return spec.style, strings.ReplaceAll(str[len(spec.name)+1:], "\n", " "), nil
 		}

--- a/src/options.go
+++ b/src/options.go
@@ -77,7 +77,7 @@ Usage: fzf [options]
                              (default: 10)
     --tmux[=OPTS]            Start fzf in a tmux popup (requires tmux 3.3+)
                              [center|top|bottom|left|right][,SIZE[%]][,SIZE[%]]
-                             (default: center,50%)
+                             [,border-native] (default: center,50%)
     --layout=LAYOUT          Choose layout: [default|reverse|reverse-list]
     --border[=STYLE]         Draw border around the finder
                              [rounded|sharp|bold|block|thinblock|double|horizontal|vertical|

--- a/src/options.go
+++ b/src/options.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
 	"unicode"
@@ -343,13 +342,12 @@ func parseTmuxOptions(arg string, index int) (*tmuxOptions, error) {
 		tokens = append([]string{"center"}, tokens...)
 	}
 
-	if i := slices.Index(tokens, "border-native"); i >= 0 {
-		// The border option, if present, is the last one
-		if i != len(tokens)-1 {
-			return nil, errorToReturn
+	for i, token := range tokens {
+		if token == "border-native" {
+			tokens = append(tokens[:i], tokens[i+1:]...) // cut the 'border-native' option
+			opts.border = true
+			break
 		}
-		tokens = slices.Delete(tokens, i, i+1)
-		opts.border = true
 	}
 
 	// One size given

--- a/src/options.go
+++ b/src/options.go
@@ -322,6 +322,14 @@ func parseTmuxOptions(arg string, index int) (*tmuxOptions, error) {
 		return nil, errorToReturn
 	}
 
+	for i, token := range tokens {
+		if token == "border-native" {
+			tokens = append(tokens[:i], tokens[i+1:]...) // cut the 'border-native' option
+			opts.border = true
+			break
+		}
+	}
+
 	// Defaults to 'center'
 	switch tokens[0] {
 	case "top", "up":
@@ -339,14 +347,6 @@ func parseTmuxOptions(arg string, index int) (*tmuxOptions, error) {
 	case "center":
 	default:
 		tokens = append([]string{"center"}, tokens...)
-	}
-
-	for i, token := range tokens {
-		if token == "border-native" {
-			tokens = append(tokens[:i], tokens[i+1:]...) // cut the 'border-native' option
-			opts.border = true
-			break
-		}
 	}
 
 	// One size given

--- a/src/tmux.go
+++ b/src/tmux.go
@@ -11,7 +11,7 @@ func runTmux(args []string, opts *Options) (int, error) {
 	// Prepare arguments
 	fzf := args[0]
 	args = append([]string{"--bind=ctrl-z:ignore"}, args[1:]...)
-	if opts.BorderShape == tui.BorderUndefined {
+	if opts.BorderShape == tui.BorderUndefined && !opts.Tmux.border {
 		args = append(args, "--border")
 	}
 	argStr := escapeSingleQuote(fzf)

--- a/src/tmux.go
+++ b/src/tmux.go
@@ -9,13 +9,16 @@ import (
 
 func runTmux(args []string, opts *Options) (int, error) {
 	// Prepare arguments
-	fzf := args[0]
-	args = append([]string{"--bind=ctrl-z:ignore"}, args[1:]...)
-	if opts.BorderShape == tui.BorderUndefined && !opts.Tmux.border {
+	fzf, rest := args[0], args[1:]
+	args = []string{"--bind=ctrl-z:ignore"}
+	if !opts.Tmux.border && opts.BorderShape == tui.BorderUndefined {
 		args = append(args, "--border")
 	}
+	if opts.Tmux.border && opts.Margin == defaultMargin() {
+		args = append(args, "--margin=0,1")
+	}
 	argStr := escapeSingleQuote(fzf)
-	for _, arg := range args {
+	for _, arg := range append(args, rest...) {
 		argStr += " " + escapeSingleQuote(arg)
 	}
 	argStr += ` --no-tmux --no-height`

--- a/src/tmux.go
+++ b/src/tmux.go
@@ -33,7 +33,10 @@ func runTmux(args []string, opts *Options) (int, error) {
 	// M        Both    The mouse position
 	// W        Both    The window position on the status line
 	// S        -y      The line above or below the status line
-	tmuxArgs := []string{"display-popup", "-E", "-B", "-d", dir}
+	tmuxArgs := []string{"display-popup", "-E", "-d", dir}
+	if !opts.Tmux.border {
+		tmuxArgs = append(tmuxArgs, "-B")
+	}
 	switch opts.Tmux.position {
 	case posUp:
 		tmuxArgs = append(tmuxArgs, "-xC", "-y0")


### PR DESCRIPTION
This commit adds the `border-native` resulting in
the following:
```
--tmux[=[center|top|bottom|left|right][,SIZE[%]][,SIZE[%]][,border-native]]
```

By default, when not specified, the `-B` flag is passed to the
`tmux popup-window` command such that no border is drawn around
the tmux popup window.

When the `border-native` option is present the `-B` flag is omitted
and the popup window is drawn using the border style configured in
the tmux config file.

Fixes #4156