### PR TITLE
Reincorporate user settings (FZF_ALT_C_COMMAND, etc.) in shell-integration behavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -48,7 +48,7 @@ func exit(code int, err error) {
 func main() {
 	protector.Protect()
 
-	options, err := fzf.ParseOptions(true, os.Args[1:])
+	options, envArgs, err := fzf.ParseOptions(true, os.Args[1:])
 	if err != nil {
 		exit(fzf.ExitError, err)
 		return
@@ -96,6 +96,6 @@ func main() {
 		return
 	}
 
-	code, err := fzf.Run(options)
+	code, err := fzf.Run(options, envArgs)
 	exit(code, err)
 }

--- a/src/core.go
+++ b/src/core.go
@@ -37,14 +37,17 @@ func (r revision) compatible(other revision) bool {
 }
 
 // Run starts fzf
-func Run(opts *Options) (int, error) {
+func Run(opts *Options, envArgs []string) (int, error) {
+
+	allArgs := append(os.Args, envArgs...)   // ensure the program name is first
+
 	if opts.Filter == nil {
 		if opts.Tmux != nil && len(os.Getenv("TMUX")) > 0 && opts.Tmux.index >= opts.Height.index {
-			return runTmux(os.Args, opts)
+			return runTmux(allArgs, opts)
 		}
 
 		if needWinpty(opts) {
-			return runWinpty(os.Args, opts)
+			return runWinpty(allArgs, opts)
 		}
 	}
 


### PR DESCRIPTION
The `fzf` keyboard shortcuts (ALT-C, etc.) were not using my `FZF_*` environment settings until I made the following code change. This change ensures that once the env is parsed, the arguments specified in the env variables are forwarded to the winpty child process along with the commandline arguments.