### PR TITLE
extra tests for alt-c

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
 FROM rubylang/ruby:3.4.1-noble
-RUN apt-get update -y && apt install -y git make golang zsh fish tmux
+RUN apt-get update && apt-get install -y git make golang zsh fish tmux
+
+# https://www.nushell.sh/book/installation.html
+RUN <<EOF
+    set -ex
+    apt-get install -y wget gnupg
+    wget -qO- https://apt.fury.io/nushell/gpg.key | gpg --dearmor -o /etc/apt/keyrings/fury-nushell.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/fury-nushell.gpg] https://apt.fury.io/nushell/ /" | tee /etc/apt/sources.list.d/fury-nushell.list
+    apt-get update
+    apt-get install -y nushell
+EOF
 RUN gem install --no-document -v 5.22.3 minitest
 RUN echo '. /usr/share/bash-completion/completions/git' >> ~/.bashrc
 RUN echo '. ~/.bashrc' >> ~/.bash_profile

--- a/test/test_shell_integration.rb
+++ b/test/test_shell_integration.rb
@@ -100,6 +100,47 @@ module TestShell
     tmux.until { |lines| assert_equal '/tmp', lines[-1] }
   end
 
+  def test_alt_c_symlink
+    base = '/tmp/fzf-test-alt-c-symlink'
+    FileUtils.rm_rf(base)
+    FileUtils.mkdir_p("#{base}/real/subdir")
+    FileUtils.ln_s("#{base}/real", "#{base}/link")
+
+    tmux.prepare
+    tmux.send_keys "cd #{base}/link", :Enter
+    tmux.prepare
+    tmux.send_keys :Escape, :c
+    tmux.until { |lines| assert_operator lines.match_count, :>, 0 }
+    tmux.send_keys 'subdir'
+    tmux.until { |lines| assert_equal 1, lines.match_count }
+    tmux.send_keys :Enter
+    tmux.prepare
+    tmux.send_keys :pwd, :Enter
+    tmux.until { |lines| assert_equal "#{base}/link/subdir", lines[-1] }
+  ensure
+    FileUtils.rm_rf(base)
+  end
+
+  def test_alt_c_absolute_cmd
+    base = '/tmp/fzf-test-alt-c-absolute'
+    FileUtils.rm_rf(base)
+    FileUtils.mkdir_p(base)
+
+    set_var('FZF_ALT_C_COMMAND', "echo #{base}")
+
+    tmux.prepare
+    tmux.send_keys 'cd /tmp', :Enter
+    tmux.prepare
+    tmux.send_keys :Escape, :c
+    tmux.until { |lines| assert_equal 1, lines.match_count }
+    tmux.send_keys :Enter
+    tmux.prepare
+    tmux.send_keys :pwd, :Enter
+    tmux.until { |lines| assert_equal base, lines[-1] }
+  ensure
+    FileUtils.rm_rf(base)
+  end
+
   def test_ctrl_r
     tmux.prepare
     tmux.send_keys 'echo 1st', :Enter


### PR DESCRIPTION
- **test: install nushell in Dockerfile**
  - setup copied from nushell.sh
    - <https://www.nushell.sh/book/installation.html>
  - Used here-documents for readability (can be inlined when preferred)
    - <https://docs.docker.com/reference/dockerfile/#here-documents>
- **test: ALT-C regression tests**
  - test both issues discussed in #4816

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:

- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm that this PR meets the above expectations and reflects my own understanding and real-world context.
