### PR TITLE
fix: Wrong placement of 'ANSI colour off' with `--no-hscroll` when the string contains zero-width characters

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -3810,9 +3810,12 @@ func (t *Terminal) printHighlighted(result Result, colBase tui.ColorPair, colMat
 					runes, _ = t.trimRight(runes, maxWidth-ellipsisWidth)
 					runes = append(runes, ellipsis...)
 
+					// Use character indices (len(runes)) instead of display width (maxWidth)
+					// to properly handle zero-width characters (combining marks, control chars)
+					contentLen := int32(len(runes) - len(ellipsis))
 					for idx, offset := range offs {
-						offs[idx].offset[0] = min(offset.offset[0], int32(maxWidth-len(ellipsis)))
-						offs[idx].offset[1] = min(offset.offset[1], int32(maxWidth))
+						offs[idx].offset[0] = min(offset.offset[0], contentLen)
+						offs[idx].offset[1] = min(offset.offset[1], contentLen)
 					}
 				}
 				displayWidth = t.displayWidthWithLimit(runes, 0, maxWidth)


### PR DESCRIPTION
Fixes #4620

## Changes
- Fix ANSI color offset calculation in `--no-hscroll` mode to use character indices instead of display width
- This correctly handles zero-width characters (combining marks, control chars) where character count differs from column width