### PR TITLE
Add "unix" and "fattr" promises

### DIFF
--- a/src/protector/protector_openbsd.go
+++ b/src/protector/protector_openbsd.go
@@ -6,5 +6,5 @@ import "golang.org/x/sys/unix"
 
 // Protect calls OS specific protections like pledge on OpenBSD
 func Protect() {
-	unix.PledgePromises("stdio cpath dpath wpath rpath tty proc exec inet")
+	unix.PledgePromises("stdio cpath dpath wpath rpath inet fattr unix tty proc exec")
 }


### PR DESCRIPTION
Without this fzf --listen=/tmp/foo.sock fails on OpenBSD:

```
fzf[66741]: pledge "unix", syscall 97
zsh: abort (core dumped)  fzf --listen=/tmp/fzf.sock
```

Further adjust the way pledges are used, so if --listen isn't specified it doesn't ask for either inet or unix.