### PR TITLE
Add --freeze-{left,right}=N option to keep the {left,right}most N fields visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ CHANGELOG
   git grep --line-number --color=always -- '' |
       fzf --ansi --delimiter : --freeze-left 1 --keep-right
   ```
+- Also added `--freeze-right=N` option to keep the rightmost N columns visible.
+  ```sh
+  fd | fzf --freeze-right 1 --delimiter /
+  fd | fzf --freeze-left 1 --freeze-right 1 --delimiter /
+  ```
 
 0.66.1
 ------

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -632,9 +632,13 @@ The given string will be repeated to draw a horizontal line on each gap
 .BI "\-\-freeze\-left=" "N"
 Number of fields to freeze on the left.
 .TP
+.BI "\-\-freeze\-right=" "N"
+Number of fields to freeze on the right.
+.TP
 .B "\-\-keep\-right"
 Keep the right end of the line visible when it's too long. Effective only when
-the query string is empty.
+the query string is empty. Use \fB\-\-freeze\-right=1\fR instead if you want
+the last field to be always visible even with a non-empty query.
 .TP
 .BI "\-\-scroll\-off=" "LINES"
 Number of screen lines to keep above or below when scrolling to the top or to

--- a/src/options.go
+++ b/src/options.go
@@ -105,6 +105,7 @@ Usage: fzf [options]
     --gap-line[=STR]         Draw horizontal line on each gap using the string
                              (default: '┈' or '-')
     --freeze-left=N          Number of fields to freeze on the left
+    --freeze-right=N         Number of fields to freeze on the right
     --keep-right             Keep the right end of the line visible on overflow
     --scroll-off=LINES       Number of screen lines to keep above or below when
                              scrolling to the top or to the bottom (default: 0)
@@ -564,6 +565,7 @@ type Options struct {
 	Normalize         bool
 	Nth               []Range
 	FreezeLeft        int
+	FreezeRight       int
 	WithNth           func(Delimiter) func([]Token, int32) string
 	AcceptNth         func(Delimiter) func([]Token, int32) string
 	Delimiter         Delimiter
@@ -2701,6 +2703,10 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 			if opts.FreezeLeft, err = nextInt("number of fields required"); err != nil {
 				return err
 			}
+		case "--freeze-right":
+			if opts.FreezeRight, err = nextInt("number of fields required"); err != nil {
+				return err
+			}
 		case "--with-nth":
 			str, err := nextString("nth expression required")
 			if err != nil {
@@ -3344,7 +3350,7 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 		return errors.New("empty jump labels")
 	}
 
-	if opts.FreezeLeft < 0 {
+	if opts.FreezeLeft < 0 || opts.FreezeRight < 0 {
 		return errors.New("number of fields to freeze must be a non-negative integer")
 	}
 

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -1201,6 +1201,33 @@ class TestCore < TestInteractive
     tmux.until { |lines| assert lines.any_include?('1␊2␊3␊4␊5␊') }
   end
 
+  def test_freeze_left_and_right
+    tmux.send_keys %[seq 10000 | tr "\n" ' ' | #{FZF} --freeze-left 3 --freeze-right 3 --ellipsis XX], :Enter
+    tmux.until { |lines| assert_match(/XX9998 9999 10000$/, lines[-3]) }
+    tmux.send_keys "'1000"
+    tmux.until { |lines| assert_match(/^> 1 2 3XX.*XX9998 9999 10000$/,lines[-3]) }
+  end
+
+  def test_freeze_right_exceed_range
+    tmux.send_keys %[seq 10000 | tr "\n" ' ' | #{FZF} --freeze-right 100000 --ellipsis XX], :Enter
+    ['', "'1000"].each do |query|
+      tmux.send_keys query
+      tmux.until { |lines| assert lines.any_include?("> #{query}".strip) }
+      tmux.until do |lines|
+        assert_match(/ 9998 9999 10000$/, lines[-3])
+        assert_equal(1, lines[-3].scan('XX').size)
+      end
+    end
+  end
+
+  def test_freeze_right_exceed_range_with_freeze_left
+    tmux.send_keys %[seq 10000 | tr "\n" ' ' | #{FZF} --freeze-left 3  --freeze-right 100000 --ellipsis XX], :Enter
+    tmux.until do |lines|
+      assert_match(/^> 1 2 3XX.*9998 9999 10000$/, lines[-3])
+      assert_equal(1, lines[-3].scan('XX').size)
+    end
+  end
+
   def test_backward_eof
     tmux.send_keys "echo foo | #{FZF} --bind 'backward-eof:reload(seq 100)'", :Enter
     tmux.until { |lines| lines.item_count == 1 && lines.match_count == 1 }


### PR DESCRIPTION
```sh
git grep --line-number --color=always -- '' |
    fzf --ansi --delimiter : --freeze-left 1

fd | fzf --freeze-right 1 --delimiter /

fd | fzf --freeze-left 1 --freeze-right 1 --delimiter /
```