### PR TITLE
Terminate child processes on Windows (fix #3134)

### DIFF
--- a/src/util/util_windows.go
+++ b/src/util/util_windows.go
@@ -178,9 +178,7 @@ func (x *Executor) QuoteEntry(entry string) string {
 		   fd -H --no-ignore -td -d 4 | fzf --preview ".\eza.exe --color=always --tree --level=3 --icons=always {}" --with-shell "powershell -NoProfile -Command"
 		*/
 		return escapeArg(entry)
-	case shellTypePwsh:
-		fallthrough
-	case shellTypePowerShell:
+	case shellTypePowerShell, shellTypePwsh:
 		escaped := strings.ReplaceAll(entry, `"`, `\"`)
 		return "'" + strings.ReplaceAll(escaped, "'", "''") + "'"
 	default:


### PR DESCRIPTION
Windows doesn't have signals, the default Kill doesn't actually kill anything, and other forms of termination don't allow cleanup.  So we spawn processes as their own process groups and then send them a `CTRL_BREAK_EVENT` to terminate.  (If they weren't in a separate group, the Ctrl-Break would trigger a SIGINT-equivalent to the fzf process, i.e. fzf would also terminate itself!)

This won't forcibly terminate misbehaving processes, but it improves the current circumstances for well-behaved (but long-running) preview processes (such as `docker logs` run against a remote server with huge logs).