### PR TITLE
Fix condition for using item numlines cache

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1347,7 +1347,7 @@ func (t *Terminal) numItemLines(item *Item, atMost int) (int, bool) {
 	}
 	if cached, prs := t.numLinesCache[item.Index()]; prs {
 		// Can we use this cache? Let's be conservative.
-		if cached.atMost >= atMost {
+		if cached.atMost <= atMost {
 			return cached.numLines, false
 		}
 	}


### PR DESCRIPTION
This fixes the bug where the first item was being truncated as discussed in #4282.