### PR TITLE
feat: append spinner in the end when --info=inline

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2978,13 +2978,13 @@ func (t *Terminal) printInfoImpl() {
 	if outputPrinter == nil {
 		output = t.trimMessage(output, maxWidth)
 		t.window.CPrint(tui.ColInfo, output)
-		if t.infoStyle == infoInline && len(output) < maxWidth-1 && t.reading {
-			t.window.Print(" ")
-			printSpinner()
-			outputLen += 2
-		}
 	} else {
 		outputPrinter(t.window, maxWidth)
+	}
+	if t.infoStyle == infoInline && outputLen < maxWidth-1 && t.reading {
+		t.window.Print(" ")
+		printSpinner()
+		outputLen += 2
 	}
 
 	if t.infoStyle == infoInlineRight {


### PR DESCRIPTION
Since all other infoStyle has spinner, maybe also add spinner for `--info=inline`.

```diff
diff --git a/src/terminal.go b/src/terminal.go
index add51919..b4006ebd 100644
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -2978,6 +2978,10 @@ func (t *Terminal) printInfoImpl() {
 	if outputPrinter == nil {
 		output = t.trimMessage(output, maxWidth)
 		t.window.CPrint(tui.ColInfo, output)
+		if t.infoStyle == infoInline {
+			t.window.Print(" ")
+			printSpinner()
+		}
 	} else {
 		outputPrinter(t.window, maxWidth)
 	}
```
