### PR TITLE
[fish] Optimize history formatting without perl

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -73,11 +73,10 @@ function fzf_key_bindings
           builtin history -z --reverse | command perl -0 -pe 's/^/$.\t/g; s/\n/\n\t/gm' | eval (__fzfcmd) --tac --read0 --print0 -q '(commandline)' | string replace -r '^\d*\t' '' | read -lz result
           and commandline -- $result
         else
-          set -l line 0
-          for i in (builtin history -z --reverse | string split0)
-            set line (math $line + 1)
-            string escape -n -- $line\t(string replace -a -- \n \n\t $i | string collect)
-          end | string join0 | string unescape -n | eval (__fzfcmd) --tac --read0 --print0 -q '(commandline)' | string replace -r '^\d*\t' '' | read -lz result
+          set -l h (builtin history -z | string split0)
+          for i in (seq (count $h) -1 1)
+            string join0 -- $i\t(string replace -a -- \n \n\t $h[$i] | string collect)
+          end | eval (__fzfcmd) --read0 --print0 -q '(commandline)' | string replace -r '^\d*\t' '' | read -lz result
           and commandline -- $result
         end
       else


### PR DESCRIPTION
The previous bug fix made the operation 2x slower. With this change, it becomes almost as fast as before.

I have another change I've been testing locally, which begins to display the results instantly (but it's a bigger change and it depends on this code, so it's better to be in another PR). Currently, because the fzf command is being constructed using eval, it becomes blocking (fish blocks when executing builtins). Consider for example:
```fish
for i in (seq 5); echo $i; sleep 1; end | eval (echo fzf)
```
Versus:
```fish
for i in (seq 5); echo $i; sleep 1; end | fzf
```