### PR TITLE
fix: respect winborder which introduced since neovim 0.11

### DIFF
--- a/plugin/fzf.vim
+++ b/plugin/fzf.vim
@@ -553,8 +553,12 @@ try
     let height = s:calc_size(&lines, dict.down, dict)
     let optstr .= ' --no-tmux --height='.height
   endif
-  " Respect --border option given in $FZF_DEFAULT_OPTS and 'options'
-  if !(exists('&winborder') && &winborder !=# '' && &winborder !=# 'none')
+
+  if exists('&winborder') && &winborder !=# '' && &winborder !=# 'none'
+    " Add 1-column horizontal margin
+    let optstr = join(['--margin 0,1', optstr])
+  else
+    " Respect --border option given in $FZF_DEFAULT_OPTS and 'options'
     let optstr = join([s:border_opt(get(dict, 'window', 0)), s:extract_option($FZF_DEFAULT_OPTS, 'border'), optstr])
   endif
 


### PR DESCRIPTION
Hi @junegunn, thanks for creating so awesome plugin. I love it and I use it with neovim everyday.

Neovim 0.11 had introduced a new global option named [`winborder`](https://github.com/neovim/neovim/pull/31074). And fzf had draw the border itself now, it's duplicated if I set `winborder` as `rounded`

![PixPin_2025-05-13_17-51-03](https://github.com/user-attachments/assets/974305f8-4bbb-44e7-a6c4-ddf4ed10aefa)

This pr fix this by respect the global `winborder` option if it's a valid value and ignore the border style which passed to fzf.

![PixPin_2025-05-13_18-07-00](https://github.com/user-attachments/assets/236d77e6-959d-4086-86fd-6c50b90b55f0)
