### PR TITLE
chore: Fix line break in comment for better readability

### DIFF
--- a/src/reader.go
+++ b/src/reader.go
@@ -216,8 +216,7 @@ func (r *Reader) feed(src io.Reader) {
 				//   position in the slab so that a straddling item that doesn't go
 				//   beyond the boundary of a slab doesn't need to be copied to
 				//   another buffer. However, the performance gain is negligible in
-				//   practice (< 0.1%) and is not
-				//   worth the added complexity.
+				//   practice (< 0.1%) and is not worth the added complexity.
 				leftover = append(leftover, buf...)
 				break
 			}


### PR DESCRIPTION
Improve comment formatting in src/reader.go by joining a sentence that was unnecessarily split across two lines. 

The phrase "is not worth the added complexity" now appears on a single line, making the comment easier to read and understand.
