### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -850,19 +850,19 @@ func nthTransformer(str string) (func(Delimiter) func([]Token, int32) string, er
 
 	return func(delimiter Delimiter) func([]Token, int32) string {
 		return func(tokens []Token, index int32) string {
-			str := ""
+			var str strings.Builder
 			for _, holder := range parts {
 				if holder.nth != nil {
-					str += StripLastDelimiter(JoinTokens(Transform(tokens, holder.nth)), delimiter)
+					str.WriteString(StripLastDelimiter(JoinTokens(Transform(tokens, holder.nth)), delimiter))
 				} else if holder.index {
 					if index >= 0 {
-						str += strconv.Itoa(int(index))
+						str.WriteString(strconv.Itoa(int(index)))
 					}
 				} else {
-					str += holder.str
+					str.WriteString(holder.str)
 				}
 			}
-			return str
+			return str.String()
 		}
 	}, nil
 }

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -3907,21 +3907,21 @@ func findPassThrough(line string) []int {
 
 func extractPassThroughs(line string) ([]string, string) {
 	passThroughs := []string{}
-	transformed := ""
+	var transformed strings.Builder
 	index := 0
 	for {
 		rest := line[index:]
 		loc := findPassThrough(rest)
 		if loc == nil {
-			transformed += rest
+			transformed.WriteString(rest)
 			break
 		}
 		passThroughs = append(passThroughs, rest[loc[0]:loc[1]])
-		transformed += line[index : index+loc[0]]
+		transformed.WriteString(line[index : index+loc[0]])
 		index += loc[1]
 	}
 
-	return passThroughs, transformed
+	return passThroughs, transformed.String()
 }
 
 func (t *Terminal) renderPreviewText(height int, lines []string, lineNo int, unchanged bool) {
@@ -4294,7 +4294,7 @@ func parsePlaceholder(match string) (bool, string, placeholderFlags) {
 		return false, match, flags
 	}
 
-	trimmed := ""
+	var trimmed strings.Builder
 	for _, char := range match[1:] {
 		switch char {
 		case '*':
@@ -4311,13 +4311,13 @@ func parsePlaceholder(match string) (bool, string, placeholderFlags) {
 			flags.raw = true
 		case 'q':
 			flags.forceUpdate = true
-			trimmed += string(char)
+			trimmed.WriteString(string(char))
 		default:
-			trimmed += string(char)
+			trimmed.WriteString(string(char))
 		}
 	}
 
-	matchWithoutFlags := "{" + trimmed
+	matchWithoutFlags := "{" + trimmed.String()
 
 	return false, matchWithoutFlags, flags
 }

--- a/src/tmux.go
+++ b/src/tmux.go
@@ -3,6 +3,7 @@ package fzf
 import (
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/junegunn/fzf/src/tui"
 )
@@ -23,11 +24,12 @@ func runTmux(args []string, opts *Options) (int, error) {
 	if opts.Tmux.border && opts.Margin == defaultMargin() {
 		args = append(args, "--margin=0,1")
 	}
-	argStr := escapeSingleQuote(fzf)
+	var argStr strings.Builder
+	argStr.WriteString(escapeSingleQuote(fzf))
 	for _, arg := range append(args, rest...) {
-		argStr += " " + escapeSingleQuote(arg)
+		argStr.WriteString(" " + escapeSingleQuote(arg))
 	}
-	argStr += ` --no-tmux --no-height`
+	argStr.WriteString(` --no-tmux --no-height`)
 
 	// Get current directory
 	dir, err := os.Getwd()
@@ -61,7 +63,7 @@ func runTmux(args []string, opts *Options) (int, error) {
 	tmuxArgs = append(tmuxArgs, "-w"+opts.Tmux.width.String())
 	tmuxArgs = append(tmuxArgs, "-h"+opts.Tmux.height.String())
 
-	return runProxy(argStr, func(temp string, needBash bool) (*exec.Cmd, error) {
+	return runProxy(argStr.String(), func(temp string, needBash bool) (*exec.Cmd, error) {
 		sh, err := sh(needBash)
 		if err != nil {
 			return nil, err

--- a/src/util/util.go
+++ b/src/util/util.go
@@ -156,32 +156,33 @@ func Once(nextResponse bool) func() bool {
 func RepeatToFill(str string, length int, limit int) string {
 	times := limit / length
 	rest := limit % length
-	output := strings.Repeat(str, times)
+	var output strings.Builder
+	output.WriteString(strings.Repeat(str, times))
 	if rest > 0 {
 		for _, r := range str {
 			rest -= uniseg.StringWidth(string(r))
 			if rest < 0 {
 				break
 			}
-			output += string(r)
+			output.WriteString(string(r))
 			if rest == 0 {
 				break
 			}
 		}
 	}
-	return output
+	return output.String()
 }
 
 // ToKebabCase converts the given CamelCase string to kebab-case
 func ToKebabCase(s string) string {
-	name := ""
+	var name strings.Builder
 	for i, r := range s {
 		if i > 0 && r >= 'A' && r <= 'Z' {
-			name += "-"
+			name.WriteString("-")
 		}
-		name += string(r)
+		name.WriteString(string(r))
 	}
-	return strings.ToLower(name)
+	return strings.ToLower(name.String())
 }
 
 // CompareVersions compares two version strings


### PR DESCRIPTION
strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)