### PR TITLE
Support --nth independent of --with-nth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ CHANGELOG
     - bash: CTRL-R now supports multi-select and `shift-delete` to delete history entries (#4715)
     - fish: Improved command history (CTRL-R) (#4703) (@bitraid)
 - `GET /` HTTP endpoint now includes `positions` field in each match entry, providing the indices of matched characters for external highlighting (#4726)
+- `--nth` now always matches against the original input line, even when
+  `--with-nth` is set. Previously `--nth` operated on the `--with-nth`
+  transformed text, coupling display and search. They are now independent:
+  `--with-nth` controls display, `--nth` controls search scope.
 - Bug fixes
     - `--walker=follow` no longer follows symlinks whose target is an ancestor of the walker root, avoiding severe resource exhaustion when a symlink points outside the tree (e.g. Wine's `z:` → `/`) (#4710)
     - Fixed AWK tokenizer not treating a new line character as whitespace

--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -113,11 +113,12 @@ Fuzzy matching algorithm (default: v2)
 .TP
 .BI "\-n, \-\-nth=" "N[,..]"
 Comma-separated list of field index expressions for limiting search scope.
-See \fBFIELD INDEX EXPRESSION\fR for the details. When you use this option with
-\fB\-\-with\-nth\fR, the field index expressions are calculated against the
-transformed lines (unlike in \fB\-\-preview\fR where fields are extracted from
-the original lines) because fzf doesn't allow searching against the hidden
-fields.
+See \fBFIELD INDEX EXPRESSION\fR for the details. The field index expressions
+are always calculated against the original input lines, even when
+\fB\-\-with\-nth\fR is used. This means \fB\-\-nth\fR and
+\fB\-\-with\-nth\fR operate independently: \fB\-\-with\-nth\fR controls the
+display, while \fB\-\-nth\fR controls which fields of the original input are
+searched.
 .TP
 .BI "\-\-with\-nth=" "N[,..] or TEMPLATE"
 Transform the presentation of each line using the field index expressions.

--- a/src/core.go
+++ b/src/core.go
@@ -249,7 +249,7 @@ func Run(opts *Options) (int, error) {
 		denyMutex.Unlock()
 		return BuildPattern(cache, patternCache,
 			opts.Fuzzy, opts.FuzzyAlgo, opts.Extended, opts.Case, opts.Normalize, forward, withPos,
-			opts.Filter == nil, nth, opts.Delimiter, inputRevision, runes, denylistCopy, headerLines)
+			opts.Filter == nil, nth, opts.Delimiter, inputRevision, runes, denylistCopy, headerLines, opts.Ansi)
 	}
 	matcher := NewMatcher(cache, patternBuilder, sort, opts.Tac, eventBox, inputRevision, opts.Threads)
 

--- a/src/pattern.go
+++ b/src/pattern.go
@@ -53,6 +53,7 @@ type Pattern struct {
 	normalize     bool
 	forward       bool
 	withPos       bool
+	ansi          bool
 	text          []rune
 	termSets      []termSet
 	sortable      bool
@@ -77,7 +78,7 @@ func init() {
 
 // BuildPattern builds Pattern object from the given arguments
 func BuildPattern(cache *ChunkCache, patternCache map[string]*Pattern, fuzzy bool, fuzzyAlgo algo.Algo, extended bool, caseMode Case, normalize bool, forward bool,
-	withPos bool, cacheable bool, nth []Range, delimiter Delimiter, revision revision, runes []rune, denylist map[int32]struct{}, startIndex int32) *Pattern {
+	withPos bool, cacheable bool, nth []Range, delimiter Delimiter, revision revision, runes []rune, denylist map[int32]struct{}, startIndex int32, ansi bool) *Pattern {
 
 	var asString string
 	if extended {
@@ -140,6 +141,7 @@ func BuildPattern(cache *ChunkCache, patternCache map[string]*Pattern, fuzzy boo
 		normalize:     normalize,
 		forward:       forward,
 		withPos:       withPos,
+		ansi:          ansi,
 		text:          []rune(asString),
 		termSets:      termSets,
 		sortable:      sortable,
@@ -471,7 +473,7 @@ func (p *Pattern) transformInput(item *Item) []Token {
 		}
 	}
 
-	tokens := Tokenize(item.AsString(true), p.delimiter)
+	tokens := Tokenize(item.AsString(p.ansi), p.delimiter)
 	ret := Transform(tokens, p.nth)
 	// Strip the last delimiter to allow suffix match
 	if len(ret) > 0 && !p.delimiter.IsAwk() {

--- a/src/pattern_test.go
+++ b/src/pattern_test.go
@@ -69,7 +69,7 @@ func buildPattern(fuzzy bool, fuzzyAlgo algo.Algo, extended bool, caseMode Case,
 	withPos bool, cacheable bool, nth []Range, delimiter Delimiter, runes []rune) *Pattern {
 	return BuildPattern(NewChunkCache(), make(map[string]*Pattern),
 		fuzzy, fuzzyAlgo, extended, caseMode, normalize, forward,
-		withPos, cacheable, nth, delimiter, revision{}, runes, nil, 0)
+		withPos, cacheable, nth, delimiter, revision{}, runes, nil, 0, false)
 }
 
 func TestExact(t *testing.T) {
@@ -161,24 +161,94 @@ func TestOrigTextAndTransformed(t *testing.T) {
 func TestTransformInputWithOrigText(t *testing.T) {
 	delim := Delimiter{str: &[]string{":"}[0]}
 	nth := []Range{{1, 1}}
-	origBytes := []byte("col1:col2")
 
-	test := func(query string, expectedMatches int) {
-		pat := buildPattern(true, algo.FuzzyMatchV2, true, CaseSmart, false, true, false, true,
-			nth, delim, []rune(query))
-		chunk := Chunk{count: 1}
-		chunk.items[0] = Item{
+	pat := BuildPattern(NewChunkCache(), make(map[string]*Pattern),
+		true, algo.FuzzyMatchV2, true, CaseSmart, false, true,
+		false, true, nth, delim, revision{}, []rune("col1"), nil, 0, false)
+
+	makeItem := func(origText string) Item {
+		origBytes := []byte(origText)
+		return Item{
 			text:     util.ToChars([]byte("col2")),
 			origText: &origBytes,
 		}
-		matches, _ := pat.matchChunk(&chunk, nil, slab)
-		if len(matches) != expectedMatches {
-			t.Errorf("query=%q: expected %d matches, got %d", query, expectedMatches, len(matches))
+	}
+
+	// Verify that transformInput tokenizes origText, not the with-nth display text.
+	// nth={1} with delimiter ":" should extract the first field from origText.
+	item := makeItem("col1:col2")
+	tokens := pat.transformInput(&item)
+	if len(tokens) != 1 || tokens[0].text.ToString() != "col1" {
+		t.Errorf("expected token 'col1', got %v", tokens)
+	}
+
+	cases := []struct {
+		name     string
+		origText string
+		ansi     bool
+		query    string
+		matches  int
+	}{
+		// --nth matches against origText, not the with-nth transformed text
+		{"match first field", "col1:col2", false, "col1", 1},
+		{"no match second field", "col1:col2", false, "col2", 0},
+
+		// With --ansi, ANSI codes are stripped before nth tokenization
+		{"ansi stripped match", "\x1b[33mcol1\x1b[m:col2", true, "col1", 1},
+		{"ansi stripped no second field", "\x1b[33mcol1\x1b[m:col2", true, "col2", 0},
+
+		// Without --ansi, escape codes are literal text in the field
+		{"ansi literal match", "\x1b[33mcol1\x1b[m:col2", false, "col1", 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := BuildPattern(NewChunkCache(), make(map[string]*Pattern),
+				true, algo.FuzzyMatchV2, true, CaseSmart, false, true,
+				false, true, nth, delim, revision{}, []rune(tc.query), nil, 0, tc.ansi)
+			chunk := Chunk{count: 1}
+			chunk.items[0] = makeItem(tc.origText)
+			matches, _ := p.matchChunk(&chunk, nil, slab)
+			if len(matches) != tc.matches {
+				t.Errorf("expected %d matches, got %d", tc.matches, len(matches))
+			}
+		})
+	}
+}
+
+func TestTransformInputAfterWithNthChange(t *testing.T) {
+	delim := Delimiter{str: &[]string{":"}[0]}
+	nth := []Range{{1, 1}}
+
+	makeItem := func(origText string) Item {
+		origBytes := []byte(origText)
+		return Item{
+			text:     util.ToChars([]byte("col2")),
+			origText: &origBytes,
 		}
 	}
 
-	test("col1", 1)
-	test("col2", 0)
+	// First match caches transformed tokens
+	pat := BuildPattern(NewChunkCache(), make(map[string]*Pattern),
+		true, algo.FuzzyMatchV2, true, CaseSmart, false, true,
+		false, true, nth, delim, revision{}, []rune("col1"), nil, 0, false)
+	item := makeItem("col1:col2")
+	tokens := pat.transformInput(&item)
+	if len(tokens) != 1 || tokens[0].text.ToString() != "col1" {
+		t.Errorf("expected token 'col1', got %v", tokens)
+	}
+
+	// Simulate change-with-nth: display text changes, cached tokens cleared.
+	item.text = util.ToChars([]byte("col2:col1"))
+	item.transformed = nil
+
+	// Re-match should still tokenize origText, not the new display text.
+	pat2 := BuildPattern(NewChunkCache(), make(map[string]*Pattern),
+		true, algo.FuzzyMatchV2, true, CaseSmart, false, true,
+		false, true, nth, delim, revision{}, []rune("col1"), nil, 0, false)
+	tokens = pat2.transformInput(&item)
+	if len(tokens) != 1 || tokens[0].text.ToString() != "col1" {
+		t.Errorf("after with-nth change, expected token 'col1', got %v", tokens)
+	}
 }
 
 func TestCacheKey(t *testing.T) {
@@ -252,7 +322,7 @@ func buildChunks(numChunks int) []*Chunk {
 func buildPatternWith(cache *ChunkCache, runes []rune) *Pattern {
 	return BuildPattern(cache, make(map[string]*Pattern),
 		true, algo.FuzzyMatchV2, true, CaseSmart, false, true,
-		false, true, []Range{}, Delimiter{}, revision{}, runes, nil, 0)
+		false, true, []Range{}, Delimiter{}, revision{}, runes, nil, 0, false)
 }
 
 func TestBitmapCacheBenefit(t *testing.T) {

--- a/test/test_core.rb
+++ b/test/test_core.rb
@@ -248,7 +248,9 @@ class TestCore < TestInteractive
         tmux.send_keys :Enter
         assert_equal ['  1st 2nd 3rd/', '  first second third/'], fzf_output_lines
       else
-        tmux.send_keys '^', '3'
+        # --nth 2 matches against the original input ("1st 2nd 3rd/"),
+        # so "^2" matches the 2nd field "2nd" — not the with-nth display.
+        tmux.send_keys '^', '2'
         tmux.until { |lines| assert_equal '  1/2', lines[-2] }
         tmux.send_keys :Enter
         assert_equal ['  1st 2nd 3rd/'], fzf_output_lines

--- a/test/test_filter.rb
+++ b/test/test_filter.rb
@@ -62,21 +62,21 @@ class TestFilter < TestBase
     writelines(['hello world ', 'byebye'])
     assert_equal \
       'hello world ',
-      `#{FZF} -f"^he hehe" -x -n 2.. --with-nth 2,1,1 < #{tempname}`.chomp
+      `#{FZF} -f"^wo" -x -n 2.. --with-nth 2,1,1 < #{tempname}`.chomp
   end
 
   def test_with_nth_template
     writelines(['hello world ', 'byebye'])
     assert_equal \
       'hello world ',
-      `#{FZF} -f"^he he.he." -x -n 2.. --with-nth '{2} {1}. {1}.' < #{tempname}`.chomp
+      `#{FZF} -f"^wo" -x -n 2.. --with-nth '{2} {1}. {1}.' < #{tempname}`.chomp
   end
 
   def test_with_nth_ansi
     writelines(["\x1b[33mhello \x1b[34;1mworld\x1b[m ", 'byebye'])
     assert_equal \
       'hello world ',
-      `#{FZF} -f"^he hehe" -x -n 2.. --with-nth 2,1,1 --ansi < #{tempname}`.chomp
+      `#{FZF} -f"^wo" -x -n 2.. --with-nth 2,1,1 --ansi < #{tempname}`.chomp
   end
 
   def test_with_nth_no_ansi
@@ -84,7 +84,7 @@ class TestFilter < TestBase
     writelines([src, 'byebye'])
     assert_equal \
       src,
-      `#{FZF} -fhehe -x -n 2.. --with-nth 2,1,1 --no-ansi < #{tempname}`.chomp
+      `#{FZF} -fworld -x -n 2.. --with-nth 2,1,1 --no-ansi < #{tempname}`.chomp
   end
 
   def test_escaped_meta_characters


### PR DESCRIPTION
Currently, `--nth` only works if the displayed text contains the expected field, and uses the same delimiter.

Use the original text with `--nth` so it works independently of `--with-nth`.

Fixes #4257