### PR TITLE
mod: update charlievieth/fastwalk to v1.0.13 and min Go version to 1.21

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.20"
+        go-version: "1.21"
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: "1.20"
+        go-version: "1.21"
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/junegunn/fzf
 
 require (
-	github.com/charlievieth/fastwalk v1.0.12
+	github.com/charlievieth/fastwalk v1.0.13
 	github.com/gdamore/tcell/v2 v2.8.1
 	github.com/junegunn/go-shellwords v0.0.0-20250127100254-2aa3b3277741
 	github.com/mattn/go-isatty v0.0.20
@@ -17,4 +17,4 @@ require (
 	golang.org/x/text v0.21.0 // indirect
 )
 
-go 1.20
+go 1.21

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/charlievieth/fastwalk v1.0.12 h1:pwfxe1LajixViQqo7EFLXU2+mQxb6OaO0CeNdVwRKTg=
-github.com/charlievieth/fastwalk v1.0.12/go.mod h1:yGy1zbxog41ZVMcKA/i8ojXLFsuayX5VvwhQVoj9PBI=
+github.com/charlievieth/fastwalk v1.0.13 h1:rCdesaKpxBft4jdNqKbJtTS23Dfhem3eEPE0jfj//xc=
+github.com/charlievieth/fastwalk v1.0.13/go.mod h1:diVcUreiU1aQ4/Wu3NbxxH4/KYdKpLDojrQ1Bb2KgNY=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.8.1 h1:KPNxyqclpWpWQlPLx6Xui1pMk8S+7+R37h3g07997NU=


### PR DESCRIPTION
This commit updates github.com/charlievieth/fastwalk to v1.0.13 which addresses fastwalk issue [#61](https://github.com/charlievieth/fastwalk/issues/61). It also updates the minimum supported Go version to 1.21 (up from 1.20) since that is now the minimum version supported by fastwalk (since we now use `binary. NativeEndian`).

@junegunn If there are any issues with updating to Go 1.21 then I can fix fastwalk in a way that allows us to use version 1.20.