### PR TITLE
refactor: use maps.Copy and maps.Clone

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -2,6 +2,7 @@
 package fzf
 
 import (
+	"maps"
 	"os"
 	"sync"
 	"time"
@@ -225,10 +226,7 @@ func Run(opts *Options) (int, error) {
 	}
 	patternBuilder := func(runes []rune) *Pattern {
 		denyMutex.Lock()
-		denylistCopy := make(map[int32]struct{})
-		for k, v := range denylist {
-			denylistCopy[k] = v
-		}
+		denylistCopy := maps.Clone(denylist)
 		denyMutex.Unlock()
 		return BuildPattern(cache, patternCache,
 			opts.Fuzzy, opts.FuzzyAlgo, opts.Extended, opts.Case, opts.Normalize, forward, withPos,

--- a/src/options.go
+++ b/src/options.go
@@ -3,6 +3,7 @@ package fzf
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
 	"strconv"
@@ -2600,9 +2601,7 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 			if err != nil {
 				return err
 			}
-			for k, v := range chords {
-				opts.Expect[k] = v
-			}
+			maps.Copy(opts.Expect, chords)
 		case "--no-expect":
 			opts.Expect = make(map[tui.Event]string)
 		case "--enabled", "--no-phony":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"math"
 	"net"
 	"os"
@@ -950,10 +951,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox, executor *util.Executor
 		wordRubout = fmt.Sprintf("%s[^%s]", sep, sep)
 		wordNext = fmt.Sprintf("[^%s]%s|(.$)", sep, sep)
 	}
-	keymapCopy := make(map[tui.Event][]*action)
-	for key, action := range opts.Keymap {
-		keymapCopy[key] = action
-	}
+	keymapCopy := maps.Clone(opts.Keymap)
 
 	t := Terminal{
 		initDelay:          delay,


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.