### PR TITLE
Will that fix the crash? I made a test build on my Linux and it worked after this change

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2928,7 +2928,7 @@ func (t *Terminal) printHeader() {
 }
 
 func (t *Terminal) printFooter() {
-	if len(t.footer) == 0 {
+	if len(t.footer) == 0 || t.footerWindow == nil {
 		return
 	}
 	indentSize := t.headerIndent(t.footerBorderShape)


### PR DESCRIPTION
  panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x70 pc=0x470c6a2]

goroutine 9 [running]:
github.com/junegunn/fzf/src.(*Terminal).printFooter(0xc00020f508)
    github.com/junegunn/fzf/src/terminal.go:2936 +0x122
github.com/junegunn/fzf/src.(*Terminal).Loop.func8.2(0xc00011c918)
    github.com/junegunn/fzf/src/terminal.go:5161 +0x3b6
github.com/junegunn/fzf/src/util.(*EventBox).Wait(0xc00011c918, 0xc000207fa0)
    github.com/junegunn/fzf/src/util/eventbox.go:34 +0x5d
github.com/junegunn/fzf/src.(*Terminal).Loop.func8()
    github.com/junegunn/fzf/src/terminal.go:5090 +0xd7
created by github.com/junegunn/fzf/src.(*Terminal).Loop in goroutine 22
    github.com/junegunn/fzf/src/terminal.go:5064 +0x61c