### PR TITLE
Fix modifier detection for Backspace / Ctrl-H on Windows (#4572)

### DIFF
--- a/src/tui/tcell.go
+++ b/src/tui/tcell.go
@@ -371,10 +371,12 @@ func (r *FullscreenRenderer) GetChar() Event {
 				}
 			case rune(tcell.KeyCtrlH):
 				switch {
+				case ctrl:
+					return keyfn('h')
 				case alt:
 					return Event{AltBackspace, 0, nil}
-				case ctrl, none, shift:
-					return keyfn('h')
+				case none, shift:
+					return Event{Backspace, 0, nil}
 				}
 			}
 		case tcell.KeyCtrlI:


### PR DESCRIPTION
Windows sends different key events and modifier combinations to the FullscreenRenderer than a FullscreenRenderer on Linux (`-tags tcell`). This led to Ctrl+H being misinterpreted (and therefore unbindable) on some Windows builds.

Basically reverts changes to `src/tui/tcell.go` introduced by `a0cabe0`.