### PR TITLE
Publish .deb package for each release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -96,6 +96,25 @@ archives:
     files:
       - non-existent*
 
+nfpms:
+  - package_name: fzf
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    vendor: junegunn
+    homepage: https://github.com/junegunn/fzf
+    maintainer: Junegunn Choi <junegunn.c@gmail.com>
+    description: Command-line fuzzy finder
+    license: MIT
+    section: utils
+    formats:
+      - deb
+    ids:
+      - fzf
+    contents:
+      - src: man/man1/fzf.1
+        dst: /usr/share/man/man1/fzf.1
+      - src: LICENSE
+        dst: /usr/share/doc/fzf/copyright
+
 release:
   github:
     owner: junegunn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@ CHANGELOG
 
 0.74.1
 ------
-- Bug fixes and improvements
+- Rendering improvements
     - Each frame is now wrapped in synchronized update mode (mode 2026) to reduce flickering on supported terminals
     - Reduced rendering output by 10-23% by skipping redundant SGR sequences
     - Fixed ghost characters and misplaced colors inside Zellij by using CHA instead of CR + CUF for horizontal cursor movement (#4858, zellij-org/zellij#5370)
     - Fixed cursor restoration on exit with `--height --no-clear` inside Neovim terminal by using DECSC/DECRC instead of `CSI s`/`CSI u`
-    - nushell: fixed deprecation error of `str downcase` on nushell 0.114.0 or above (#4857) (@sim590)
+- nushell: fixed deprecation error of `str downcase` on nushell 0.114.0 or above (#4857) (@sim590)
+- Each release now includes `.deb` packages for easy installation on Debian-based distros (#4859)
 
 0.74.0
 ------


### PR DESCRIPTION
Close #4859

## Test

```sh
goreleaser release --snapshot --clean
```

will generate deb files under `dist/`.

Start a Debian container using Docker and test:

```sh
docker run --rm -it -v "$PWD/dist:/pkg" debian:stable bash
apt install -y /pkg/fzf_*_arm64.deb
fzf --version
  # 0.74.0-devel (b0270fb0)

apt update && apt install -y man-db
man fzf
  # Works
```