### PR TITLE
Include man pages in release archives

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,7 +94,8 @@ archives:
         formats:
           - zip
     files:
-      - non-existent*
+      - man/man1/fzf.1
+      - man/man1/fzf-tmux.1
 
 release:
   github:


### PR DESCRIPTION
## Summary

- Replace `non-existent*` glob in `.goreleaser.yml` `archives.files` with explicit paths to `man/man1/fzf.1` and `man/man1/fzf-tmux.1`
- Release tarballs (tar.gz) and zip archives will now include the man pages alongside the fzf binary
- No changes to the binary, build process, or install scripts

## Motivation

Closes #4229. The man pages are already maintained in the repository but were excluded from release archives by the goreleaser config. Including them makes it easier for package maintainers and users who download release assets directly to install the documentation.

## Test plan

- [ ] Verify with `goreleaser build --clean --snapshot` that archives contain man pages
- [ ] Confirm existing binary packaging is unchanged

This contribution was developed with AI assistance (Claude Code).