### PR TITLE
Add --no-clear-on-start option

### DIFF
--- a/src/options.go
+++ b/src/options.go
@@ -650,6 +650,7 @@ type Options struct {
 	ListenAddr        *listenAddress
 	Unsafe            bool
 	ClearOnExit       bool
+	KeepScreen        bool
 	WalkerOpts        walkerOpts
 	WalkerRoot        []string
 	WalkerSkip        []string
@@ -3277,6 +3278,8 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 			opts.ClearOnExit = true
 		case "--no-clear":
 			opts.ClearOnExit = false
+		case "--no-clear-on-start":
+			opts.KeepScreen = true
 		case "--walker":
 			str, err := nextString("walker options required [file][,dir][,follow][,hidden]")
 			if err != nil {

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -942,7 +942,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox, executor *util.Executor
 		if tui.HasFullscreenRenderer() {
 			renderer = tui.NewFullscreenRenderer(opts.Theme, opts.Black, opts.Mouse)
 		} else {
-			renderer, err = tui.NewLightRenderer(opts.TtyDefault, ttyin, opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit,
+			renderer, err = tui.NewLightRenderer(opts.TtyDefault, ttyin, opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit, opts.KeepScreen,
 				true, func(h int) int { return h })
 		}
 	} else {
@@ -958,7 +958,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox, executor *util.Executor
 			effectiveMinHeight += borderLines(opts.BorderShape)
 			return min(termHeight, max(evaluateHeight(opts, termHeight), effectiveMinHeight))
 		}
-		renderer, err = tui.NewLightRenderer(opts.TtyDefault, ttyin, opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit, false, maxHeightFunc)
+		renderer, err = tui.NewLightRenderer(opts.TtyDefault, ttyin, opts.Theme, opts.Black, opts.Mouse, opts.Tabstop, opts.ClearOnExit, opts.KeepScreen, false, maxHeightFunc)
 	}
 	if err != nil {
 		return nil, err

--- a/src/tui/light.go
+++ b/src/tui/light.go
@@ -100,6 +100,7 @@ type LightRenderer struct {
 	mouse         bool
 	forceBlack    bool
 	clearOnExit   bool
+	keepScreen    bool
 	prevDownTime  time.Time
 	clicks        [][2]int
 	ttyin         *os.File
@@ -146,7 +147,7 @@ type LightWindow struct {
 	wrapSignWidth int
 }
 
-func NewLightRenderer(ttyDefault string, ttyin *os.File, theme *ColorTheme, forceBlack bool, mouse bool, tabstop int, clearOnExit bool, fullscreen bool, maxHeightFunc func(int) int) (Renderer, error) {
+func NewLightRenderer(ttyDefault string, ttyin *os.File, theme *ColorTheme, forceBlack bool, mouse bool, tabstop int, clearOnExit bool, keepScreen bool, fullscreen bool, maxHeightFunc func(int) int) (Renderer, error) {
 	out, err := openTtyOut(ttyDefault)
 	if err != nil {
 		out = os.Stderr
@@ -156,6 +157,7 @@ func NewLightRenderer(ttyDefault string, ttyin *os.File, theme *ColorTheme, forc
 		forceBlack:    forceBlack,
 		mouse:         mouse,
 		clearOnExit:   clearOnExit,
+		keepScreen:    keepScreen,
 		ttyin:         ttyin,
 		ttyout:        out,
 		yoffset:       0,
@@ -195,7 +197,7 @@ func (r *LightRenderer) Init() error {
 	} else {
 		// We assume that --no-clear is used for repetitive relaunching of fzf.
 		// So we do not clear the lower bottom of the screen.
-		if r.clearOnExit {
+		if r.clearOnExit && !r.keepScreen {
 			r.csi("J")
 		}
 		y, x := r.findOffset()

--- a/src/tui/light_test.go
+++ b/src/tui/light_test.go
@@ -10,7 +10,7 @@ import (
 func TestLightRenderer(t *testing.T) {
 	tty_file, _ := os.Open("")
 	renderer, _ := NewLightRenderer(
-		"", tty_file, &ColorTheme{}, true, false, 0, false, true,
+		"", tty_file, &ColorTheme{}, true, false, 0, false, false, true,
 		func(h int) int { return h })
 
 	light_renderer := renderer.(*LightRenderer)


### PR DESCRIPTION
This can be used in shell integration, to avoid clear the cmdline
content

before:
<img width="1734" height="392" alt="image" src="https://github.com/user-attachments/assets/22f9bb04-5135-4a10-8a6d-c559e832a44b" />

after:
<img width="1804" height="352" alt="image" src="https://github.com/user-attachments/assets/e449f916-cc40-44bf-9b1d-527054011d1e" />
