### PR TITLE
[zsh/completion] don't unescape FZF_DEFAULT_OPTS

### DIFF
--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -99,9 +99,9 @@ if [[ -o interactive ]]; then
 __fzf_defaults() {
   # $1: Prepend to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
   # $2: Append to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
-  echo "--height ${FZF_TMUX_HEIGHT:-40%} --min-height 20+ --bind=ctrl-z:ignore $1"
+  echo -E "--height ${FZF_TMUX_HEIGHT:-40%} --min-height 20+ --bind=ctrl-z:ignore $1"
   command cat "${FZF_DEFAULT_OPTS_FILE-}" 2> /dev/null
-  echo "${FZF_DEFAULT_OPTS-} $2"
+  echo -E "${FZF_DEFAULT_OPTS-} $2"
 }
 
 __fzf_comprun() {


### PR DESCRIPTION
With zsh, binding `ctrl-\` in `FZF_DEFAULT_OPTS` breaks fzf completion trigger (but fzf-history-widget `ctrl-r` works). Turns out `__fzf_defaults` unescapes the backslash. This PR intends to fix that.

to reproduce: use config below and trigger fzf completions with `$FZF_COMPLETION_TRIGGER`:
```
export FZF_DEFAULT_OPTS='--bind=ctrl-\\:toggle-track'
```