### PR TITLE
fix(shell): check for mawk existence before version check

### DIFF
--- a/shell/common.sh
+++ b/shell/common.sh
@@ -22,12 +22,12 @@ __fzf_exec_awk() {
       # modern point of view.  To use a standard-conforming version in Solaris,
       # one needs to explicitly use /usr/xpg4/bin/awk.
       __fzf_awk=/usr/xpg4/bin/awk
-    else
+    elif command -v mawk >/dev/null 2>&1; then
       # choose the faster mawk if: it's installed && build date >= 20230322 &&
       # version >= 1.3.4
-      local n x y z d
-      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+        local n x y z d
+        IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+        [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
     fi
   fi
   # Note: macOS awk has a quirk that it stops processing at all when it sees

--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -47,10 +47,10 @@ __fzf_exec_awk() {
     __fzf_awk=awk
     if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
       __fzf_awk=/usr/xpg4/bin/awk
-    else
-      local n x y z d
-      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    elif command -v mawk >/dev/null 2>&1; then
+        local n x y z d
+        IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+        [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
     fi
   fi
   LC_ALL=C exec "$__fzf_awk" "$@"
@@ -524,7 +524,7 @@ if ! declare -F __fzf_list_hosts > /dev/null; then
               if ($i != "0.0.0.0")
                 print $i
           }
-        ' /etc/hosts 2> /dev/null 
+        ' /etc/hosts 2> /dev/null
       )
   }
 fi

--- a/shell/completion.zsh
+++ b/shell/completion.zsh
@@ -112,10 +112,10 @@ __fzf_exec_awk() {
     __fzf_awk=awk
     if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
       __fzf_awk=/usr/xpg4/bin/awk
-    else
-      local n x y z d
-      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    elif command -v mawk >/dev/null 2>&1; then
+        local n x y z d
+        IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+        [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
     fi
   fi
   LC_ALL=C exec "$__fzf_awk" "$@"

--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -33,10 +33,10 @@ __fzf_exec_awk() {
     __fzf_awk=awk
     if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
       __fzf_awk=/usr/xpg4/bin/awk
-    else
-      local n x y z d
-      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    elif command -v mawk >/dev/null 2>&1; then
+        local n x y z d
+        IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+        [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
     fi
   fi
   LC_ALL=C exec "$__fzf_awk" "$@"

--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -54,10 +54,10 @@ __fzf_exec_awk() {
     __fzf_awk=awk
     if [[ $OSTYPE == solaris* && -x /usr/xpg4/bin/awk ]]; then
       __fzf_awk=/usr/xpg4/bin/awk
-    else
-      local n x y z d
-      IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
-      [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
+    elif command -v mawk >/dev/null 2>&1; then
+        local n x y z d
+        IFS=' .' read n x y z d <<< $(command mawk -W version 2> /dev/null)
+        [[ $n == mawk ]] && (( d >= 20230302 && (x * 1000 + y) * 1000 + z >= 1003004 )) && __fzf_awk=mawk
     fi
   fi
   LC_ALL=C exec "$__fzf_awk" "$@"


### PR DESCRIPTION

fix #4463

### problem

The `__fzf_exec_awk` helper function calls `mawk -W version` without checking if `mawk` exists. If `mawk` is not installed, this can trigger a slow `command_not_found_handler` (e.g., from
`ftc.zsh`), causing a noticeable delay.

### to reproduce

1. Run this Docker command to simulate a slow `command_not_found_handler`[^1] on `alpine:edge`[^2]:

```bash
docker run --rm --interactive --tty -e TERM alpine:edge sh -uec '
apk add fzf perl zsh
{
  echo "source <(fzf --zsh)"
  echo "command_not_found_handler() { sleep 4; return 127;}"
  echo "typeset -fT fzf-history-widget __fzf_exec_awk"
  echo "PS4='\''%B%F{0}+ %D{%T:%3.} %2N:%i%f%b '\''"
} > ~/.zshrc
/bin/zsh'
```

2. Press `CTRL-R`, and `Enter`.

**Trace showing the delay:**
```bash
# ... ~4s  ...
+ 17:16:15:072 fzf-history-widget:18 [[ $(__fzf_exec_awk '{print $1; exit}' <<< "$selected") -regex-match ^[1-9][0-9]*+ 17:16:15:077 fzf-history-widget:18 __fzf_exec_awk '{print $1; exit}'
+ 17:16:15:077 __fzf_exec_awk:1 [[ -z '' ]]
+ 17:16:15:077 __fzf_exec_awk:2 __fzf_awk=awk
+ 17:16:15:077 __fzf_exec_awk:3 [[ linux-musl == solaris* ]]
+ 17:16:15:078 __fzf_exec_awk:6 local n x y z d
+ 17:16:15:078 __fzf_exec_awk:7 mawk -W version
+ 17:16:19:084 __fzf_exec_awk:7 IFS=' .' + 17:16:19:084 __fzf_exec_awk:7 read n x y z d
+ 17:16:19:084 __fzf_exec_awk:8 [[ '' == mawk ]]
+ 17:16:19:084 __fzf_exec_awk:11 LC_ALL=C awk '{print $1; exit}'
+ 17:16:15:072 fzf-history-widget:18 [[ $(__fzf_exec_awk '{print $1; exit}' <<< "$selected") -regex-match ^[1-9][0-9]* ]]
+ 17:16:19:086 fzf-history-widget:21 LBUFFER=$'\t'
```

### solution

check for the existence of the executable before checking its version

changed once in `shell/common.sh` and run `shell/update-common.sh`, nice 

### related

#4412

[^1]: see `man zshmisc | less --pattern 'command_not_found_handler'` for more infos
[^2]: alpine:edge is minimal and fast, and has a recent 'fzf' version for the package manager
