### PR TITLE
Add --ansi-preview to preserve ANSI colors in preview

### DIFF
--- a/src/core.go
+++ b/src/core.go
@@ -109,6 +109,11 @@ func Run(opts *Options) (int, error) {
 				eventBox.Set(EvtHeader, header)
 				return false
 			}
+			if opts.AnsiPreview {
+				rawCopy := make([]byte, len(data))
+				copy(rawCopy, data)
+				item.rawOrigText = &rawCopy
+			}
 			item.text, item.colors = ansiProcessor(data)
 			item.text.Index = itemIndex
 			itemIndex++
@@ -154,6 +159,11 @@ func Run(opts *Options) (int, error) {
 			item.text.TrimTrailingWhitespaces(int(maxColorOffset))
 			item.text.Index = itemIndex
 			item.origText = &data
+			if opts.AnsiPreview {
+				rawCopy := make([]byte, len(data))
+				copy(rawCopy, data)
+				item.rawOrigText = &rawCopy
+			}
 			itemIndex++
 			return true
 		})

--- a/src/item.go
+++ b/src/item.go
@@ -13,15 +13,16 @@ type transformed struct {
 	tokens   []Token
 }
 
-// Item represents each input line. 56 bytes.
+// Item represents each input line. 64 bytes.
 type Item struct {
 	text        util.Chars    // 32 = 24 + 1 + 1 + 2 + 4
 	transformed *transformed  // 8
 	origText    *[]byte       // 8
+	rawOrigText *[]byte       // 8
 	colors      *[]ansiOffset // 8
 }
 
-// Index returns ordinal index of the Item
+// Index returns ordinal index of the ItemAdding rawText changes the struct size; the comment
 func (item *Item) Index() int32 {
 	return item.text.Index
 }
@@ -40,8 +41,11 @@ func (item *Item) Colors() []ansiOffset {
 	return *item.colors
 }
 
-// AsString returns the original string
+// AsString returns the original string (prefers the raw field when not stripping)
 func (item *Item) AsString(stripAnsi bool) string {
+	if item.rawOrigText != nil && !stripAnsi {
+		return string(*item.rawOrigText) // true raw ANSI
+	}
 	if item.origText != nil {
 		if stripAnsi {
 			trimmed, _, _ := extractColor(string(*item.origText), nil, nil)

--- a/src/options.go
+++ b/src/options.go
@@ -56,6 +56,7 @@ Usage: fzf [options]
     --read0                  Read input delimited by ASCII NUL characters
     --print0                 Print output delimited by ASCII NUL characters
     --ansi                   Enable processing of ANSI color codes
+	--ansi-preview           Pass ANSI color codes to preview command
     --sync                   Synchronous search for multi-staged filtering
 
   GLOBAL STYLE
@@ -660,6 +661,7 @@ type Options struct {
 	BlockProfile      string
 	MutexProfile      string
 	TtyDefault        string
+	AnsiPreview       bool
 }
 
 func filterNonEmpty(input []string) []string {
@@ -766,7 +768,8 @@ func defaultOptions() *Options {
 		WalkerSkip:   []string{".git", "node_modules"},
 		TtyDefault:   tui.DefaultTtyDevice,
 		Help:         false,
-		Version:      false}
+		Version:      false,
+		AnsiPreview:  false,}
 }
 
 func isDir(path string) bool {
@@ -2775,8 +2778,12 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 			opts.Multi = 0
 		case "--ansi":
 			opts.Ansi = true
+		case "--ansi-preview":
+			opts.AnsiPreview = true
 		case "--no-ansi":
 			opts.Ansi = false
+		case "--no-ansi-preview":
+			opts.AnsiPreview = false
 		case "--no-mouse":
 			opts.Mouse = false
 		case "+c", "--no-color":


### PR DESCRIPTION
Fixes #4626

fzf was stripping ANSI escape codes during item ingestion, so preview `{}` never received the original colored text.  
This change preserves the raw ANSI input alongside the stripped text and introduces `--ansi-preview` to route raw data only to the preview path.  
Default behavior remains unchanged and raw storage is only enabled when `--ansi-preview` is used.Tell me if there any other change i have to make.


<img width="938" height="504" alt="image" src="https://github.com/user-attachments/assets/02fece4a-69fc-495a-b1a3-3570c0558780" />
