### PR TITLE
Fix 7-byte CSI sequence leftover prints

### DIFF
--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -479,6 +479,7 @@ func (r *LightRenderer) escSequence(sz *int) Event {
 					return Event{Delete, 0, nil}
 				}
 				if len(r.buffer) == 7 && r.buffer[6] == '~' && r.buffer[4] == '1' {
+					*sz = 7
 					switch r.buffer[5] {
 					case '0':
 						return Event{AltShiftDelete, 0, nil}
@@ -525,6 +526,7 @@ func (r *LightRenderer) escSequence(sz *int) Event {
 					return Event{PageUp, 0, nil}
 				}
 				if len(r.buffer) == 7 && r.buffer[6] == '~' && r.buffer[4] == '1' {
+					*sz = 7
 					switch r.buffer[5] {
 					case '0':
 						return Event{AltShiftPageUp, 0, nil}
@@ -569,6 +571,7 @@ func (r *LightRenderer) escSequence(sz *int) Event {
 					return Event{PageDown, 0, nil}
 				}
 				if len(r.buffer) == 7 && r.buffer[6] == '~' && r.buffer[4] == '1' {
+					*sz = 7
 					switch r.buffer[5] {
 					case '0':
 						return Event{AltShiftPageDown, 0, nil}


### PR DESCRIPTION
Some CSI key sequences like `^[[5;10~` were only partially consumed by the parser, leaving trailing bytes (e.g. `10~`) in the input buffer which could then be printed as stray characters in the terminal.

In `escSequence()` (in `light.go`) the branches handling certain 7‑byte CSI forms returned the correct event but failed to set the consumed size pointer *sz = 7, so the caller removed too few bytes from the buffer.
After setting `*sz = 7` in the affected branches the entire 7‑byte sequence is consumed and no leftover bytes are interpreted/printed.