### PR TITLE
fix: make first/last actions consistent with visual top/bottom

### DIFF
--- a/src/terminal.go
+++ b/src/terminal.go
@@ -6849,12 +6849,24 @@ func (t *Terminal) Loop() error {
 						t.vset(t.merger.FindIndex(t.resultMerger.Get(0).item.Index()))
 					}
 				} else {
-					t.vset(0)
+					// actFirst should always go to visual top
+					// In reverse layouts, visual top is the last index
+					if t.layout == layoutReverse || t.layout == layoutReverseList {
+						t.vset(t.merger.Length() - 1)
+					} else {
+						t.vset(0)
+					}
 				}
 				t.constrain()
 				req(reqList)
 			case actLast:
-				t.vset(t.merger.Length() - 1)
+				// actLast should always go to visual bottom
+				// In reverse layouts, visual bottom is the first index (0)
+				if t.layout == layoutReverse || t.layout == layoutReverseList {
+					t.vset(0)
+				} else {
+					t.vset(t.merger.Length() - 1)
+				}
 				t.constrain()
 				req(reqList)
 			case actPosition:


### PR DESCRIPTION
The first and last actions now always navigate to the visual top and bottom of the list, regardless of the layout setting.

**Problem:**
Previously:
- In default layout: first → index 0 (visual top), last → last index (visual bottom)
- In reverse/reverse-list layout: first → index 0 (visual bottom), last → last index (visual top)

This was inconsistent with up/down actions which always move relative to visual position.

**Solution:**
Now:
- `first` always goes to visual top
- `last` always goes to visual bottom

In reverse layouts, this means:
- `first` navigates to the last index (visual top in reverse)
- `last` navigates to index 0 (visual bottom in reverse)

**Testing:**
- All existing tests pass
- Compiled successfully with `make`

Fixes #4539