### PR TITLE
Support old uname in macOS

### DIFF
--- a/install
+++ b/install
@@ -164,7 +164,7 @@ download() {
 }
 
 # Try to download binary executable
-archi=$(uname -smo)
+archi=$(uname -smo 2>/dev/null || uname -sm)
 binary_available=1
 binary_error=""
 case "$archi" in


### PR DESCRIPTION
`./install --all` exit with error code because of `uname -smo` in macOS 10.15.7, 12.7.6 (yes, they're old).

```console
$ ./install --all
uname: illegal option -- o
usage: uname [-amnprsv]
No prebuilt binary for  ...
go executable not found. Installation failed.
```

`man uname` doesn't contain `-o` option in macOS 10.15.7, 12.7.6. I can confirm that `man uname` contain `-o` option in macOS 15.6.

So we can fallback to `uname -sm` after trying `uname -smo`.