### PR TITLE
Added some missing variables

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -1279,9 +1279,19 @@ fzf exports the following environment variables to its child processes.
 .br
 .BR FZF_PROMPT "          Prompt string"
 .br
+.BR FZF_GHOST "           Ghost string"
+.br
+.BR FZF_POINTER "         Pointer string"
+.br
 .BR FZF_PREVIEW_LABEL "   Preview label string"
 .br
 .BR FZF_BORDER_LABEL "    Border label string"
+.br
+.BR FZF_LIST_LABEL "      List label string"
+.br
+.BR FZF_INPUT_LABEL "     Input label string"
+.br
+.BR FZF_HEADER_LABEL "    Header label string"
 .br
 .BR FZF_ACTION "          The name of the last action performed"
 .br

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -1091,9 +1091,13 @@ func (t *Terminal) environImpl(forPreview bool) []string {
 	env = append(env, "FZF_ACTION="+t.lastAction.Name())
 	env = append(env, "FZF_KEY="+t.lastKey)
 	env = append(env, "FZF_PROMPT="+string(t.promptString))
+	env = append(env, "FZF_GHOST="+string(t.ghost))
+	env = append(env, "FZF_POINTER="+string(t.pointer))
 	env = append(env, "FZF_PREVIEW_LABEL="+t.previewLabelOpts.label)
 	env = append(env, "FZF_BORDER_LABEL="+t.borderLabelOpts.label)
 	env = append(env, "FZF_LIST_LABEL="+t.listLabelOpts.label)
+	env = append(env, "FZF_INPUT_LABEL="+t.inputLabelOpts.label)
+	env = append(env, "FZF_HEADER_LABEL="+t.headerLabelOpts.label)
 	if len(t.nthCurrent) > 0 {
 		env = append(env, "FZF_NTH="+RangesToString(t.nthCurrent))
 	}


### PR DESCRIPTION
I was trying to create a complex command and needed some variables to restore the state of application, but I saw that I could not find some variables because they were not implemented!
Mainly the "FZF_POINTER" variable! I believe it is important that it is accessible! I exported the others to maintain consistency only.

Other thing: The variable 'FZF_LIST_LABEL' was already being exported, but not documented in the manpage!

Thanks.
