### PR TITLE
Add initial security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Reporting
+
+If you wish to report a security vulnerability privately, we appreciate your diligence. Please follow the guidelines below to submit your report.
+
+## Reporting
+
+To report a security vulnerability, please provide the following information:
+
+1. **PROJECT**
+   - Include the URL of the project repository - Example: <https://github.com/junegunn/fzf>
+
+2. **PUBLIC**
+   - Indicate whether this vulnerability has already been publicly discussed or disclosed.
+   - If so, provide relevant links.
+
+3. **DESCRIPTION**
+   - Provide a detailed description of the security vulnerability.
+   - Include as much information as possible to help us understand and address the issue.
+
+Send this information, along with any additional relevant details, to <email AT somewhere or other channel>.
+
+## Confidentiality
+
+We kindly ask you to keep the report confidential until a public announcement is made.
+
+## Notes
+
+- Vulnerabilities will be handled on a best-effort basis.
+- You may request an advance copy of the patched release, but we cannot guarantee early access before the public release.
+- You will be notified via email simultaneously with the public announcement.
+- We will respond within a few weeks to confirm whether your report has been accepted or rejected.
+
+Thank you for helping to improve the security of our project!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,7 +17,7 @@ To report a security vulnerability, please provide the following information:
    - Provide a detailed description of the security vulnerability.
    - Include as much information as possible to help us understand and address the issue.
 
-Send this information, along with any additional relevant details, to <email AT somewhere or other channel>.
+Send this information, along with any additional relevant details, to <junegunn.c AT gmail DOT com>.
 
 ## Confidentiality
 


### PR DESCRIPTION
This PR adds a SECURITY.md file, battle tested in other projects and orgs, (the construct is CC0 ie public domain, for example from here https://raw.githubusercontent.com/itiquette/git-provider-sync/refs/heads/main/SECURITY.md so just reuse)

A SECURITY.md would help anyone assessing the project for use, give a hint of how it handles critical no public security issues, and give anyone a clear instruction on how to report them non public.

**IE, for someone thinking about using fzf in an organization or privately it would give an extra trust factor.**

This policy basically says "send your findings, and we will see if we handle them, we will notify you".

Besides, being a good FOSS practice, makes the project look more professional and it is heavily supported by GitHub https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file etc as one of the community health files, so it will pop up automatically in the UI for the end user. 

Examples:
Security Tab in project front will be added automatically
![Skärmbild från 2025-05-11 05-57-27](https://github.com/user-attachments/assets/db47a7d5-1c70-400c-bbca-46f8949995b8)


Security Policy in the top right corner of UI will be added automatically

![Skärmbild från 2025-05-11 05-58-05](https://github.com/user-attachments/assets/85afc0d8-df10-4091-bfec-612560f72bf3)

Security Policy under Security Overview for the project will have the Security Policy green and enabled.
![Skärmbild från 2025-05-11 05-58-23](https://github.com/user-attachments/assets/3162ee7d-7990-4029-9186-0e2d0538d64b)

NOTE: there is a <...> in the text, where the preferred channel for reporting should be added I left that for you, (or tell me what to add there, and I'll rebase with that).

NOTE: I had this in multiple orgs and projects over the years. Only once I had a report, so I don't think one should be worry about getting to much reports from this, this is at least my experience.