### PR TITLE
[fish] Fix compatibility with v3.1.2 - v3.3.1

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -75,7 +75,7 @@ function fzf_key_bindings
           'string join0 -- $i\t(string replace -a -- \n \n\t $h[$i] | string collect);' \
           'end'
       end
-      set -l result (eval "$FZF_DEFAULT_COMMAND | $(__fzfcmd) --read0 --print0 -q (commandline) --bind='enter:become:string replace -a -- \n\t \n {2..} | string collect'")
+      set -l result (eval $FZF_DEFAULT_COMMAND \| (__fzfcmd) --read0 --print0 -q (commandline | string escape) "--bind=enter:become:'string replace -a -- \n\t \n {2..} | string collect'")
       and commandline -- $result
     end
     commandline -f repaint


### PR DESCRIPTION
Don't use the command substitution syntax: $(cmd)

Fix #4196

---

I tested this change with versions 3.3.1, 3.1.2, and 3.0.2.

The first two work but the last has issues: The `string` command doesn't have the `collect` subcommand (was added in v3.1b1), and `cd` doesn't have the `--` switch (couldn't find the the version that was added).

Version 3.1.1 had broken `eval`. The remaining versions 3.1.0 and 3.1b1, may or may not work.

So, the oldest tested working version is 3.1.2.