### PR TITLE
docs: fix README wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ On Windows, fzf is available via [Chocolatey][choco], [Scoop][scoop],
 
 ### Using git
 
-Alternatively, you can "git clone" this repository to any directory and run
+Alternatively, you can "git clone" this repository to any directory and run the
 [install](https://github.com/junegunn/fzf/blob/master/install) script.
 
 ```sh


### PR DESCRIPTION
## Summary
- Add a missing article in the install script sentence.

## Related issue
- N/A (doc wording fix)

## Guideline alignment
- https://github.com/junegunn/fzf/blob/master/README.md

## Validation/testing
- Not run (docs change only)