### PR TITLE
fix: sync preview hidden state across alternate layouts

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -4866,6 +4866,13 @@ func (t *Terminal) hasPreviewWindowOnRight() bool {
 	return t.hasPreviewWindow() && t.activePreviewOpts.position == posRight
 }
 
+func (t *Terminal) togglePreview(hidden bool) {
+	t.previewOpts.hidden = hidden
+	if t.previewOpts.alternative != nil {
+		t.previewOpts.alternative.hidden = hidden
+	}
+}
+
 func (t *Terminal) currentItem() *Item {
 	cnt := t.merger.Length()
 	if t.cy >= 0 && cnt > 0 && cnt > t.cy {
@@ -5899,6 +5906,7 @@ func (t *Terminal) Loop() error {
 				}
 				if act {
 					t.activePreviewOpts.Toggle()
+					t.togglePreview(t.activePreviewOpts.hidden)
 					updatePreviewWindow(false)
 					if t.canPreview() {
 						valid, list := t.buildPlusList(t.previewOpts.command, false)
@@ -6161,6 +6169,7 @@ func (t *Terminal) Loop() error {
 			case actClose:
 				if t.hasPreviewWindow() {
 					t.activePreviewOpts.Toggle()
+					t.togglePreview(t.activePreviewOpts.hidden)
 					updatePreviewWindow(false)
 				} else {
 					req(reqQuit)


### PR DESCRIPTION
Fixes #4100

## Changes
- Add togglePreview() helper to sync hidden state to both main and alternative preview layouts
- Call togglePreview() after toggle/show/hide/close actions to ensure state consistency

When using alternate preview layouts (e.g., `right,60%,<80(down:45%)`), hiding the preview in one layout now persists when the terminal is resized and the alternate layout becomes active.