### PR TITLE
fix: allow combining adaptive (~) with negative (-) height

### DIFF
--- a/man/man1/fzf.1
+++ b/man/man1/fzf.1
@@ -403,8 +403,6 @@ Adaptive height has the following limitations:
 .br
 * Cannot be used with top/bottom margin and padding given in percent size
 .br
-* Negative value is not allowed
-.br
 * It will not find the right size when there are multi-line items
 
 .TP

--- a/src/options.go
+++ b/src/options.go
@@ -2222,9 +2222,6 @@ func parseHeight(str string, index int) (heightSpec, error) {
 		str = str[1:]
 	}
 	if strings.HasPrefix(str, "-") {
-		if heightSpec.auto {
-			return heightSpec, errors.New("negative(-) height is not compatible with adaptive(~) height")
-		}
 		heightSpec.inverse = true
 		str = str[1:]
 	}


### PR DESCRIPTION
Previously, combining --height='~-50%' or --height='~-1' would fail.

This restriction was unnecessary. The ~ prefix enables adaptive height, and the - prefix enables inverse height (terminal height minus N). These features can work together.

Changes:
- Remove error check in parseHeight
- Update man page

Fixes #4682