### PR TITLE
Detect terminal resize on Windows

### DIFF
--- a/src/terminal_windows.go
+++ b/src/terminal_windows.go
@@ -4,10 +4,48 @@ package fzf
 
 import (
 	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
 )
 
+const resizePollInterval = 100 * time.Millisecond
+
+type resizeSignal struct{}
+
+func (resizeSignal) String() string { return "resize" }
+func (resizeSignal) Signal()        {}
+
+// Windows has no SIGWINCH, so poll the console screen buffer for window
+// size changes instead.
 func notifyOnResize(resizeChan chan<- os.Signal) {
-	// TODO
+	consoleOut, err := syscall.Open("CONOUT$", syscall.O_RDWR, 0)
+	if err != nil {
+		return
+	}
+	var info windows.ConsoleScreenBufferInfo
+	if windows.GetConsoleScreenBufferInfo(windows.Handle(consoleOut), &info) != nil {
+		return
+	}
+	last := info.Window
+	go func() {
+		for {
+			time.Sleep(resizePollInterval)
+			if windows.GetConsoleScreenBufferInfo(windows.Handle(consoleOut), &info) != nil {
+				continue
+			}
+			current := info.Window
+			if current.Right-current.Left != last.Right-last.Left ||
+				current.Bottom-current.Top != last.Bottom-last.Top {
+				last = current
+				select {
+				case resizeChan <- resizeSignal{}:
+				default:
+				}
+			}
+		}
+	}()
 }
 
 func notifyStop(p *os.Process) {


### PR DESCRIPTION
Windows has no SIGWINCH and notifyOnResize was an empty TODO, so fzf running in --height mode never noticed console size changes. Poll the console screen buffer dimensions every 100ms and push a signal through the same channel SIGWINCH uses on Unix. Full-screen mode is unaffected as it goes through tcell which emits its own resize events.

Fix #4790

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm that this PR meets the above expectations and reflects my own understanding and real-world context.
