### PR TITLE
fix(terminal): handle SIGHUP signal

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -5209,7 +5209,7 @@ func (t *Terminal) Loop() error {
 
 	{ // Late initialization
 		intChan := make(chan os.Signal, 1)
-		signal.Notify(intChan, os.Interrupt, syscall.SIGTERM)
+		signal.Notify(intChan, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 		go func() {
 			for {
 				select {


### PR DESCRIPTION
### to reproduce:

1. start fzf with sleep 12345

```bash
fzf --bind 'start:reload:true' --preview 'sleep 12345'
```

2. kill fzf with SIGHUP

```bash
kill -SIGHUP $(pgrep -x fzf)
```

3. check for the sleep command still running

```bash
ps -o pid,ppid,pcpu,state,command -p $(pgrep -x sleep)
```

### additional notes

Occurs most often for me when closing a window in Apple’s default Terminal while fzf is still running

<img width="400" alt="sig" src="https://github.com/user-attachments/assets/4d5cd0ac-972b-4e52-abdf-5c136b97f451" />

**EDIT1**: add image
