### PR TITLE
[bash,zsh] Improve the AWK compatibility

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -529,7 +529,10 @@ if ! declare -F __fzf_list_hosts > /dev/null; then
       ) \
       <(
         __fzf_exec_awk '
-          /^[[:blank:]]*(#|$)|0\.0\.0\.0/ { next }
+          # Note: mawk <= 1.3.3-20090705 does not support the POSIX brackets of
+          # the form [[:blank:]], and Ubuntu 18.04 LTS still uses this
+          # 16-year-old mawk unfortunately.  We need to use [ \t] instead.
+          /^[ \t]*(#|$)|0\.0\.0\.0/ { next }
           {
             sub(/#.*/, "")
             for (i = 2; i <= NF; i++)

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -50,12 +50,20 @@ __fzf_defaults() {
 __fzf_exec_awk() {
   if [[ -z ${__fzf_awk-} ]]; then
     __fzf_awk=awk
-
-    # choose the faster mawk if: it's installed && build date >= 20230322 &&
-    # version >= 1.3.4
-    local n x y z d
-    IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-    [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
+      # Note: Solaris awk at /usr/bin/awk is meant for backward compatibility
+      # with an ancient implementation of 1977 awk in the original UNIX.  It
+      # lacks many features of POSIX awk, so it is essentially useless in the
+      # modern point of view.  To use a standard-conforming version in Solaris,
+      # one needs to explicitly use /usr/xpg4/bin/awk.
+      __fzf_awk=/usr/xpg4/bin/awk
+    else
+      # choose the faster mawk if: it's installed && build date >= 20230322 &&
+      # version >= 1.3.4
+      local n x y z d
+      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    fi
   fi
 
   # Note: macOS awk has a quirk that it stops processing at all when it sees

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -39,6 +39,32 @@ __fzf_defaults() {
   echo "${FZF_DEFAULT_OPTS-} $2"
 }
 
+# This function performs `exec awk "$@"` safely by working around awk
+# compatibility issues.
+#
+# Note: To reduce an extra fork, this function performs "exec" so is expected
+# to be run as the last command in a subshell.
+#
+# Note: This function is included with {completion,key-bindings}.{bash,zsh} and
+# synchronized.
+__fzf_exec_awk() {
+  if [[ -z ${__fzf_awk-} ]]; then
+    __fzf_awk=awk
+
+    # choose the faster mawk if: it's installed && build date >= 20230322 &&
+    # version >= 1.3.4
+    local n x y z d
+    IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+    [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+  fi
+
+  # Note: macOS awk has a quirk that it stops processing at all when it sees
+  # any data not following UTF-8 in the input stream when the current LC_CTYPE
+  # specifies the UTF-8 encoding.  To work around this quirk, one needs to
+  # specify LC_ALL=C to change the current encoding to the plain one.
+  LC_ALL=C exec "$__fzf_awk" "$@"
+}
+
 __fzf_comprun() {
   if [[ "$(type -t _fzf_comprun 2>&1)" = function ]]; then
     _fzf_comprun "$@"
@@ -364,7 +390,7 @@ _fzf_complete() {
   fi
 
   local cur selected trigger cmd post
-  post="$(caller 0 | command awk '{print $2}')_post"
+  post="$(caller 0 | __fzf_exec_awk '{print $2}')_post"
   type -t "$post" > /dev/null 2>&1 || post='command cat'
 
   trigger=${FZF_COMPLETION_TRIGGER-'**'}
@@ -443,7 +469,7 @@ _fzf_proc_completion() {
 }
 
 _fzf_proc_completion_post() {
-  command awk '{print $2}'
+  __fzf_exec_awk '{print $2}'
 }
 
 # To use custom hostname lists, override __fzf_list_hosts.
@@ -475,7 +501,7 @@ if ! declare -F __fzf_list_hosts > /dev/null; then
         shopt -u dotglob nocaseglob failglob
         shopt -s nullglob
 
-        command awk '
+        __fzf_exec_awk '
           tolower($1) ~ /^host(name)?$/ {
             for (i = 2; i <= NF; i++)
               if ($i !~ /[*?%]/)
@@ -484,7 +510,7 @@ if ! declare -F __fzf_list_hosts > /dev/null; then
         ' ~/.ssh/config ~/.ssh/config.d/* /etc/ssh/ssh_config 2> /dev/null
       ) \
       <(
-        command awk -F ',' '
+        __fzf_exec_awk -F ',' '
           match($0, /^[[a-z0-9.,:-]+/) {
             $0 = substr($0, 1, RLENGTH)
             gsub(/\[/, "")
@@ -494,7 +520,7 @@ if ! declare -F __fzf_list_hosts > /dev/null; then
         ' ~/.ssh/known_hosts 2> /dev/null
       ) \
       <(
-        command awk '
+        __fzf_exec_awk '
           /^[[:blank:]]*(#|$)|0\.0\.0\.0/ { next }
           {
             sub(/#.*/, "")
@@ -523,7 +549,7 @@ _fzf_complete_ssh() {
     *)
       local user=
       [[ "$2" =~ '@' ]] && user="${2%%@*}@"
-      _fzf_complete +m -- "$@" < <(__fzf_list_hosts | command awk -v user="$user" '{print user $0}')
+      _fzf_complete +m -- "$@" < <(__fzf_list_hosts | __fzf_exec_awk -v user="$user" '{print user $0}')
       ;;
   esac
 }

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -307,7 +307,10 @@ if ! declare -f __fzf_list_hosts > /dev/null; then
       ) \
       <(
         __fzf_exec_awk '
-          /^[[:blank:]]*(#|$)|0\.0\.0\.0/ { next }
+          # Note: mawk <= 1.3.3-20090705 does not support the POSIX brackets of
+          # the form [[:blank:]], and Ubuntu 18.04 LTS still uses this
+          # 16-year-old mawk unfortunately.  We need to use [ \t] instead.
+          /^[ \t]*(#|$)|0\.0\.0\.0/ { next }
           {
             sub(/#.*/, "")
             for (i = 2; i <= NF; i++)

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -115,12 +115,20 @@ __fzf_defaults() {
 __fzf_exec_awk() {
   if [[ -z ${__fzf_awk-} ]]; then
     __fzf_awk=awk
-
-    # choose the faster mawk if: it's installed && build date >= 20230322 &&
-    # version >= 1.3.4
-    local n x y z d
-    IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-    [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
+      # Note: Solaris awk at /usr/bin/awk is meant for backward compatibility
+      # with an ancient implementation of 1977 awk in the original UNIX.  It
+      # lacks many features of POSIX awk, so it is essentially useless in the
+      # modern point of view.  To use a standard-conforming version in Solaris,
+      # one needs to explicitly use /usr/xpg4/bin/awk.
+      __fzf_awk=/usr/xpg4/bin/awk
+    else
+      # choose the faster mawk if: it's installed && build date >= 20230322 &&
+      # version >= 1.3.4
+      local n x y z d
+      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    fi
   fi
 
   # Note: macOS awk has a quirk that it stops processing at all when it sees

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -36,12 +36,20 @@ __fzf_defaults() {
 __fzf_exec_awk() {
   if [[ -z ${__fzf_awk-} ]]; then
     __fzf_awk=awk
-
-    # choose the faster mawk if: it's installed && build date >= 20230322 &&
-    # version >= 1.3.4
-    local n x y z d
-    IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-    [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
+      # Note: Solaris awk at /usr/bin/awk is meant for backward compatibility
+      # with an ancient implementation of 1977 awk in the original UNIX.  It
+      # lacks many features of POSIX awk, so it is essentially useless in the
+      # modern point of view.  To use a standard-conforming version in Solaris,
+      # one needs to explicitly use /usr/xpg4/bin/awk.
+      __fzf_awk=/usr/xpg4/bin/awk
+    else
+      # choose the faster mawk if: it's installed && build date >= 20230322 &&
+      # version >= 1.3.4
+      local n x y z d
+      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    fi
   fi
 
   # Note: macOS awk has a quirk that it stops processing at all when it sees

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -57,12 +57,20 @@ __fzf_defaults() {
 __fzf_exec_awk() {
   if [[ -z ${__fzf_awk-} ]]; then
     __fzf_awk=awk
-
-    # choose the faster mawk if: it's installed && build date >= 20230322 &&
-    # version >= 1.3.4
-    local n x y z d
-    IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-    [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
+      # Note: Solaris awk at /usr/bin/awk is meant for backward compatibility
+      # with an ancient implementation of 1977 awk in the original UNIX.  It
+      # lacks many features of POSIX awk, so it is essentially useless in the
+      # modern point of view.  To use a standard-conforming version in Solaris,
+      # one needs to explicitly use /usr/xpg4/bin/awk.
+      __fzf_awk=/usr/xpg4/bin/awk
+    else
+      # choose the faster mawk if: it's installed && build date >= 20230322 &&
+      # version >= 1.3.4
+      local n x y z d
+      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    fi
   fi
 
   # Note: macOS awk has a quirk that it stops processing at all when it sees


### PR DESCRIPTION
This PR adds some workarounds for bugs and quirks of `awk` implementations. Details are described in the respective commit messages.

### Shell function shared by four files

To implement this, I added a function `__fzf_exec_awk`, but I needed to copy this function to all `{complete,key-bindings}.{zsh,bash}` (just like the existing `__fzf_defaults`). However, it might not be useful. When modifying the function in the future, it one needs to update all the four files at the same time. Also, the size of copied lines becomes large. Is there an existing policy about how to process this situation? If you want to introduce a mechanism to automatically update the copied part of the files or to introduce a mechanism to generate the final form of the files from templates, I'm not reluctant to implement it.