### PR TITLE
Clarify Search Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,10 +382,10 @@ type in multiple search terms delimited by spaces. e.g. `^music .mp3$ sbtrkt
 | `'wild`   | exact-match (quoted)                    | Items that include `wild`                    |
 | `'wild'`  | exact-boundary-match (quoted both ends) | Items that include `wild` at word boundaries |
 | `^music`  | prefix-exact-match                      | Items that start with `music`                |
-| `.mp3$`   | suffix-exact-match                      | Items that end with `.mp3`                   |
+| `mp3$`    | suffix-exact-match                      | Items that end with `mp3`                   |
 | `!fire`   | inverse-exact-match                     | Items that do not include `fire`             |
 | `!^music` | inverse-prefix-exact-match              | Items that do not start with `music`         |
-| `!.mp3$`  | inverse-suffix-exact-match              | Items that do not end with `.mp3`            |
+| `!mp3$`   | inverse-suffix-exact-match              | Items that do not end with `mp3`            |
 
 If you don't prefer fuzzy matching and do not wish to "quote" every word,
 start fzf with `-e` or `--exact` option. Note that when  `--exact` is set,


### PR DESCRIPTION
I just thought the example `.mp3$` wasn't great as I think it implies that `.` is a regex character in this context.

Plus I saw how someone could interpret it this way from: https://github.com/Aloxaf/fzf-tab/issues/403

 Feel free to close if you don't agree. 

P.S. Thank you very much for making fzf.