### PR TITLE
fix: make header align with list

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2299,7 +2299,7 @@ func (t *Terminal) printHeader() {
 
 		t.printHighlighted(Result{item: item},
 			tui.ColHeader, tui.ColHeader, false, false, line, line, true,
-			func(markerClass) { t.window.Print("  ") }, nil)
+			func(markerClass) { t.window.Print(strings.Repeat(" ", t.pointerLen+t.markerLen)) }, nil)
 	}
 	t.wrap = wrap
 }


### PR DESCRIPTION
Currently, header is padded by hardcode length now.

When `pointer`/`marker` set to empty with, it would be better to align header with the list.
```sh
FZF_DEFAULT_OPTS= ./fzf --info=inline --pointer= --header-lines=3
```
<img src="https://github.com/user-attachments/assets/618132c9-96ae-4a65-ac7d-d67607ecdf77" width="200"/>
<img src="https://github.com/user-attachments/assets/66345257-5384-4483-8264-b62ded5a765c" width="200"/>

fzf.vim `:Buffers`
<img src="https://github.com/user-attachments/assets/e9d44db9-7b89-43df-9a37-239284c8098a" width="200"/>
