### PR TITLE
Disable tmux popup when already running inside one

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -39,7 +39,7 @@ func (r revision) compatible(other revision) bool {
 // Run starts fzf
 func Run(opts *Options) (int, error) {
 	if opts.Filter == nil {
-		if opts.Tmux != nil && len(os.Getenv("TMUX")) > 0 && opts.Tmux.index >= opts.Height.index {
+		if opts.Tmux != nil && len(os.Getenv("TMUX")) > 0 && len(os.Getenv("TMUX_PANE")) > 0 && opts.Tmux.index >= opts.Height.index {
 			return runTmux(os.Args, opts)
 		}
 

--- a/src/proxy.go
+++ b/src/proxy.go
@@ -98,7 +98,8 @@ func runProxy(commandPrefix string, cmdBuilder func(temp string, needBash bool) 
 		validIdentifier := regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 		for _, pairStr := range os.Environ() {
 			pair := strings.SplitN(pairStr, "=", 2)
-			if validIdentifier.MatchString(pair[0]) {
+			// TMUX_PANE is never set inside a tmux popup, and should not be set so as to not be detected as a regular tmux pane
+			if validIdentifier.MatchString(pair[0]) && pair[0] != "TMUX_PANE" {
 				exports = append(exports, fmt.Sprintf("export %s=%s", pair[0], escapeSingleQuote(pair[1])))
 			} else if strings.HasPrefix(pair[0], "BASH_FUNC_") && strings.HasSuffix(pair[0], "%%") {
 				name := pair[0][10 : len(pair[0])-2]


### PR DESCRIPTION
`tmux popup` doesn't work and immediately returns instead when spawn inside one (`tmux popup tmux popup echo foo` results in an empty popup). For that reason, `fzf --tmux` doesn't work when executed inside a `tmux popup`, for example:

```shell
FZF_DEFAULT_OPTS=--tmux tmux popup 'find . | fzf'
```

And executing `fzf --tmux` inside `fzf --tmux` (as [`forgit`](https://github.com/wfxr/forgit) does, which was how I ran into this issue) also doesn't work, for example:

```shell
find . -type d | FZF_DEFAULT_OPTS=--tmux fzf --bind="enter:execute(find {} -type f | fzf | xargs less)"
```

A popup can be detected by the absence of the `TMUX_PANE` environment variable, so we can simply disable the `--tmux` mode when it is absent. And it also must be excluded for the exports in `runProxy()` so that the popup can also be detected properly by child processes.