### PR TITLE
[fish] History improvements and small changes

### DIFF
--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -158,6 +158,7 @@ function fzf_key_bindings
 
     set -lx FZF_DEFAULT_OPTS (__fzf_defaults '' \
       '--nth=2..,.. --scheme=history --multi --wrap-sign="\t↳ "' \
+      '--bind=\'shift-delete:execute-silent(eval history delete --exact --case-sensitive -- (string escape -n -- {+} | string replace -r -a "^\d*\\\\\\t|(?<=\\\\\\n)\\\\\\t" ""))+reload(eval $FZF_DEFAULT_COMMAND)\'' \
       "--bind=ctrl-r:toggle-sort --highlight-line $FZF_CTRL_R_OPTS" \
       '--accept-nth=2.. --read0 --print0 --with-shell='(status fish-path)\\ -c)
 

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -144,13 +144,8 @@ function fzf_key_bindings
     set -lx FZF_DEFAULT_COMMAND "$FZF_CTRL_T_COMMAND"
     set -lx FZF_DEFAULT_OPTS_FILE
 
-    if set -l result (eval (__fzfcmd) --walker-root=$dir --query=$fzf_query | string split0)
-      # Remove last token from commandline.
-      commandline -t ''
-      for i in $result
-        commandline -it -- $prefix(string escape -- $i)' '
-      end
-    end
+    set -l result (eval (__fzfcmd) --walker-root=$dir --query=$fzf_query | string split0)
+    and commandline -rt -- (string join -- ' ' $prefix(string escape -- $result))' '
 
     commandline -f repaint
   end

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -14,11 +14,20 @@
 
 # Key bindings
 # ------------
-# For compatibility with fish versions down to 3.1.2, the script does not use:
-# - The -f/--function switch of command: set
-# - The process substitution syntax: $(cmd)
-# - Ranges that omit start/end indexes: $var[$start..] $var[..$end] $var[..]
+# The oldest supported fish version is 3.1b1. To maintain compatibility, the
+# command substitution syntax $(cmd) should never be used, even behind a version
+# check, otherwise the source command will fail on fish versions older than 3.4.0.
 function fzf_key_bindings
+
+  # Check fish version
+  set -l fish_ver (string match -r '^(\d+).(\d+)' $version 2> /dev/null; or echo 0\n0\n0)
+  if test \( "$fish_ver[2]" -lt 3 \) -o \( "$fish_ver[2]" -eq 3 -a "$fish_ver[3]" -lt 1 \)
+    echo "This script requires fish version 3.1b1 or newer." >&2
+    return 1
+  else if not type -q fzf
+    echo "fzf was not found in path." >&2
+    return 1
+  end
 
   function __fzf_defaults
     # $argv[1]: Prepend to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS


### PR DESCRIPTION
The main change of this PR (first commit) is inspired by fish v4: `<ctrl-r>` operates only on the line at cursor, allowing to insert history entries when creating functions in the command line, writing begin/end blocks or constructing multiline commands with `<alt-enter>`.

A few other small changes are included:
- Make `<ctrl-r>` work when both perl and coreutils are missing.
- Simplify the `commandline` call in `fzf-file-widget`.
- Add fish version and dependencies check.

One feature that is present in the default history pager of fish, but not directly available in `fzf-history-widget`, is the ability to delete a history item (`<shift-delete>`). Of course, users can add their own binding in fzf, but the command is quite complex (in order to first restore the history command in its original form, and handle correctly multiline commands and trailing newlines). I think many users are missing out on this very useful feature. If you agree, I can add a commit that adds this functionality. The binding will be added before the user options, so it won't override any existing user bindings.
