### PR TITLE
Fix fzf with no cmdline arguments on Cygwin

### DIFF
--- a/src/winpty_windows.go
+++ b/src/winpty_windows.go
@@ -44,10 +44,26 @@ func needWinpty(opts *Options) bool {
 }
 
 func runWinpty(args []string, opts *Options) (int, error) {
-	argStr := escapeSingleQuote(args[0])
+	_argStr := ""
+
+	osname, _ := exec.Command("uname", "-s").Output()
+	if strings.Contains(strings.ToLower(string(osname)), "cygwin") {
+		out, err := exec.Command("cygpath", args[0]).Output()
+		if err == nil {
+			_argStr += strings.Trim(string(out), "\n")
+		} else {
+			_argStr += args[0]
+		}
+	} else {
+		_argStr += args[0]
+	}
+
+	argStr := escapeSingleQuote(_argStr)
+
 	for _, arg := range args[1:] {
 		argStr += " " + escapeSingleQuote(arg)
 	}
+
 	argStr += ` --no-winpty`
 
 	if isMintty345() {


### PR DESCRIPTION
This addresses issue #4382.

In module `src/winpty_windows.go`, function `runWinpty()` is handing off the executable's full pathname to `runProxy()` as the first argument. The path was coming over Windows-style and causing Cygwin to choke. So I'm checking `uname -s` for Cygwin and calling `cygpath` to reformat if needed. Very basic test runs now looking good:

![fzf test drive](https://github.com/user-attachments/assets/3aead4e7-14e1-4ff2-84b0-338a892af9d7)
