### PR TITLE
[fish] Improve fish binary path detection

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -64,7 +64,8 @@ function fzf_key_bindings
       set -lx FZF_DEFAULT_OPTS (__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort --wrap-sign '"\t"↳ ' --highlight-line +m $FZF_CTRL_R_OPTS")
       set -lx FZF_DEFAULT_OPTS_FILE ''
       set -lx FZF_DEFAULT_COMMAND
-      string match -q -r -- '/fish$' $SHELL; or set -lx SHELL (type -p fish)
+      set -a -- FZF_DEFAULT_OPTS --with-shell=(status fish-path)\\ -c
+
       if type -q perl
         set -a FZF_DEFAULT_OPTS '--tac'
         set FZF_DEFAULT_COMMAND 'builtin history -z --reverse | command perl -0 -pe \'s/^/$.\t/g; s/\n/\n\t/gm\''


### PR DESCRIPTION
Instead of exporting a local `$SHELL` containing the location of fish in `$PATH` when global `$SHELL` is not fish, always set `--with-shell` with the actual binary path of fish that the function is running from.

This change ensures that fzf is executing the shell commands using the same fish binary that the function is running with. Can be useful now that the upcoming version of fish can be self-installable (https://github.com/fish-shell/fish-shell/pull/10367), coexisting with a different system installed version, or when testing different builds of fish in general. Tested to work with fish v3.1.2.