### PR TITLE
use mktemp, fix TERM quoting

### DIFF
--- a/bin/fzf-tmux
+++ b/bin/fzf-tmux
@@ -195,7 +195,7 @@ cleanup() {
 trap 'cleanup 1' SIGUSR1
 trap 'cleanup' EXIT
 
-envs="export TERM=$(printf %q "TERM ") "
+envs="export TERM=$(printf %q "$TERM") "
 if [[ $opt =~ "-E" ]]; then
   if [[ $tmux_version == 3.2 ]]; then
     FZF_DEFAULT_OPTS="--margin 0,1 $FZF_DEFAULT_OPTS"


### PR DESCRIPTION
- Replace $RANDOM with mktemp for temp file creation
- Apply printf %q to TERM for consistency with other env vars
