### PR TITLE
Prepand PATH expansion instead of append

### DIFF
--- a/install
+++ b/install
@@ -259,7 +259,7 @@ for shell in $shells; do
 # Setup fzf
 # ---------
 if [[ ! "\$PATH" == *$fzf_base_esc/bin* ]]; then
-  PATH="\${PATH:+\${PATH}:}$fzf_base/bin"
+  PATH="$fzf_base/bin\${PATH:+:\${PATH}}"
 fi
 
 EOF

--- a/test/lib/common.sh
+++ b/test/lib/common.sh
@@ -9,7 +9,7 @@ export FZF_DEFAULT_OPTS="--no-scrollbar --pointer '>' --marker '>'"
 # Setup fzf
 # ---------
 if [[ ! "$PATH" == *<%= BASE %>/bin* ]]; then
-  export PATH="${PATH:+${PATH}:}<%= BASE %>/bin"
+  export PATH="<%= BASE %>/bin${PATH:+:${PATH}}"
 fi
 
 # Auto-completion


### PR DESCRIPTION
This improves the evaluation of fzf when there is another version globally installed. So the custom downloaded/installed version takes precendence over the version installed by a packager manager for example.