### PR TITLE
[fish] Small clean-ups and optimizations

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -109,8 +109,7 @@ function fzf_key_bindings
   end
 
   function __fzfcmd
-    test -n "$FZF_TMUX"; or set FZF_TMUX 0
-    test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
+    test -n "$FZF_TMUX_HEIGHT"; or set -l FZF_TMUX_HEIGHT 40%
     if test -n "$FZF_TMUX_OPTS"
       echo "fzf-tmux $FZF_TMUX_OPTS -- "
     else if test "$FZF_TMUX" = "1"

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -14,6 +14,10 @@
 
 # Key bindings
 # ------------
+# For compatibility with fish versions down to 3.1.2, the script does not use:
+# - The -f/--function switch of command: set
+# - The process substitution syntax: $(cmd)
+# - Ranges that omit start/end indexes: $var[$start..] $var[..$end] $var[..]
 function fzf_key_bindings
 
   function __fzf_defaults

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -116,18 +116,15 @@ function fzf_key_bindings
   end
 
   bind \cr fzf-history-widget
+  bind -M insert \cr fzf-history-widget
+
   if not set -q FZF_CTRL_T_COMMAND; or test -n "$FZF_CTRL_T_COMMAND"
     bind \ct fzf-file-widget
-  end
-  if not set -q FZF_ALT_C_COMMAND; or test -n "$FZF_ALT_C_COMMAND"
-    bind \ec fzf-cd-widget
-  end
-
-  bind -M insert \cr fzf-history-widget
-  if not set -q FZF_CTRL_T_COMMAND; or test -n "$FZF_CTRL_T_COMMAND"
     bind -M insert \ct fzf-file-widget
   end
+
   if not set -q FZF_ALT_C_COMMAND; or test -n "$FZF_ALT_C_COMMAND"
+    bind \ec fzf-cd-widget
     bind -M insert \ec fzf-cd-widget
   end
 

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -32,27 +32,22 @@ function fzf_key_bindings
     set -lx dir $commandline[1]
     set -l fzf_query $commandline[2]
     set -l prefix $commandline[3]
-    set -l result
 
-    test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
-    begin
-      set -lx FZF_DEFAULT_OPTS (__fzf_defaults "--reverse --walker=file,dir,follow,hidden --scheme=path --walker-root=$dir" "$FZF_CTRL_T_OPTS")
-      set -lx FZF_DEFAULT_COMMAND "$FZF_CTRL_T_COMMAND"
-      set -lx FZF_DEFAULT_OPTS_FILE ''
-      set result (eval (__fzfcmd) -m --query=$fzf_query)
-    end
-    if test -z "$result"
-      commandline -f repaint
-      return
-    else
+    set -lx FZF_DEFAULT_OPTS (__fzf_defaults \
+      "--reverse --walker=file,dir,follow,hidden --scheme=path --walker-root=$dir" \
+      "$FZF_CTRL_T_OPTS --multi")
+
+    set -lx FZF_DEFAULT_COMMAND "$FZF_CTRL_T_COMMAND"
+    set -lx FZF_DEFAULT_OPTS_FILE
+
+    if set -l result (eval (__fzfcmd) --query=$fzf_query)
       # Remove last token from commandline.
-      commandline -t ""
+      commandline -t ''
+      for i in $result
+        commandline -it -- $prefix(string escape -- $i)' '
+      end
     end
-    for i in $result
-      commandline -it -- $prefix
-      commandline -it -- (string escape -- $i)
-      commandline -it -- ' '
-    end
+
     commandline -f repaint
   end
 

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -17,12 +17,13 @@
 function fzf_key_bindings
 
   function __fzf_defaults
-    # $1: Prepend to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
-    # $2: Append to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
-    test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
-    echo "--height $FZF_TMUX_HEIGHT --min-height 20+ --bind=ctrl-z:ignore" $argv[1]
-    test -r "$FZF_DEFAULT_OPTS_FILE"; and string collect -N -- <$FZF_DEFAULT_OPTS_FILE
-    echo $FZF_DEFAULT_OPTS $argv[2]
+    # $argv[1]: Prepend to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
+    # $argv[2..]: Append to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
+    test -n "$FZF_TMUX_HEIGHT"; or set -l FZF_TMUX_HEIGHT 40%
+    string join ' ' -- \
+      "--height $FZF_TMUX_HEIGHT --min-height=20+ --bind=ctrl-z:ignore" $argv[1] \
+      (test -r "$FZF_DEFAULT_OPTS_FILE"; and string join -- ' ' <$FZF_DEFAULT_OPTS_FILE) \
+      $FZF_DEFAULT_OPTS $argv[2..-1]
   end
 
   # Store current token in $dir as root for the 'find' command

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -89,20 +89,16 @@ function fzf_key_bindings
     set -l fzf_query $commandline[2]
     set -l prefix $commandline[3]
 
-    test -n "$FZF_TMUX_HEIGHT"; or set FZF_TMUX_HEIGHT 40%
-    begin
-      set -lx FZF_DEFAULT_OPTS (__fzf_defaults "--reverse --walker=dir,follow,hidden --scheme=path --walker-root=$dir" "$FZF_ALT_C_OPTS")
-      set -lx FZF_DEFAULT_OPTS_FILE ''
-      set -lx FZF_DEFAULT_COMMAND "$FZF_ALT_C_COMMAND"
-      set -l result (eval (__fzfcmd) +m --query=$fzf_query)
+    set -lx FZF_DEFAULT_OPTS (__fzf_defaults \
+      "--reverse --walker=dir,follow,hidden --scheme=path --walker-root=$dir" \
+      "$FZF_ALT_C_OPTS --no-multi")
 
-      if test -n "$result"
-        cd -- $result
+    set -lx FZF_DEFAULT_OPTS_FILE
+    set -lx FZF_DEFAULT_COMMAND "$FZF_ALT_C_COMMAND"
 
-        # Remove last token from commandline.
-        commandline -t ""
-        commandline -it -- $prefix
-      end
+    if set -l result (eval (__fzfcmd) --query=$fzf_query)
+      cd -- $result
+      commandline -rt -- $prefix
     end
 
     commandline -f repaint


### PR DESCRIPTION
Minor all-around code improvements and clean-ups. No actual changes to the operation of the script. Tested to work with fish versions 3.1.2, 3.7.1 and 4.0b1-430-g5e38a2a46.

Independently of these changes, even though everything seems to work with the beta version 4.0 of fish, there is (again) one test that inconsistently fails (only with v4):

```
TestFish#test_ctrl_r_multiline [test/test_shell_integration.rb:137]:
Expected "" to include "\"foo".
```
