### PR TITLE
fish: Fixes and improvements to CTRL-R

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,13 +506,17 @@ the following key bindings in bash, zsh, and fish.
       ```
     - Can be disabled by setting `FZF_CTRL_T_COMMAND` to an empty string when
       sourcing the script
-- `CTRL-R` - Paste the selected command from history onto the command-line
+- `CTRL-R` - Paste the selected command from history onto the command-line. With fish shell, it is possible to select multiple commands.
     - If you want to see the commands in chronological order, press `CTRL-R`
       again which toggles sorting by relevance
     - Press `ALT-R` to toggle "raw" mode where you can see the surrounding items
       of a match. In this mode, you can press `CTRL-N` and `CTRL-P` to move
       between the matching items only.
     - Press `CTRL-/` or `ALT-/` to toggle line wrapping
+    - Fish shell only:
+      - Press `SHIFT-DELETE` to delete the selected commands
+      - Press `ALT-ENTER` to reformat and insert the selected commands
+      - Press `ALT-T` to cycle through command prefix (timestamp, date/time, none)
     - Set `FZF_CTRL_R_OPTS` to pass additional options to fzf
       ```sh
       # CTRL-Y to copy the command into clipboard using pbcopy
@@ -520,6 +524,13 @@ the following key bindings in bash, zsh, and fish.
         --bind 'ctrl-y:execute-silent(echo -n {2..} | pbcopy)+abort'
         --color header:italic
         --header 'Press CTRL-Y to copy command into clipboard'"
+      ```
+      ```fish
+      # Fish shell: Set date/time as default prefix
+      set -gx FZF_CTRL_R_OPTS "--with-nth 1,3.. --bind 'alt-t:change-with-nth(2..|3..|1,3..)'"
+
+      # Or display no prefix by default
+      set -gx FZF_CTRL_R_OPTS "--with-nth 3.. --bind 'alt-t:change-with-nth(2..|1,3..|3..)'"
       ```
     - Can be disabled by setting `FZF_CTRL_R_COMMAND` to an empty string when
       sourcing the script

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -183,36 +183,26 @@ function fzf_key_bindings
     set -l -- fzf_query (string escape -- $command_line[$current_line])
 
     set -lx -- FZF_DEFAULT_OPTS (__fzf_defaults '' \
-      '--nth=2..,.. --scheme=history --multi --no-multi-line --no-wrap --wrap-sign="\t\t\t↳ " --preview-wrap-sign="↳ "' \
-      '--bind=\'shift-delete:execute-silent(for i in (string split0 -- <{+f}); eval builtin history delete --exact --case-sensitive -- (string escape -n -- $i | string replace -r "^\d*\\\\\\t" ""); end)+reload(eval $FZF_DEFAULT_COMMAND)\'' \
-      '--bind="alt-enter:become(string join0 -- (string collect -- {+2..} | fish_indent -i))"' \
+      '--with-nth=2.. --nth=2..,.. --scheme=history --multi --no-multi-line' \
+      '--no-wrap --wrap-sign="\t\t\t↳ " --preview-wrap-sign="↳ " --freeze-left=1' \
+      '--bind="alt-enter:become(set -g fzf_temp {+sf3..}; string join0 -- (string split0 -- <$fzf_temp | fish_indent -i); unlink $fzf_temp &>/dev/null)"' \
+      '--bind="alt-t:change-with-nth(1,3..|3..|2..)"' \
+      '--bind="shift-delete:execute-silent(eval builtin history delete -Ce -- (string escape -n -- (string split0 -- <{+sf3..})))+reload(eval $FZF_DEFAULT_COMMAND)"' \
       "--bind=ctrl-r:toggle-sort,alt-r:toggle-raw --highlight-line $FZF_CTRL_R_OPTS" \
-      '--accept-nth=2.. --delimiter="\t" --tabstop=4 --read0 --print0 --with-shell='(status fish-path)\\ -c)
+      '--accept-nth=3.. --delimiter="\t" --tabstop=4 --read0 --print0 --with-shell='(status fish-path)\\ -c)
 
     # Add dynamic preview options if preview command isn't already set by user
     if string match -qvr -- '--preview[= ]' "$FZF_DEFAULT_OPTS"
-      # Convert the highlighted timestamp using the date command if available
-      set -l -- date_cmd '{1}'
-      if type -q date
-        if date -d @0 '+%s' 2>/dev/null | string match -q 0
-          # GNU date
-          set -- date_cmd '(date -d @{1} \\"+%F %a %T\\")'
-        else if date -r 0 '+%s' 2>/dev/null | string match -q 0
-          # BSD date
-          set -- date_cmd '(date -r {1} \\"+%F %a %T\\")'
-        end
-      end
-
-      # Prepend the options to allow user customizations
+      # Prepend the options to allow user overrides
       set -p -- FZF_DEFAULT_OPTS \
-        '--bind="focus,resize:bg-transform:if test \\"$FZF_COLUMNS\\" -gt 100 -a \\\\( \\"$FZF_SELECT_COUNT\\" -gt 0 -o \\\\( -z \\"$FZF_WRAP\\" -a (string length -- {}) -gt (math $FZF_COLUMNS - 4) \\\\) -o (string collect -- {2..} | fish_indent | count) -gt 1 \\\\); echo show-preview; else echo hide-preview; end"' \
-        '--preview="string collect -- (test \\"$FZF_SELECT_COUNT\\" -gt 0; and string collect -- {+2..}) \\"\\n# \\"'$date_cmd' {2..} | fish_indent --ansi"' \
+        '--bind="focus,multi,resize:bg-transform:if test \\"$FZF_COLUMNS\\" -gt 100 -a \\\\( \\"$FZF_SELECT_COUNT\\" -gt 0 -o \\\\( -z \\"$FZF_WRAP\\" -a (string join0 -- <{f3..} | string length) -gt (math $FZF_COLUMNS - (switch $FZF_WITH_NTH; case 2..; echo 13; case 1,3..; echo 25; case 3..; echo 1; end)) \\\\) -o (string split0 -- <{sf3..} | fish_indent | count) -gt 1 \\\\); echo show-preview; else echo hide-preview; end"' \
+        '--preview="test \\"$FZF_SELECT_COUNT\\" -gt 0; and string split0 -- <{+sf3..} | fish_indent --only-indent --ansi; and echo -n \\\\n; string collect -- \\\\#\\\\ {1} (string split0 -- <{sf3..}) | fish_indent --ansi"' \
         '--preview-window="right,50%,wrap-word,follow,info,hidden"'
     end
 
     set -lx FZF_DEFAULT_OPTS_FILE
 
-    set -lx -- FZF_DEFAULT_COMMAND 'builtin history -z --show-time="%s%t"'
+    set -lx -- FZF_DEFAULT_COMMAND 'builtin history -z'
 
     # Enable syntax highlighting colors on fish v4.3.3 and newer
     if set -l -- v (string match -r -- '^(\d+)\.(\d+)(?:\.(\d+))?' $version)
@@ -221,7 +211,9 @@ function fzf_key_bindings
       \( -n "$v[4]" -a "$v[4]" -ge 3 \) \)
 
       set -a -- FZF_DEFAULT_OPTS '--ansi'
-      set -a -- FZF_DEFAULT_COMMAND '--color=always'
+      set -a -- FZF_DEFAULT_COMMAND '--color=always --show-time=(set_color $fish_color_comment)"%F %a %T%t%s%t"(set_color $fish_color_normal)'
+    else
+      set -a -- FZF_DEFAULT_COMMAND '--show-time="%F %a %T%t%s%t"'
     end
 
     # Merge history from other sessions before searching


### PR DESCRIPTION
A few more changes to command history:

- `SHIFT-DELETE`:
  - Improve performance by only calling `history delete` once and passing the selected items via command substitution.
- Preview window:
  - Handle very long lists of selected commands (using temporary files instead of command arguments).
  - Reformat only the highlighted command. Selected commands are only indented and colorized, so that they match how they are inserted by pressing `ENTER` (instead of `ALT-ENTER`).
  - Include trailing whitespace characters, so commands that end with `\␊` don't lose the trailing newline and cause a following selected command to be shown as a continuation of the previous one.
  - Also bind the check of whether to display the preview to `multi`, so it will be triggered when selecting the very last command (which is not triggered by `focus`).
- Prefix of commands list:
  - Enable changing the timestamp to date/time, or disabling it completely, by pressing `ALT-T` (uses the new `change-with-nth` option).
  - Remove the dependence of the external `date` command for conversion.
  - Set the color to `$fish_color_comment`, so it is easier distinguished from the actual command.
- Command insertion:
  - Fix an issue with commands that end with `\␊`: `accept-nth` strips the trailing newline, but it is important to keep it when inserting multiple commands. Consider the following example: The commands `rm -rf ~/trash \␊` (1) and `ls ~/` (2) are selected for insertion. What will be inserted instead, is a single `rm -rf` command with a line break after `~/trash` and the last token being `/~` (will wipe the home directory!). For that reason, a `become` action is bind to `ENTER`, that reads the selected commands from a temporary file (for not hitting the single argument length limit) created with the `s` flag, and then having to manually delete the file (since it's not possible for fzf to remove the file). This is unnecessary for most cases though, and it would be much better if `accept-nth` (and maybe also `with-nth`) had a flag to keep trailing whitespace characters. Let me know what you think.
- Update README:
  - Inform about the ability to select multiple commands.
  - Document the key bindings which are unique to fish shell.
  - Add examples of how to change the default prefix through `$FZF_CTRL_R_OPTS`.

---

While working on this, I noticed a couple of issues that I think are worth mentioning:
- The `become` command may fail to execute and won't return to the shell prompt: Because the command is passed to the shell as a single argument, it is possible to exceed the 128K limit of `MAX_ARG_STRLEN`. This is not so serious for `preview` or `transform` (will return `argument list too long` error), but for `become` the shell will be left in a broken state. This doesn't affect the script, but maybe fzf should not attempt to execute the command if its final total length is longer than `128 * 1024 - 1` characters.
- Scrolling in preview window with enabled wrap/wrap-word, does not happen line by line for wrapped lines. This means that it's not possible to scroll a long line that doesn't completely fit:

```fish
echo (string repeat -n 400 'test ') eol | fzf --preview="echo {}" --preview-window=wrap-word --height=8
```

```
                                                ╭─────────────────────────────────────────────╮
                                                │ test test test test test test test test     │
                                                │ ↳ test test test test test test test test   │
                                                │ ↳ test test test test test test test test   │
                                                │ ↳ test test test test test test test test   │
▌ test test test test test test test test tes·· │ ↳ test test test test test test test test   │
  1/1 ───────────────────────────────────────── │ ↳ test test test test test test test test   │
>                                               ╰─────────────────────────────────────────────╯

```

If `follow` is also set, it scrolls too far down and no part of the line is visible (notice the info shows `2/1`).

```fish
echo (string repeat -n 400 'test ') eol | fzf --preview="echo {}" --preview-window=wrap-word,follow --height=8
```

```
                                                ╭─────────────────────────────────────────────╮
                                                │                                         2/1 │
                                                │                                             │
                                                │                                             │
                                                │                                             │
▌ test test test test test test test test tes·· │                                             │
  1/1 ───────────────────────────────────────── │                                             │
>                                               ╰─────────────────────────────────────────────╯
```
Scrolling up, will scroll to the beginning of the line, and the ability to scroll again is lost (it's not possible to view the end of the line).
