### PR TITLE
Proposal: Add `--track-nth` option for field-based tracking across reloads

### DIFF
--- a/shell/completion.bash
+++ b/shell/completion.bash
@@ -211,6 +211,7 @@ _fzf_opts_completion() {
     --tiebreak
     --tmux
     --track
+    --track-nth
     --version
     --walker
     --walker-root

--- a/src/options.go
+++ b/src/options.go
@@ -101,6 +101,8 @@ Usage: fzf [options]
     --no-multi-line          Disable multi-line display of items when using --read0
     --raw                    Enable raw mode (show non-matching items)
     --track                  Track the current selection when the result is updated
+    --track-nth=N[,..]       Track the current selection by the value of specific fields
+                             when the result is updated
     --tac                    Reverse the order of the input
     --gap[=N]                Render empty lines between each item
     --gap-line[=STR]         Draw horizontal line on each gap using the string
@@ -594,6 +596,7 @@ type Options struct {
 	Sort              int
 	Raw               bool
 	Track             trackOption
+	TrackNth          []Range
 	Tac               bool
 	Tail              int
 	Criteria          []criterion
@@ -2811,6 +2814,15 @@ func parseOptions(index *int, opts *Options, allArgs []string) error {
 			opts.Track = trackEnabled
 		case "--no-track":
 			opts.Track = trackDisabled
+		case "--track-nth":
+			str, err := nextString("nth expression required")
+			if err != nil {
+				return err
+			}
+			if opts.TrackNth, err = splitNth(str); err != nil {
+				return err
+			}
+			opts.Track = trackEnabled
 		case "--tac":
 			opts.Tac = true
 		case "--no-tac":

--- a/src/terminal.go
+++ b/src/terminal.go
@@ -314,6 +314,8 @@ type Terminal struct {
 	sort                 bool
 	toggleSort           bool
 	track                trackOption
+	trackNth             []Range
+	trackNthValue        string
 	targetIndex          int32
 	delimiter            Delimiter
 	expect               map[tui.Event]string
@@ -1043,6 +1045,7 @@ func NewTerminal(opts *Options, eventBox *util.EventBox, executor *util.Executor
 		sort:               opts.Sort > 0,
 		toggleSort:         opts.ToggleSort,
 		track:              opts.Track,
+		trackNth:           opts.TrackNth,
 		targetIndex:        minItem.Index(),
 		delimiter:          opts.Delimiter,
 		expect:             opts.Expect,
@@ -1825,8 +1828,19 @@ func (t *Terminal) UpdateList(result MatchResult) {
 	merger := result.merger
 	t.mutex.Lock()
 	prevIndex := minItem.Index()
+	prevNthValue := ""
+	useNthTracking := len(t.trackNth) > 0 && t.track != trackDisabled
 	newRevision := merger.Revision()
-	if t.revision.compatible(newRevision) && t.track != trackDisabled {
+
+	if useNthTracking {
+		if t.track.Current() && t.trackNthValue != "" {
+			prevNthValue = t.trackNthValue
+		} else if t.merger.Length() > 0 {
+			if item := t.currentItem(); item != nil {
+				prevNthValue = t.extractTrackNthValue(item)
+			}
+		}
+	} else if t.revision.compatible(newRevision) && t.track != trackDisabled {
 		if t.merger.Length() > 0 {
 			prevIndex = t.currentIndex()
 		} else if merger.Length() > 0 {
@@ -1893,7 +1907,30 @@ func (t *Terminal) UpdateList(result MatchResult) {
 		t.triggerLoad = false
 		t.eventChan <- tui.Load.AsEvent()
 	}
-	if prevIndex >= 0 {
+	if useNthTracking && prevNthValue != "" {
+		pos := t.cy - t.offset
+		count := t.merger.Length()
+		found := false
+		for i := 0; i < count; i++ {
+			item := t.merger.Get(i).item
+			if t.extractTrackNthValue(item) == prevNthValue {
+				t.cy = i
+				t.offset = t.cy - pos
+				found = true
+				break
+			}
+		}
+		if !found {
+			if t.track.Current() {
+				t.track = trackDisabled
+				t.trackNth = nil
+				t.cy = pos
+				t.offset = 0
+			} else if t.cy > count {
+				t.cy = count - min(count, t.maxItems()) + pos
+			}
+		}
+	} else if prevIndex >= 0 {
 		pos := t.cy - t.offset
 		count := t.merger.Length()
 		i := t.merger.FindIndex(prevIndex)
@@ -5355,6 +5392,13 @@ func (t *Terminal) currentIndex() int32 {
 	return minItem.Index()
 }
 
+func (t *Terminal) extractTrackNthValue(item *Item) string {
+	text := item.AsString(t.ansi)
+	tokens := Tokenize(text, t.delimiter)
+	transformed := Transform(tokens, t.trackNth)
+	return JoinTokens(transformed)
+}
+
 func (t *Terminal) addClickHeaderWord(env []string) []string {
 	/*
 	 * echo $'HL1\nHL2' | fzf --header-lines 3 --header $'H1\nH2' --header-lines-border --bind 'click-header:preview:env | grep FZF_CLICK'
@@ -5814,7 +5858,7 @@ func (t *Terminal) Loop() error {
 					case reqList:
 						t.printList()
 						currentIndex := t.currentIndex()
-						if t.track.Current() && t.track.index != currentIndex {
+						if t.track.Current() && len(t.trackNth) == 0 && t.track.index != currentIndex {
 							t.track = trackDisabled
 							info = true
 						}
@@ -6951,8 +6995,14 @@ func (t *Terminal) Loop() error {
 			case actToggleTrackCurrent:
 				if t.track.Current() {
 					t.track = trackDisabled
+					t.trackNthValue = ""
 				} else if t.track.Disabled() {
 					t.track = trackCurrent(t.currentIndex())
+					if len(t.trackNth) > 0 {
+						if item := t.currentItem(); item != nil {
+							t.trackNthValue = t.extractTrackNthValue(item)
+						}
+					}
 				}
 				req(reqInfo)
 			case actShowHeader:
@@ -7011,11 +7061,17 @@ func (t *Terminal) Loop() error {
 				// Global tracking has higher priority
 				if !t.track.Global() {
 					t.track = trackCurrent(t.currentIndex())
+					if len(t.trackNth) > 0 {
+						if item := t.currentItem(); item != nil {
+							t.trackNthValue = t.extractTrackNthValue(item)
+						}
+					}
 				}
 				req(reqInfo)
 			case actUntrackCurrent:
 				if t.track.Current() {
 					t.track = trackDisabled
+					t.trackNthValue = ""
 				}
 				req(reqInfo)
 			case actSearch:


### PR DESCRIPTION
## What

- Add a new option `--track-nth` option for the nth field-based tracking across reloads

## Why

I'm often using fzf with `--track` and `reload` to filtering dynamic contents. While it's useful, it sometimes leads me to an undesired entry when I use fzf for some kind of dynamic contents since its tracking is based on the index. For example, if I use fzf for filtering Kubernetes Pods (`kubectl get pods`) with the preview for the pod spec, I would like to make fzf track the entry based on the name of Pod via its nth field value, not the index. 