### PR TITLE
[fish] Allow setting multi-select and list reload for history

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -61,7 +61,7 @@ function fzf_key_bindings
       # merge history from other sessions before searching
       test -z "$fish_private_mode"; and builtin history merge
 
-      set -lx FZF_DEFAULT_OPTS (__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '"\t"↳ ' --highlight-line $FZF_CTRL_R_OPTS +m")
+      set -lx FZF_DEFAULT_OPTS (__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '"\t"↳ ' --highlight-line +m $FZF_CTRL_R_OPTS")
       set -lx FZF_DEFAULT_OPTS_FILE ''
       set -lx FZF_DEFAULT_COMMAND
       string match -q -r -- '/fish$' $SHELL; or set -lx SHELL (type -p fish)
@@ -75,8 +75,8 @@ function fzf_key_bindings
           'string join0 -- $i\t(string replace -a -- \n \n\t $h[$i] | string collect);' \
           'end'
       end
-      set -l result (eval "$FZF_DEFAULT_COMMAND | $(__fzfcmd) --read0 --print0 -q (commandline)")
-      and commandline -- (string replace -r -- '^\d*\t' '' $result)
+      set -l result (eval "$FZF_DEFAULT_COMMAND | $(__fzfcmd) --read0 --print0 -q (commandline) --bind='enter:become:string replace -a -- \n\t \n {2..} | string collect'")
+      and commandline -- $result
     end
     commandline -f repaint
   end

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -57,32 +57,21 @@ function fzf_key_bindings
   function fzf-history-widget -d "Show command history"
     test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
     begin
-      set -l FISH_MAJOR (string split -- '.' $version)[1]
-      set -l FISH_MINOR (string split -- '.' $version)[2]
-
       # merge history from other sessions before searching
       test -z "$fish_private_mode"; and builtin history merge
 
-      # history's -z flag is needed for multi-line support.
-      # history's -z flag was added in fish 2.4.0, so don't use it for versions
-      # before 2.4.0.
-      if test "$FISH_MAJOR" -gt 2 -o \( "$FISH_MAJOR" -eq 2 -a "$FISH_MINOR" -ge 4 \)
-        set -lx FZF_DEFAULT_OPTS (__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '"\t"↳ ' --highlight-line $FZF_CTRL_R_OPTS +m")
-        set -lx FZF_DEFAULT_OPTS_FILE ''
-        if type -q perl
-          set -l fzf_command (__fzfcmd) --tac --read0 --print0 -q (commandline)
-          builtin history -z --reverse | command perl -0 -pe 's/^/$.\t/g; s/\n/\n\t/gm' | $fzf_command | string replace -r '^\d*\t' '' | read -lz result
-          and commandline -- $result
-        else
-          set -l h (builtin history -z | string split0)
-          set -l fzf_command (__fzfcmd) --read0 --print0 -q (commandline)
-          for i in (seq (count $h) -1 1)
-            string join0 -- $i\t(string replace -a -- \n \n\t $h[$i] | string collect)
-          end | $fzf_command | string replace -r '^\d*\t' '' | read -lz result
-          and commandline -- $result
-        end
+      set -lx FZF_DEFAULT_OPTS (__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '"\t"↳ ' --highlight-line $FZF_CTRL_R_OPTS +m")
+      set -lx FZF_DEFAULT_OPTS_FILE ''
+      if type -q perl
+        set -l fzf_command (__fzfcmd) --tac --read0 --print0 -q (commandline)
+        builtin history -z --reverse | command perl -0 -pe 's/^/$.\t/g; s/\n/\n\t/gm' | $fzf_command | string replace -r '^\d*\t' '' | read -lz result
+        and commandline -- $result
       else
-        builtin history | eval (__fzfcmd) -q '(commandline)' | read -l result
+        set -l h (builtin history -z | string split0)
+        set -l fzf_command (__fzfcmd) --read0 --print0 -q (commandline)
+        for i in (seq (count $h) -1 1)
+          string join0 -- $i\t(string replace -a -- \n \n\t $h[$i] | string collect)
+        end | $fzf_command | string replace -r '^\d*\t' '' | read -lz result
         and commandline -- $result
       end
     end


### PR DESCRIPTION
The purpose of this PR is twofold:
- Allow users to extend the history widget functionality, so that it can delete selected items and reload the list, with something like:

```fish
set -gx FZF_CTRL_R_OPTS '--multi --bind=\'ctrl-x:execute(eval history delete -- (string escape -- {+2..} | string replace -a "\n\t" "\n"))+reload(eval $FZF_DEFAULT_COMMAND)\''
```

- Make the loading of history items non-blocking.