### PR TITLE
Fix bin/fzf-preview.sh to make image preview work on ghostty terminal

### DIFF
--- a/bin/fzf-preview.sh
+++ b/bin/fzf-preview.sh
@@ -58,7 +58,7 @@ elif ! [[ $KITTY_WINDOW_ID ]] && (( FZF_PREVIEW_TOP + FZF_PREVIEW_LINES == $(stt
 fi
 
 # 1. Use icat (from Kitty) if kitten is installed
-if command -v kitten > /dev/null; then
+if [[ $KITTY_WINDOW_ID ]] || [[ $GHOSTTY_RESOURCES_DIR ]] && command -v kitten > /dev/null; then
   # 1. 'memory' is the fastest option but if you want the image to be scrollable,
   #    you have to use 'stream'.
   #

--- a/bin/fzf-preview.sh
+++ b/bin/fzf-preview.sh
@@ -57,15 +57,15 @@ elif ! [[ $KITTY_WINDOW_ID ]] && (( FZF_PREVIEW_TOP + FZF_PREVIEW_LINES == $(stt
   dim=${FZF_PREVIEW_COLUMNS}x$((FZF_PREVIEW_LINES - 1))
 fi
 
-# 1. Use kitty icat on kitty terminal and ghostty terminal
-if [[ $KITTY_WINDOW_ID || $GHOSTTY_RESOURCES_DIR ]]; then
+# 1. Use icat (from Kitty) if kitten is installed
+if command -v kitten > /dev/null; then
   # 1. 'memory' is the fastest option but if you want the image to be scrollable,
   #    you have to use 'stream'.
   #
   # 2. The last line of the output is the ANSI reset code without newline.
   #    This confuses fzf and makes it render scroll offset indicator.
   #    So we remove the last line and append the reset code to its previous line.
-  kitty icat --clear --transfer-mode=memory --unicode-placeholder --stdin=no --place="$dim@0x0" "$file" | sed '$d' | sed $'$s/$/\e[m/'
+  kitten icat --clear --transfer-mode=memory --unicode-placeholder --stdin=no --place="$dim@0x0" "$file" | sed '$d' | sed $'$s/$/\e[m/'
 
 # 2. Use chafa with Sixel output
 elif command -v chafa > /dev/null; then

--- a/bin/fzf-preview.sh
+++ b/bin/fzf-preview.sh
@@ -57,8 +57,8 @@ elif ! [[ $KITTY_WINDOW_ID ]] && (( FZF_PREVIEW_TOP + FZF_PREVIEW_LINES == $(stt
   dim=${FZF_PREVIEW_COLUMNS}x$((FZF_PREVIEW_LINES - 1))
 fi
 
-# 1. Use kitty icat on kitty terminal
-if [[ $KITTY_WINDOW_ID ]]; then
+# 1. Use kitty icat on kitty terminal and ghostty terminal
+if [[ $KITTY_WINDOW_ID || $GHOSTTY_RESOURCES_DIR ]]; then
   # 1. 'memory' is the fastest option but if you want the image to be scrollable,
   #    you have to use 'stream'.
   #


### PR DESCRIPTION
Fix bin/fzf-preview.sh so that image preview works on [ghostty](https://github.com/ghostty-org/ghostty) terminal.

# Issue

Despite [ghostty supporting the Kitten graphics protocol](https://ghostty.org/docs/features), the image preview does not work even if `kitten` is installed on the system because the script only checks for the `KITTY_WINDOW_ID` environment variable, which is unset in ghostty terminal sessions.
So, when trying to preview images in ghostty, it merely prints the file type:
```console
coko7@example:~$ ./fzf-preview.sh arch_rainbow.png
arch_rainbow.png: PNG image data, 3840 x 2160, 8-bit/color RGBA, non-interlaced
```

# Solution

Check if `kitten` is installed on the system using `command -v kitten`.
See: https://sw.kovidgoyal.net/kitty/kittens_intro/