### PR TITLE
docs: Add installation method with gah

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,12 @@ You can download the official fzf binaries from the releases page.
 
 * https://github.com/junegunn/fzf/releases
 
+On Linux and macOS the process can be automated using [gah](https://github.com/marverix/gah):
+
+```
+gah install fzf
+```
+
 ### Setting up shell integration
 
 Add the following line to your shell configuration file.


### PR DESCRIPTION
Hello!
This PR adds to the documentation installation method using [gah](https://github.com/marverix/gah):
> gah is an GitHub Releases app installer, that DOES NOT REQUIRE SUDO! It is a simple bash script that downloads the latest release of an app from GitHub and installs it in ~/.local/bin. It is designed to be used with apps that are distributed as a single binary file.