### PR TITLE
Fix goreleaser deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,12 +85,14 @@ notarize:
 
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
-    builds:
+    ids:
       - fzf
-    format: tar.gz
+    formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     files:
       - non-existent*
 
@@ -102,7 +104,7 @@ release:
   name_template: '{{ .Version }}'
 
 snapshot:
-  name_template: "{{ .Version }}-devel"
+  version_template: "{{ .Version }}-devel"
 
 changelog:
   sort: asc


### PR DESCRIPTION
Current goreleaser v2.13.1 has several deprecations:
* since v2.2: https://goreleaser.com/deprecations#snapshotname_template
* since v2.6: https://goreleaser.com/deprecations#archivesformat
* since v2.6: https://goreleaser.com/deprecations#archivesformat_overridesformat
* since v2.8: https://goreleaser.com/deprecations#archivesbuilds

Check build output locally: `goreleaser release --clean --snapshot`