### PR TITLE
fix: rebind readline command redraw-current-line

### DIFF
--- a/shell/key-bindings.bash
+++ b/shell/key-bindings.bash
@@ -121,7 +121,7 @@ else # awk - fallback for POSIX systems
 fi
 
 # Required to refresh the prompt after fzf
-bind -m emacs-standard '"\eR": redraw-current-line'
+bind -m emacs-standard '"\C-\e(": redraw-current-line'
 
 bind -m vi-command '"\C-z": emacs-editing-mode'
 bind -m vi-insert '"\C-z": emacs-editing-mode'
@@ -130,7 +130,7 @@ bind -m emacs-standard '"\C-z": vi-editing-mode'
 if ((BASH_VERSINFO[0] < 4)); then
   # CTRL-T - Paste the selected file path into the command line
   if [[ ${FZF_CTRL_T_COMMAND-x} != "" ]]; then
-    bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\eR\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f\C-y\ey\C-_"'
+    bind -m emacs-standard '"\C-t": " \C-b\C-k \C-u`__fzf_select__`\e\C-e\C-\e(\C-a\C-y\C-h\C-e\e \C-y\ey\C-x\C-x\C-f\C-y\ey\C-_"'
     bind -m vi-command '"\C-t": "\C-z\C-t\C-z"'
     bind -m vi-insert '"\C-t": "\C-z\C-t\C-z"'
   fi
@@ -140,7 +140,7 @@ if ((BASH_VERSINFO[0] < 4)); then
     if [[ -n ${FZF_CTRL_R_COMMAND-} ]]; then
       echo "warning: FZF_CTRL_R_COMMAND is set to a custom command, but custom commands are not yet supported for CTRL-R" >&2
     fi
-    bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\eR"'
+    bind -m emacs-standard '"\C-r": "\C-e \C-u\C-y\ey\C-u`__fzf_history__`\e\C-e\C-\e("'
     bind -m vi-command '"\C-r": "\C-z\C-r\C-z"'
     bind -m vi-insert '"\C-r": "\C-z\C-r\C-z"'
   fi
@@ -165,7 +165,7 @@ fi
 
 # ALT-C - cd into the selected directory
 if [[ ${FZF_ALT_C_COMMAND-x} != "" ]]; then
-  bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\eR\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d\C-y\ey\C-_"'
+  bind -m emacs-standard '"\ec": " \C-b\C-k \C-u`__fzf_cd__`\e\C-e\C-\e(\C-m\C-y\C-h\e \C-y\ey\C-x\C-x\C-d\C-y\ey\C-_"'
   bind -m vi-command '"\ec": "\C-z\ec\C-z"'
   bind -m vi-insert '"\ec": "\C-z\ec\C-z"'
 fi


### PR DESCRIPTION
## Rebind `redraw-current-line` readline command from "\er" (ALT-R)
The custom key bind in _/shell/key-bindings.bash_ overrides the default readline keybinding of `"\er": revert-line`, causing undocumented changes in readline command keybindings.

## Solution: Bind `redraw-current-line` to "\eR" (SHIFT-ALT-R)
Attempting to manually rebind "\er" to `revert-line` in _~/.inputrc_ introduces unexpected behavior in the ALT_C operation of fzf, resulting in an empty `complete` readline command after the builtin cd, filling the terminal screen with all possible binary executables in the user's `$PATH`. This keybinding in the `__fzf_cd__` function is used only internally and is not explicitly documented or exposed to fzf users. Using "\eR" rather than "\er" eliminates an unnecessary and undocumented default readline keybinding override that may confound users troubleshooting readline command keybindings.

Closes: #4634

## Tests
`make test`
```
--- PASS: TestTrimLength (0.00s)
=== RUN   TestCharsLines
[[97 98 99 100 101 102 10]] true
[[97 98 99 100 101 102 10] [44032 45208 45796 10]] true
[[97 98 99 100 101 102 10] [44032 45208 45796 10] [9 100 101 102]] false
[[97 98] [99 100] [101 102 10] [44032]] true
[[97 98] [99 100] [101 102 10] [44032] [45208]] true
[[97 98] [99 100] [101 102 10] [44032] [45208] [45796 10]] true
[[97 98] [99 100] [101 102 10] [44032] [45208] [45796 10] [9]] true
[[97 98] [99 100] [101 102 10] [44032] [45208] [45796 10] [9] [100 101]] true
[[97 98] [99 100] [101 102 10] [44032] [45208] [45796 10] [9] [100 101] [102]] false
[[97 98] [99 100] [101 102 10] [44032] [45208] [45796 10] [9 100] [101 102]] false
[[97 98 99] [100 101] [102 10] [44032] [45208] [45796 10] [9 100 101] [102]] false
[[97 98 99] [100] [101] [102 10] [44032] [45208] [45796] [10] [9 100 101] [102]] false
[[97 98 99] [100] [101] [102] [10] [44032] [45208] [45796] [10] [9] [100] [101] [102]] false
--- PASS: TestCharsLines (0.00s)
=== RUN   TestEventBox
--- PASS: TestEventBox (0.00s)
=== RUN   TestMax
--- PASS: TestMax (0.00s)
=== RUN   TestMax16
--- PASS: TestMax16 (0.00s)
=== RUN   TestMax32
--- PASS: TestMax32 (0.00s)
=== RUN   TestMin
--- PASS: TestMin (0.00s)
=== RUN   TestMin32
--- PASS: TestMin32 (0.00s)
=== RUN   TestConstrain
--- PASS: TestConstrain (0.00s)
=== RUN   TestConstrain32
--- PASS: TestConstrain32 (0.00s)
=== RUN   TestAsUint16
--- PASS: TestAsUint16 (0.00s)
=== RUN   TestDurWithIn
--- PASS: TestDurWithIn (0.00s)
=== RUN   TestOnce
--- PASS: TestOnce (0.00s)
=== RUN   TestRunesWidth
--- PASS: TestRunesWidth (0.00s)
=== RUN   TestTruncate
--- PASS: TestTruncate (0.00s)
=== RUN   TestRepeatToFill
--- PASS: TestRepeatToFill (0.00s)
=== RUN   TestStringWidth
--- PASS: TestStringWidth (0.00s)
=== RUN   TestCompareVersions
--- PASS: TestCompareVersions (0.00s)
PASS
ok      github.com/junegunn/fzf/src/util        (cached)

```

`make itest` (verbose detail of skipped test)
```
  1) Skipped:
TestLayout#test_combinations [test/test_layout.rb:1228]:
Skipped, no message given

352 runs, 3334 assertions, 0 failures, 0 errors, 1 skips
```