### PR TITLE
fix: avoid heap allocation of server variable in startHttpServer

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -122,13 +122,12 @@ func startHttpServer(address listenAddress, actionChannel chan []*action, getHan
 		}
 	}
 
-	server := httpServer{
-		apiKey:        []byte(apiKey),
-		actionChannel: actionChannel,
-		getHandler:    getHandler,
-	}
-
 	go func() {
+		server := httpServer{
+			apiKey:        []byte(apiKey),
+			actionChannel: actionChannel,
+			getHandler:    getHandler,
+		}
 		for {
 			conn, err := listener.Accept()
 			if err != nil {


### PR DESCRIPTION
This PR addresses issue #4735 by moving the `server` variable declaration inside the goroutine in `startHttpServer()`. 

Previously, the `server` variable was allocated on the heap because Go's escape analysis detected that it was captured by a goroutine. By moving the declaration inside the goroutine itself, the variable can now be allocated on the stack instead, eliminating an unnecessary dynamic allocation of ~40 bytes.

The fix is minimal - just moving the struct declaration from outside to inside the `go func()` block. This doesn't change any behavior, only improves performance slightly by avoiding heap allocation.

---

Fixes #4735