### PR TITLE
enhancement: move server definition into go func to allocate it in stack and reduce heap allocation

### DIFF
--- a/src/server.go
+++ b/src/server.go
@@ -122,13 +122,12 @@ func startHttpServer(address listenAddress, actionChannel chan []*action, getHan
 		}
 	}
 
-	server := httpServer{
-		apiKey:        []byte(apiKey),
-		actionChannel: actionChannel,
-		getHandler:    getHandler,
-	}
-
 	go func() {
+		server := httpServer{
+			apiKey:        []byte(apiKey),
+			actionChannel: actionChannel,
+			getHandler:    getHandler,
+		}
 		for {
 			conn, err := listener.Accept()
 			if err != nil {


### PR DESCRIPTION
## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [X] I confirm that this PR meets the above expectations and reflects my own understanding and real-world context.

---

move `server` definition into `go func` to reduce heap allocation. `actionChannel`, `getHandler` will still be allocated in heap inevitably.

Fixes #4735.
