### PR TITLE
fix: `--preview-window wrap` breaks preview scrolling in some condition

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4182,6 +4182,7 @@ Loop:
 				continue
 			} else if fillRet == tui.FillSuspend {
 				t.previewed.filled = true
+				t.previewer.scrollable = true
 				break
 			}
 			if unchanged && lineNo == 0 {
@@ -4195,6 +4196,7 @@ Loop:
 			}
 			if fillRet == tui.FillSuspend {
 				t.previewed.filled = true
+				t.previewer.scrollable = true
 				break
 			}
 		}


### PR DESCRIPTION
Fixes #4258

## Changes
- Set `scrollable = true` when `FillSuspend` is returned during preview rendering
- Ensures preview window correctly detects scrollability when wrapped lines fill the window