### PR TITLE
Make symlinks to directories to return as directories, not files (#4675)

### DIFF
--- a/src/reader.go
+++ b/src/reader.go
@@ -303,8 +303,12 @@ func (r *Reader) readFiles(roots []string, opts walkerOpts, ignores []string) bo
 		}
 		path = trimPath(path)
 		if path != "." {
-			isDir := de.IsDir()
-			if isDir || opts.follow && isSymlinkToDir(path, de) {
+			isDirSymlink := isSymlinkToDir(path, de)
+			if isDirSymlink && !opts.follow {
+				return filepath.SkipDir
+			}
+			isDir := de.IsDir() || isDirSymlink
+			if isDir {
 				base := filepath.Base(path)
 				if !opts.hidden && base[0] == '.' && base != ".." {
 					return filepath.SkipDir


### PR DESCRIPTION
Fixes #4675

Changes the way directories and symbolic links are detected so that symlinks to directories are handled identically to directories when opts.follow is enabled.