### PR TITLE
[fish] Fix for newlines and other characters

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -96,12 +96,12 @@ function fzf_key_bindings
 
     set -lx FZF_DEFAULT_OPTS (__fzf_defaults \
       "--reverse --walker=file,dir,follow,hidden --scheme=path --walker-root=$dir" \
-      "$FZF_CTRL_T_OPTS --multi")
+      "$FZF_CTRL_T_OPTS --multi --print0")
 
     set -lx FZF_DEFAULT_COMMAND "$FZF_CTRL_T_COMMAND"
     set -lx FZF_DEFAULT_OPTS_FILE
 
-    if set -l result (eval (__fzfcmd) --query=$fzf_query)
+    if set -l result (eval (__fzfcmd) --query=$fzf_query | string split0)
       # Remove last token from commandline.
       commandline -t ''
       for i in $result
@@ -155,12 +155,12 @@ function fzf_key_bindings
 
     set -lx FZF_DEFAULT_OPTS (__fzf_defaults \
       "--reverse --walker=dir,follow,hidden --scheme=path --walker-root=$dir" \
-      "$FZF_ALT_C_OPTS --no-multi")
+      "$FZF_ALT_C_OPTS --no-multi --print0")
 
     set -lx FZF_DEFAULT_OPTS_FILE
     set -lx FZF_DEFAULT_COMMAND "$FZF_ALT_C_COMMAND"
 
-    if set -l result (eval (__fzfcmd) --query=$fzf_query)
+    if set -l result (eval (__fzfcmd) --query=$fzf_query | string split0)
       cd -- $result
       commandline -rt -- $prefix
     end


### PR DESCRIPTION
These changes fix issues with newlines in names, and escaped newlines and other characters in command line (more details in commit messages). For the last fix, the `__fzf_parse_commandline` function is rewritten, which now takes advantage of commands/options present in newer fish versions, while maintaining compatibility with the oldest supported version, which is actually v3.1b. All fish versions were individually tested, and they all seem to work, even v3.1.1 despite the reported issues with eval. Dropping support for versions older than v3.2.0 would simplify the code a little, but I think it's better to keep it for now, because v3.1.2 is on Debian 11.

I also have some observations relating the display of file/dir names by fzf:
- When the `--read0` option is not set, the ␤ symbol is not shown for trailing newlines in file names, while it is shown for directory names (after 6fa8295a, where the path separator is appended). I think it would be better to always show trailing newlines, so that file `foo` can be distinguished from `foo\n`.
- Except for new line and carriage return, no symbol is inserted for other whitespace characters: bell (could have U+2407 ␇), backspace (could have U+2408 ␈), form feed (could have U+240C ␌), vertical tab (could have U+240B ␋). 
- Tabs (horizontal) are replaced by spaces, making `foo\tbar` undistinguished from `foo        bar` (maybe it could be replaced by U+2409 ␉ instead, only for file/dir names).
- The path separator that is appended for directories (6fa8295a), is also applied to the root directory (causing it to be displayed as `//`): `fzf --walker{=dir,-root=/}`

