### PR TITLE
fix: Problem using 'execute' action invoked via HTTP POST-request

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -245,199 +245,200 @@ type runningCmd struct {
 
 // Terminal represents terminal input/output
 type Terminal struct {
-	initDelay          time.Duration
-	infoCommand        string
-	infoStyle          infoStyle
-	infoPrefix         string
-	wrap               bool
-	wrapSign           string
-	wrapSignWidth      int
-	ghost              string
-	separator          labelPrinter
-	separatorLen       int
-	spinner            []string
-	promptString       string
-	prompt             func()
-	promptLen          int
-	borderLabel        labelPrinter
-	borderLabelLen     int
-	borderLabelOpts    labelOpts
-	previewLabel       labelPrinter
-	previewLabelLen    int
-	previewLabelOpts   labelOpts
-	inputLabel         labelPrinter
-	inputLabelLen      int
-	inputLabelOpts     labelOpts
-	headerLabel        labelPrinter
-	headerLabelLen     int
-	headerLabelOpts    labelOpts
-	footerLabel        labelPrinter
-	footerLabelLen     int
-	footerLabelOpts    labelOpts
-	gutterReverse      bool
-	gutterRawReverse   bool
-	pointer            string
-	pointerLen         int
-	pointerEmpty       string
-	pointerEmptyRaw    string
-	marker             string
-	markerLen          int
-	markerEmpty        string
-	markerMultiLine    [3]string
-	queryLen           [2]int
-	layout             layoutType
-	fullscreen         bool
-	keepRight          bool
-	hscroll            bool
-	hscrollOff         int
-	scrollOff          int
-	gap                int
-	gapLine            labelPrinter
-	gapLineLen         int
-	wordRubout         string
-	wordNext           string
-	subWordRubout      string
-	subWordNext        string
-	cx                 int
-	cy                 int
-	offset             int
-	xoffset            int
-	yanked             []rune
-	input              []rune
-	inputOverride      *[]rune
-	pasting            *[]rune
-	multi              int
-	multiLine          bool
-	sort               bool
-	toggleSort         bool
-	track              trackOption
-	delimiter          Delimiter
-	expect             map[tui.Event]string
-	keymap             map[tui.Event][]*action
-	keymapOrg          map[tui.Event][]*action
-	pressed            string
-	printQueue         []string
-	printQuery         bool
-	history            *History
-	cycle              bool
-	highlightLine      bool
-	headerVisible      bool
-	headerFirst        bool
-	headerLines        int
-	header             []string
-	header0            []string
-	footer             []string
-	ellipsis           string
-	scrollbar          string
-	previewScrollbar   string
-	ansi               bool
-	freezeLeft         int
-	freezeRight        int
-	nthAttr            tui.Attr
-	nth                []Range
-	nthCurrent         []Range
-	acceptNth          func([]Token, int32) string
-	tabstop            int
-	margin             [4]sizeSpec
-	padding            [4]sizeSpec
-	unicode            bool
-	listenAddr         *listenAddress
-	listenPort         *int
-	listener           net.Listener
-	listenUnsafe       bool
-	borderShape        tui.BorderShape
-	listBorderShape    tui.BorderShape
-	inputBorderShape   tui.BorderShape
-	headerBorderShape  tui.BorderShape
-	headerLinesShape   tui.BorderShape
-	footerBorderShape  tui.BorderShape
-	listLabel          labelPrinter
-	listLabelLen       int
-	listLabelOpts      labelOpts
-	cleanExit          bool
-	executor           *util.Executor
-	paused             bool
-	inputless          bool
-	border             tui.Window
-	window             tui.Window
-	inputWindow        tui.Window
-	inputBorder        tui.Window
-	headerWindow       tui.Window
-	headerBorder       tui.Window
-	headerLinesWindow  tui.Window
-	headerLinesBorder  tui.Window
-	footerWindow       tui.Window
-	footerBorder       tui.Window
-	wborder            tui.Window
-	pborder            tui.Window
-	pwindow            tui.Window
-	borderWidth        int
-	count              int
-	progress           int
-	hasStartActions    bool
-	hasResultActions   bool
-	hasFocusActions    bool
-	hasLoadActions     bool
-	hasResizeActions   bool
-	triggerLoad        bool
-	reading            bool
-	running            *util.AtomicBool
-	failed             *string
-	jumping            jumpMode
-	jumpLabels         string
-	printer            func(string)
-	printsep           string
-	merger             *Merger
-	passMerger         *Merger
-	resultMerger       *Merger
-	matchMap           map[int32]Result
-	selected           map[int32]selectedItem
-	version            int64
-	revision           revision
-	bgVersion          int64
-	runningCmds        *util.ConcurrentSet[*runningCmd]
-	reqBox             *util.EventBox
-	initialPreviewOpts previewOpts
-	previewOpts        previewOpts
-	activePreviewOpts  *previewOpts
-	previewer          previewer
-	previewed          previewed
-	previewBox         *util.EventBox
-	eventBox           *util.EventBox
-	mutex              sync.Mutex
-	uiMutex            sync.Mutex
-	initFunc           func() error
-	prevLines          []itemLine
-	suppress           bool
-	startChan          chan fitpad
-	killChan           chan bool
-	serverInputChan    chan []*action
-	callbackChan       chan versionedCallback
-	bgQueue            map[action][]func(bool)
-	bgSemaphore        chan struct{}
-	bgSemaphores       map[action]chan struct{}
-	keyChan            chan tui.Event
-	eventChan          chan tui.Event
-	slab               *util.Slab
-	theme              *tui.ColorTheme
-	tui                tui.Renderer
-	ttyDefault         string
-	ttyin              *os.File
-	executing          *util.AtomicBool
-	termSize           tui.TermSize
-	lastAction         actionType
-	lastKey            string
-	lastFocus          int32
-	areaLines          int
-	areaColumns        int
-	forcePreview       bool
-	clickHeaderLine    int
-	clickHeaderColumn  int
-	clickFooterLine    int
-	clickFooterColumn  int
-	proxyScript        string
-	numLinesCache      map[int32]numLinesCacheValue
-	raw                bool
+	initDelay            time.Duration
+	infoCommand          string
+	infoStyle            infoStyle
+	infoPrefix           string
+	wrap                 bool
+	wrapSign             string
+	wrapSignWidth        int
+	ghost                string
+	separator            labelPrinter
+	separatorLen         int
+	spinner              []string
+	promptString         string
+	prompt               func()
+	promptLen            int
+	borderLabel          labelPrinter
+	borderLabelLen       int
+	borderLabelOpts      labelOpts
+	previewLabel         labelPrinter
+	previewLabelLen      int
+	previewLabelOpts     labelOpts
+	inputLabel           labelPrinter
+	inputLabelLen        int
+	inputLabelOpts       labelOpts
+	headerLabel          labelPrinter
+	headerLabelLen       int
+	headerLabelOpts      labelOpts
+	footerLabel          labelPrinter
+	footerLabelLen       int
+	footerLabelOpts      labelOpts
+	gutterReverse        bool
+	gutterRawReverse     bool
+	pointer              string
+	pointerLen           int
+	pointerEmpty         string
+	pointerEmptyRaw      string
+	marker               string
+	markerLen            int
+	markerEmpty          string
+	markerMultiLine      [3]string
+	queryLen             [2]int
+	layout               layoutType
+	fullscreen           bool
+	keepRight            bool
+	hscroll              bool
+	hscrollOff           int
+	scrollOff            int
+	gap                  int
+	gapLine              labelPrinter
+	gapLineLen           int
+	wordRubout           string
+	wordNext             string
+	subWordRubout        string
+	subWordNext          string
+	cx                   int
+	cy                   int
+	offset               int
+	xoffset              int
+	yanked               []rune
+	input                []rune
+	inputOverride        *[]rune
+	pasting              *[]rune
+	multi                int
+	multiLine            bool
+	sort                 bool
+	toggleSort           bool
+	track                trackOption
+	delimiter            Delimiter
+	expect               map[tui.Event]string
+	keymap               map[tui.Event][]*action
+	keymapOrg            map[tui.Event][]*action
+	pressed              string
+	printQueue           []string
+	printQuery           bool
+	history              *History
+	cycle                bool
+	highlightLine        bool
+	headerVisible        bool
+	headerFirst          bool
+	headerLines          int
+	header               []string
+	header0              []string
+	footer               []string
+	ellipsis             string
+	scrollbar            string
+	previewScrollbar     string
+	ansi                 bool
+	freezeLeft           int
+	freezeRight          int
+	nthAttr              tui.Attr
+	nth                  []Range
+	nthCurrent           []Range
+	acceptNth            func([]Token, int32) string
+	tabstop              int
+	margin               [4]sizeSpec
+	padding              [4]sizeSpec
+	unicode              bool
+	listenAddr           *listenAddress
+	listenPort           *int
+	listener             net.Listener
+	listenUnsafe         bool
+	borderShape          tui.BorderShape
+	listBorderShape      tui.BorderShape
+	inputBorderShape     tui.BorderShape
+	headerBorderShape    tui.BorderShape
+	headerLinesShape     tui.BorderShape
+	footerBorderShape    tui.BorderShape
+	listLabel            labelPrinter
+	listLabelLen         int
+	listLabelOpts        labelOpts
+	cleanExit            bool
+	executor             *util.Executor
+	paused               bool
+	inputless            bool
+	border               tui.Window
+	window               tui.Window
+	inputWindow          tui.Window
+	inputBorder          tui.Window
+	headerWindow         tui.Window
+	headerBorder         tui.Window
+	headerLinesWindow    tui.Window
+	headerLinesBorder    tui.Window
+	footerWindow         tui.Window
+	footerBorder         tui.Window
+	wborder              tui.Window
+	pborder              tui.Window
+	pwindow              tui.Window
+	borderWidth          int
+	count                int
+	progress             int
+	hasStartActions      bool
+	hasResultActions     bool
+	hasFocusActions      bool
+	hasLoadActions       bool
+	hasResizeActions     bool
+	triggerLoad          bool
+	reading              bool
+	running              *util.AtomicBool
+	failed               *string
+	jumping              jumpMode
+	jumpLabels           string
+	printer              func(string)
+	printsep             string
+	merger               *Merger
+	passMerger           *Merger
+	resultMerger         *Merger
+	matchMap             map[int32]Result
+	selected             map[int32]selectedItem
+	version              int64
+	revision             revision
+	bgVersion            int64
+	runningCmds          *util.ConcurrentSet[*runningCmd]
+	reqBox               *util.EventBox
+	initialPreviewOpts   previewOpts
+	previewOpts          previewOpts
+	activePreviewOpts    *previewOpts
+	previewer            previewer
+	previewed            previewed
+	previewBox           *util.EventBox
+	eventBox             *util.EventBox
+	mutex                sync.Mutex
+	uiMutex              sync.Mutex
+	initFunc             func() error
+	prevLines            []itemLine
+	suppress             bool
+	startChan            chan fitpad
+	killChan             chan bool
+	serverInputChan      chan []*action
+	callbackChan         chan versionedCallback
+	bgQueue              map[action][]func(bool)
+	bgSemaphore          chan struct{}
+	bgSemaphores         map[action]chan struct{}
+	keyChan              chan tui.Event
+	eventChan            chan tui.Event
+	slab                 *util.Slab
+	theme                *tui.ColorTheme
+	tui                  tui.Renderer
+	ttyDefault           string
+	ttyin                *os.File
+	executing            *util.AtomicBool
+	externalActionSource bool
+	termSize             tui.TermSize
+	lastAction           actionType
+	lastKey              string
+	lastFocus            int32
+	areaLines            int
+	areaColumns          int
+	forcePreview         bool
+	clickHeaderLine      int
+	clickHeaderColumn    int
+	clickFooterLine      int
+	clickFooterColumn    int
+	proxyScript          string
+	numLinesCache        map[int32]numLinesCacheValue
+	raw                  bool
 }
 
 type numLinesCacheValue struct {
@@ -4786,6 +4787,19 @@ func (t *Terminal) executeCommand(template string, forcePlus bool, background bo
 		t.tui.Pause(true)
 		cmd.Run()
 		t.tui.Resume(true, false)
+		// When execute is triggered via HTTP POST (external action source), fzf's
+		// GetChar() was already blocking on tty read. Any keystroke intended for
+		// the executed command might have been captured by the blocking GetChar.
+		// We need to drain that captured keystroke to prevent it from being
+		// processed as an fzf event after execute returns.
+		if t.externalActionSource {
+			select {
+			case <-t.keyChan:
+				// Discarded captured key
+			case <-time.After(10 * time.Millisecond):
+				// No key captured or GetChar still blocking
+			}
+		}
 		t.mutex.Lock()
 		// NOTE: Using t.reqBox.Set(reqFullRedraw...) instead can cause a deadlock
 		t.fullRedraw()
@@ -5693,6 +5707,7 @@ func (t *Terminal) Loop() error {
 			}
 		case serverActions := <-t.serverInputChan:
 			event = tui.Invalid.AsEvent()
+			t.externalActionSource = true
 			if t.listenAddr == nil || t.listenAddr.IsLocal() || t.listenUnsafe {
 				actions = serverActions
 			} else {
@@ -7165,6 +7180,7 @@ func (t *Terminal) Loop() error {
 		for _, event := range events {
 			t.reqBox.Set(event, nil)
 		}
+		t.externalActionSource = false
 	}
 	return nil
 }


### PR DESCRIPTION
Fixes #4524

## Summary
When execute is triggered via HTTP POST, fzf's GetChar() goroutine was already blocking on tty read. Any keystroke intended for the executed command (e.g., 'q' to quit less) was captured by the blocking GetChar call instead of going to the subprocess.

## Changes
- Track when actions originate from external source (HTTP POST via serverInputChan)
- Drain any captured keystroke from keyChan after execute completes for external actions
- Reset the flag at end of each loop iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)