### PR TITLE
Add --no-input to hide the input section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ CHANGELOG
   ```
     - `$FZF_KEY` was updated to expose the type of the click. e.g. `click`, `ctrl-click`, etc. You can use it to implement a more sophisticated behavior.
     - `kill` completion for bash and zsh were updated to use this feature
+- Added `--no-input` option to completely disable and hide the input section
 - Extended `{q}` placeholder to support ranges. e.g. `{q:1}`, `{q:2..}`, etc.
 - Added `search(...)` and `transform-search(...)` action to trigger an fzf search with an arbitrary query string. This can be used to extend the search syntax of fzf. In the following example, fzf will use the first word of the query to trigger ripgrep search, and use the rest of the query to perform fzf search within the result.
   ```sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ CHANGELOG
     - `$FZF_KEY` was updated to expose the type of the click. e.g. `click`, `ctrl-click`, etc. You can use it to implement a more sophisticated behavior.
     - `kill` completion for bash and zsh were updated to use this feature
 - Added `--no-input` option to completely disable and hide the input section
+  ```sh
+  # Click header to trigger search
+  fzf --header '[src] [test]' --no-input --layout reverse \
+      --header-border bottom --input-border \
+      --bind 'click-header:transform-search:echo ${FZF_CLICK_HEADER_WORD:1:-1}'
+  ```
 - Extended `{q}` placeholder to support ranges. e.g. `{q:1}`, `{q:2..}`, etc.
 - Added `search(...)` and `transform-search(...)` action to trigger an fzf search with an arbitrary query string. This can be used to extend the search syntax of fzf. In the following example, fzf will use the first word of the query to trigger ripgrep search, and use the rest of the query to perform fzf search within the result.
   ```sh

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -621,6 +621,11 @@ Position of the list label
 .SS INPUT SECTION
 
 .TP
+.B "\-\-no\-input"
+Disable and hide the input section. You can no longer type in queries. To
+trigger a search, use \fBsearch\fR action.
+
+.TP
 .BI "\-\-prompt=" "STR"
 Input prompt (default: '> ')
 .TP

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1358,7 +1358,10 @@ func (t *Terminal) Input() (bool, []rune) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	paused := t.paused
-	src := t.input
+	var src []rune
+	if !t.inputless {
+		src = t.input
+	}
 	if t.inputOverride != nil {
 		paused = false
 		src = *t.inputOverride

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1129,9 +1129,15 @@ func (t *Terminal) visibleHeaderLinesInList() int {
 
 // Extra number of lines needed to display fzf
 func (t *Terminal) extraLines() int {
-	extra := 1
-	if t.inputBorderShape.Visible() {
-		extra += borderLines(t.inputBorderShape)
+	extra := 0
+	if !t.inputless {
+		extra++
+		if !t.noSeparatorLine() {
+			extra++
+		}
+		if t.inputBorderShape.Visible() {
+			extra += borderLines(t.inputBorderShape)
+		}
 	}
 	if t.listBorderShape.Visible() {
 		extra += borderLines(t.listBorderShape)
@@ -1145,9 +1151,6 @@ func (t *Terminal) extraLines() int {
 			extra += borderLines(t.headerLinesShape)
 		}
 		extra += t.headerLines
-	}
-	if !t.noSeparatorLine() {
-		extra++
 	}
 	return extra
 }
@@ -1640,8 +1643,11 @@ func (t *Terminal) adjustMarginAndPadding() (int, int, [4]int, [4]int) {
 
 	minAreaWidth := minWidth
 	minAreaHeight := minHeight
+	if t.inputless {
+		minAreaHeight--
+	}
 	if t.noSeparatorLine() {
-		minAreaHeight -= 1
+		minAreaHeight--
 	}
 	if t.needPreviewWindow() {
 		minPreviewWidth, minPreviewHeight := t.minPreviewSize(t.activePreviewOpts)
@@ -1878,6 +1884,9 @@ func (t *Terminal) resizeWindows(forcePreview bool, redrawBorder bool) {
 			switch previewOpts.position {
 			case posUp, posDown:
 				minWindowHeight := minHeight
+				if t.inputless {
+					minWindowHeight--
+				}
 				if t.noSeparatorLine() {
 					minWindowHeight--
 				}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1358,10 +1358,7 @@ func (t *Terminal) Input() (bool, []rune) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	paused := t.paused
-	var src []rune
-	if !t.inputless {
-		src = t.input
-	}
+	src := t.input
 	if t.inputOverride != nil {
 		paused = false
 		src = *t.inputOverride

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1270,7 +1270,7 @@ func (t *Terminal) parsePrompt(prompt string) (func(), int) {
 }
 
 func (t *Terminal) noSeparatorLine() bool {
-	return noSeparatorLine(t.infoStyle, t.separatorLen > 0)
+	return t.inputless || noSeparatorLine(t.infoStyle, t.separatorLen > 0)
 }
 
 func getScrollbar(perLine int, total int, height int, offset int) (int, int) {
@@ -5695,7 +5695,7 @@ func (t *Terminal) Loop() error {
 					// Header
 					numLines := t.visibleHeaderLinesInList()
 					lineOffset := 0
-					if t.inputWindow == nil && !t.headerFirst {
+					if !t.inputless && t.inputWindow == nil && !t.headerFirst {
 						// offset for info line
 						if t.noSeparatorLine() {
 							lineOffset = 1

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1358,7 +1358,10 @@ func (t *Terminal) Input() (bool, []rune) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 	paused := t.paused
-	src := t.input
+	var src []rune
+	if !t.inputless {
+		src = t.input
+	}
 	if t.inputOverride != nil {
 		paused = false
 		src = *t.inputOverride
@@ -5853,9 +5856,9 @@ func (t *Terminal) Loop() error {
 				continue
 			}
 			if t.inputless {
-				// Always just discard the query
-				t.input = nil
-				t.cx = 0
+				// Always just discard the change
+				t.input = previousInput
+				t.cx = len(t.input)
 			} else {
 				t.truncateQuery()
 			}

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2523,7 +2523,7 @@ func (t *Terminal) headerIndent(borderShape tui.BorderShape) int {
 
 func (t *Terminal) printHeaderImpl(window tui.Window, borderShape tui.BorderShape, lines1 []string, lines2 []string) {
 	max := t.window.Height()
-	if t.inputWindow == nil && window == nil && t.headerFirst {
+	if !t.inputless && t.inputWindow == nil && window == nil && t.headerFirst {
 		max--
 		if !t.noSeparatorLine() {
 			max--
@@ -2553,7 +2553,7 @@ func (t *Terminal) printHeaderImpl(window tui.Window, borderShape tui.BorderShap
 		if needReverse && idx < len(lines1) {
 			line = len(lines1) - idx - 1
 		}
-		if t.inputWindow == nil && window == nil && !t.headerFirst {
+		if !t.inputless && t.inputWindow == nil && window == nil && !t.headerFirst {
 			line++
 			if !t.noSeparatorLine() {
 				line++

--- a/src/tui/dummy.go
+++ b/src/tui/dummy.go
@@ -45,6 +45,7 @@ func (r *FullscreenRenderer) Clear()                             {}
 func (r *FullscreenRenderer) NeedScrollbarRedraw() bool          { return false }
 func (r *FullscreenRenderer) ShouldEmitResizeEvent() bool        { return false }
 func (r *FullscreenRenderer) Bell()                              {}
+func (r *FullscreenRenderer) HideCursor()                        {}
 func (r *FullscreenRenderer) Refresh()                           {}
 func (r *FullscreenRenderer) Close()                             {}
 func (r *FullscreenRenderer) Size() TermSize                     { return TermSize{} }

--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -52,6 +52,7 @@ type TcellWindow struct {
 	borderStyle BorderStyle
 	uri         *string
 	params      *string
+	showCursor  bool
 }
 
 func (w *TcellWindow) Top() int {
@@ -72,7 +73,9 @@ func (w *TcellWindow) Height() int {
 
 func (w *TcellWindow) Refresh() {
 	if w.moveCursor {
-		_screen.ShowCursor(w.left+w.lastX, w.top+w.lastY)
+		if w.showCursor {
+			_screen.ShowCursor(w.left+w.lastX, w.top+w.lastY)
+		}
 		w.moveCursor = false
 	}
 	w.lastX = 0
@@ -102,6 +105,10 @@ const (
 
 func (r *FullscreenRenderer) Bell() {
 	_screen.Beep()
+}
+
+func (r *FullscreenRenderer) HideCursor() {
+	r.showCursor = false
 }
 
 func (r *FullscreenRenderer) PassThrough(str string) {
@@ -167,6 +174,9 @@ func (r *FullscreenRenderer) getScreen() (tcell.Screen, error) {
 		s, e := tcell.NewScreen()
 		if e != nil {
 			return nil, e
+		}
+		if !r.showCursor {
+			s.HideCursor()
 		}
 		_screen = s
 	}
@@ -590,7 +600,8 @@ func (r *FullscreenRenderer) NewWindow(top int, left int, width int, height int,
 		width:       width,
 		height:      height,
 		normal:      normal,
-		borderStyle: borderStyle}
+		borderStyle: borderStyle,
+		showCursor:  r.showCursor}
 	w.Erase()
 	return w
 }

--- a/src/tui/tui.go
+++ b/src/tui/tui.go
@@ -615,6 +615,7 @@ type Renderer interface {
 	NeedScrollbarRedraw() bool
 	ShouldEmitResizeEvent() bool
 	Bell()
+	HideCursor()
 
 	GetChar() Event
 
@@ -662,6 +663,7 @@ type FullscreenRenderer struct {
 	forceBlack   bool
 	prevDownTime time.Time
 	clicks       [][2]int
+	showCursor   bool
 }
 
 func NewFullscreenRenderer(theme *ColorTheme, forceBlack bool, mouse bool) Renderer {
@@ -670,7 +672,8 @@ func NewFullscreenRenderer(theme *ColorTheme, forceBlack bool, mouse bool) Rende
 		mouse:        mouse,
 		forceBlack:   forceBlack,
 		prevDownTime: time.Unix(0, 0),
-		clicks:       [][2]int{}}
+		clicks:       [][2]int{},
+		showCursor:   true}
 	return r
 }
 

--- a/test/test_layout.rb
+++ b/test/test_layout.rb
@@ -876,4 +876,19 @@ class TestLayout < TestInteractive
     BLOCK
     tmux.until { assert_block(block, _1) }
   end
+
+  def test_min_height_auto_no_input
+    tmux.send_keys %(seq 100 | #{FZF} --style full:sharp --no-input --height 1% --min-height 5+), :Enter
+
+    block = <<~BLOCK
+      ┌─────────
+      │   5
+      │   4
+      │   3
+      │   2
+      │ > 1
+      └─────────
+    BLOCK
+    tmux.until { assert_block(block, _1) }
+  end
 end


### PR DESCRIPTION
Close #2890
Close #1396

I can't think of many use cases. Maybe for really simple menus?

You can't type in queries in this mode, and the only way to trigger an fzf search is to use `search(...)` or `transform-search(...)` action.

```sh
# Click header to trigger search
fzf --header '[src] [test]' --no-input --layout reverse \
    --header-border bottom --input-border \
    --bind 'click-header:transform-search:echo ${FZF_CLICK_HEADER_WORD:1:-1}'
```

<img width="855" alt="image" src="https://github.com/user-attachments/assets/6f5a315f-078a-4319-b34e-6990d660f3dd" />

## Issues

* Any action that changes the query is simply ignored.
* Should we respect the initial query? e.g. `fzf --no-input --query a`
    * This may give the wrong impression that the "query" is still respected in this mode
    * The same can be done using `start` event. i.e. `fzf --no-input --bind start:search:a`