### PR TITLE
bash: set keybinding right before printing special character

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -31,9 +31,6 @@ if [[ $- =~ i ]]; then
 
 ###########################################################
 
-# To redraw line after fzf closes (printf '\e[5n')
-bind '"\e[0n": redraw-current-line' 2> /dev/null
-
 __fzf_defaults() {
   # $1: Prepend to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
   # $2: Append to FZF_DEFAULT_OPTS_FILE and FZF_DEFAULT_OPTS
@@ -328,6 +325,7 @@ __fzf_generic_path_completion() {
         else
           COMPREPLY=( "$cur" )
         fi
+        bind '"\e[0n": redraw-current-line' 2> /dev/null
         printf '\e[5n'
         return 0
       fi
@@ -384,6 +382,7 @@ _fzf_complete() {
     else
       COMPREPLY=("$cur")
     fi
+    bind '"\e[0n": redraw-current-line' 2> /dev/null
     printf '\e[5n'
     return 0
   else

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -325,6 +325,7 @@ __fzf_generic_path_completion() {
         else
           COMPREPLY=( "$cur" )
         fi
+        # To redraw line after fzf closes (printf '\e[5n')
         bind '"\e[0n": redraw-current-line' 2> /dev/null
         printf '\e[5n'
         return 0


### PR DESCRIPTION
Currently, fzf sets the `\e[0n` keybinding upon initialization, which is sadly the only way to call readline functions in Bash. Unfortunately, this method is also used by tools like [zoxide](https://github.com/ajeetdsouza/zoxide), causing the keybinding to be overridden:

https://github.com/ajeetdsouza/zoxide/blob/095b270fea283ed0a9d147c2b154a80030f19a4c/templates/bash.txt#L160

Since the only purpose of this particular keybinding appears to be to hack around this particular limitation of Bash, the way I've handled this issue in zoxide is to set the keybinding _right_ before calling it via `printf '\e[5n'`. This PR does the same for fzf.

Context: I'm the author of zoxide, just trying to ensure our plugins don't clash :)