### PR TITLE
[fish] Unescape query from commandline

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -154,8 +154,8 @@ function fzf_key_bindings
     # eval is used to do shell expansion on paths
     eval set commandline $commandline
 
-    # Combine multiple consecutive slashes into one
-    set commandline (string replace -r -a -- '/+' '/' $commandline)
+    # Combine multiple consecutive slashes into one, and unescape.
+    set commandline (string replace -r -a -- '/+' '/' $commandline | string unescape -n)
 
     if test -z "$commandline"
       # Default to current directory with no --query
@@ -171,10 +171,8 @@ function fzf_key_bindings
         # if $dir is "." but commandline is not a relative path, this means no file path found
         set fzf_query $commandline
       else
-        # Special characters must be double escaped.
-        set -l re_dir (string escape -n -- $dir)
         # Also remove trailing slash after dir, to "split" input properly
-        set fzf_query (string replace -r -- "^$re_dir/?" '' $commandline)
+        set fzf_query (string replace -r -- "^$dir/?" '' $commandline)
       end
     end
 
@@ -184,7 +182,7 @@ function fzf_key_bindings
   end
 
   function __fzf_get_dir -d 'Find the longest existing filepath from input string'
-    set dir (string unescape -n -- $argv)
+    set dir $argv
 
     # Strip trailing slash, unless $dir is root dir (/)
     set dir (string replace -r -- '(?<!^)/$' '' $dir)


### PR DESCRIPTION
This tackles the issue discussed in https://github.com/junegunn/fzf/pull/4230#issuecomment-2645173485. It makes the query taken from command line, be similar to that of bash and zsh, without sacrificing compatibility with old fish versions. Outer open quotes are removed - more details and examples in commit message.

Now, pressing `<CTRL-T>`/`<ALT-C>` after the shell has auto-completed part of a file/dir name with special characters, works as expected:

```
touch /tmp/fzf-test\ \"{a,b}\"
ls /tmp/fzf-test<TAB>
ls /tmp/fzf-test\ \"<CTRL-T>
```

The query becomes: `fzf-test "`
