### PR TITLE
[shell][zsh] Don't resolve symlinks in ALT-c (#4816)

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -110,8 +110,14 @@ fzf-cd-widget() {
     zle redisplay
     return 0
   fi
+  # Use subshell expansion to get the absolute PWD of the target dir.
+  # This allows the recorded shell history to be reused even from a different
+  # working directory.
+  # If failed, fallback to the unexpanded path to surface the error to the user.
+  # NOTE: Don't use the `:a` modifier as it resolves symlinks like `pwd -P`.
+  dir=$(builtin cd >/dev/null -- "${dir}" && echo "${PWD}" || echo "${dir}")
   zle push-line # Clear buffer. Auto-restored on next prompt.
-  BUFFER="builtin cd -- ${(q)dir:a}"
+  BUFFER="builtin cd -- ${(q)dir}"
   zle accept-line
   local ret=$?
   unset dir # ensure this doesn't end up appearing in prompt expansion


### PR DESCRIPTION
This way ALT-c behaves more aligned with `cd`.

Imagine a setup like:
```
/foo -> foo_real
/foo_real/bar
```

Right now if we first `cd foo` (a symlink to `foo_real`), and then use ALT-c to goto `bar`, then we would end up executing `cd /foo_real/bar` instead of `cd /foo/bar`. `$PWD = /foo_real/bar`.

For comparison, if we first `cd foo` and then `cd bar`, we end up with `$PWD = /foo/bar`.

This commit changes the internal logic of `fzf-cd-widget` to first run `cd <result of FZF_ALT_C_COMMAND>` in a subshell to simulate the behavior of `cd`, and then insert the target PWD into the shell history. This way we get behavior consistent with the builtin `cd` command, while also recording reusable shell history.

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm that this PR meets the above expectations and reflects my own understanding and real-world context.
