### PR TITLE
Fix bug in advanced guide for using fzf as a ripgrep launcher

### DIFF
--- a/ADVANCED.md
+++ b/ADVANCED.md
@@ -363,7 +363,7 @@ projects, and it will free up memory as you narrow down the results.
 RG_PREFIX="rg --column --line-number --no-heading --color=always --smart-case "
 INITIAL_QUERY="${*:-}"
 fzf --ansi --disabled --query "$INITIAL_QUERY" \
-    --bind "start:reload:$RG_PREFIX {q}" \
+    --bind "start:reload:$RG_PREFIX {q} || true" \
     --bind "change:reload:sleep 0.1; $RG_PREFIX {q} || true" \
     --delimiter : \
     --preview 'bat --color=always {1} --highlight-line {2}' \


### PR DESCRIPTION
With the previous version if you passed in an initial search term that resulted in 0 results you would get rg error output in the prompt. It looks like down the change path the `|| true` clause was added but it also needs to be on the initial query.