### PR TITLE
Fix: Inverted match logic in extendedMatch

### DIFF
--- a/src/pattern.go
+++ b/src/pattern.go
@@ -394,7 +394,8 @@ func (p *Pattern) extendedMatch(item *Item, withPos bool, slab *util.Slab) ([]Of
 			off, score, pos := p.iter(pfun, input, term.caseSensitive, term.normalize, p.forward, term.text, withPos, slab)
 			if sidx := off[0]; sidx >= 0 {
 				if term.inv {
-					continue
+					// Inverted match. The entire termSet is not a match.
+					return nil, 0, nil
 				}
 				offset, currentScore = off, score
 				matched = true


### PR DESCRIPTION
This pull request addresses a bug in the extendedMatch function where inverted search terms were not being handled correctly. Previously, if an inverted term in a term set resulted in a match, the code would simply continue to the next term. This could lead to incorrect search results, as the entire term set would be considered a match if any subsequent non-inverted term also matched. The fix ensures that if an inverted term matches, the extendedMatch function immediately returns, correctly indicating that the term set is not a match. This change ensures that inverted search queries behave as expected.