### PR TITLE
Updates man page documentation

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -740,7 +740,7 @@ ENVIRONMENT VARIABLES EXPORTED TO CHILD PROCESSES.
 
 e.g.
      \fB# Prepend the current cursor position in yellow
-     fzf \-\-info\-command='printf "\\x1b[33;1m$FZF_POS\\x1b[m/$FZF_INFO 💛\\n"'\fR
+     fzf \-\-info\-command='printf "\\x1b[33;1m$FZF_POS\\x1b[m/$FZF_INFO 💛"'\fR
 
 .TP
 .B "\-\-no\-info"
@@ -2108,7 +2108,7 @@ payload of HTTP POST request to the \fB\-\-listen\fR server.
 
 e.g.
     \fB# Disallow selecting an empty line
-    printf "1. Hello\\n2. Goodbye\\n\\n3. Exit\\n" |
+    printf "1. Hello\\n2. Goodbye\\n\\n3. Exit" |
       fzf \-\-height '~100%' \-\-reverse \-\-header 'Select one' \\
           \-\-bind 'enter:transform:[[ \-n {} ]] &&
                     echo accept ||


### PR DESCRIPTION
### docs(man): Add example for {+f} in preview command

Provide an example for having multiple selected items be seperated by newlines,
as the question comes up from time to time.

References:
- https://github.com/junegunn/fzf/discussions/4604
- https://github.com/junegunn/fzf/discussions/4187

---

### docs(man): replace echo -e with printf to improve portability across different shells

`echo -e` behaves inconsistently across different shells.

References:
- https://github.com/romkatv/zsh4humans/issues/35#issuecomment-1000200683
- https://www.in-ulm.de/~mascheck/various/echo+printf/

For example:
  /bin/sh   -c 'echo -e 1'  ->  `-e 1`
  /bin/dash -c 'echo -e 2'  ->  `-e 2`
  /bin/bash -c 'echo -e 3'  ->  `3`

While POSIX 2024 added text regarding `-e` support, it does not guarantee
consistent behavior across different shells. `printf` is the recommended
portable alternative for formatted output and escape sequences.

References:
- https://www.austingroupbugs.net/view.php?id=1222
- https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/utilities/echo.html#tag_20_37_18
- https://pubs.opengroup.org/onlinepubs/9799919799.2024edition/utilities/echo.html#tag_20_37_18
