### PR TITLE
Fix panic when use header border without pointer/marker

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2647,6 +2647,9 @@ func (t *Terminal) headerIndent(borderShape tui.BorderShape) int {
 	}
 	if borderShape.HasLeft() {
 		indentSize -= 1 + t.borderWidth
+		if indentSize < 0 {
+			indentSize = 0
+		}
 	}
 	return indentSize
 }

--- a/test/test_layout.rb
+++ b/test/test_layout.rb
@@ -991,4 +991,16 @@ class TestLayout < TestInteractive
     BLOCK
     tmux.until { assert_block(block, it) }
   end
+
+  def test_header_border_no_pointer_and_marker
+    tmux.send_keys %(seq 10 | #{FZF} --header-lines 1 --header-border sharp --no-list-border --pointer '' --marker ''), :Enter
+    block = <<~BLOCK
+      ┌──────
+      │ 1
+      └──────
+        9/9 ─
+      >
+    BLOCK
+    tmux.until { assert_block(block, it) }
+  end
 end


### PR DESCRIPTION
```sh
FZF_DEFAULT_OPTS= FZF_DEFAULT_OPTS_FILE= fzf --header-border --pointer= --header-lines 1
```

```go
panic: strings: negative Repeat count

goroutine 58 [running]:
strings.Repeat({0x5c5f0633ad10?, 0x5c5f0633ad10?}, 0x1?)
	strings/strings.go:624 +0x585
github.com/junegunn/fzf/src.(*Terminal).printHeaderImpl(0xc000190008, {0x5c5f063a3978, 0xc00032c280?}, 0x4, {0x5c5f0656f960, 0x0, 0x5c5f062cde68?}, {0xc000114010, 0x1, 0x1})
	github.com/junegunn/fzf/src/terminal.go:2655 +0x1c6
github.com/junegunn/fzf/src.(*Terminal).printHeader.func1(...)
	github.com/junegunn/fzf/src/terminal.go:2610
github.com/junegunn/fzf/src.(*Terminal).withWindow(...)
	github.com/junegunn/fzf/src/terminal.go:1269
github.com/junegunn/fzf/src.(*Terminal).printHeader(0xc000190008)
	github.com/junegunn/fzf/src/terminal.go:2605 +0xe6
github.com/junegunn/fzf/src.(*Terminal).Loop.func8.2(0xc000010810)
	github.com/junegunn/fzf/src/terminal.go:4656 +0x565
github.com/junegunn/fzf/src/util.(*EventBox).Wait(0xc000010810, 0xc0002c7fa0)
	github.com/junegunn/fzf/src/util/eventbox.go:34 +0x5d
github.com/junegunn/fzf/src.(*Terminal).Loop.func8()
	github.com/junegunn/fzf/src/terminal.go:4581 +0xd7
created by github.com/junegunn/fzf/src.(*Terminal).Loop in goroutine 51
	github.com/junegunn/fzf/src/terminal.go:4559 +0x5fc
```
