### PR TITLE
[fish] remove defunct bind feature detection

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -133,14 +133,12 @@ function fzf_key_bindings
     bind \ec fzf-cd-widget
   end
 
-  if bind -M insert &> /dev/null
-    bind -M insert \cr fzf-history-widget
-    if not set -q FZF_CTRL_T_COMMAND; or test -n "$FZF_CTRL_T_COMMAND"
-      bind -M insert \ct fzf-file-widget
-    end
-    if not set -q FZF_ALT_C_COMMAND; or test -n "$FZF_ALT_C_COMMAND"
-      bind -M insert \ec fzf-cd-widget
-    end
+  bind -M insert \cr fzf-history-widget
+  if not set -q FZF_CTRL_T_COMMAND; or test -n "$FZF_CTRL_T_COMMAND"
+    bind -M insert \ct fzf-file-widget
+  end
+  if not set -q FZF_ALT_C_COMMAND; or test -n "$FZF_ALT_C_COMMAND"
+    bind -M insert \ec fzf-cd-widget
   end
 
   function __fzf_parse_commandline -d 'Parse the current command line token and return split of existing filepath, fzf query, and optional -option= prefix'


### PR DESCRIPTION
This was originally proposed in #171 to detect support for `bind -M`, but versions _not_ supporting the feature were long archaic, and the detection practically becomes `if true`:

```shellsession
$ codespace:/> fish --version
fish, version 3.1.0
$ codespace:/> bind -M insert # By default there's no mode-specific bindings
$ codespace:/> if bind -M insert &> /dev/null; echo true; end
true
```

It also has a small cost for users with considerable mode-specific bindings, e.g. with `fish_vi_key_bindings` enabled:

```shellsession
$ time bind -M insert &> /dev/null

________________________________________________________
Executed in    1.34 millis    fish           external 
   usr time  541.00 micros  541.00 micros    0.00 micros 
   sys time  492.00 micros  492.00 micros    0.00 micros
```

(Note in this very case it's just ~1ms, but this check is prevalent and can add up. I'd like to address this in other programs too.)