### PR TITLE
test(zsh): check capture for fzf exit status in widget

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -139,11 +139,11 @@ fzf-history-widget() {
   # as the associative 'history' array, which maps event numbers to full history
   # lines, are set. Also, make sure Perl is installed for multi-line output.
   if zmodload -F zsh/parameter p:{commands,history} 2>/dev/null && (( ${+commands[perl]} )); then
+    extracted_with_perl=1
     selected="$(printf '%s\t%s\000' "${(kv)history[@]}" |
       perl -0 -ne 'if (!$seen{(/^\s*[0-9]+\**\t(.*)/s, $1)}++) { s/\n/\n\t/g; print; }' |
       FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort,alt-r:toggle-raw --wrap-sign '\t↳ ' --highlight-line --multi ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER} --read0") \
       FZF_DEFAULT_OPTS_FILE='' $(__fzfcmd))"
-      extracted_with_perl=1
   else
     selected="$(fc -rl 1 | __fzf_exec_awk '{ cmd=$0; sub(/^[ \t]*[0-9]+\**[ \t]+/, "", cmd); if (!seen[cmd]++) print $0 }' |
       FZF_DEFAULT_OPTS=$(__fzf_defaults "" "-n2..,.. --scheme=history --bind=ctrl-r:toggle-sort,alt-r:toggle-raw --wrap-sign '\t↳ ' --highlight-line --multi ${FZF_CTRL_R_OPTS-} --query=${(qqq)LBUFFER}") \

--- a/test/test_shell_integration.rb
+++ b/test/test_shell_integration.rb
@@ -999,6 +999,20 @@ class TestZsh < TestBase
     tmux.send_keys 'C-l', 'C-r'
   end
 
+  test_perl_and_awk 'ctrl_r_exit_code' do
+    exit_file = "#{tempname}-exit"
+    # Wrapper captures status, as widgets return values don't propagate to "$?"
+    # A non-zero status causes the shell to beep when the widget exits (man zshzle)
+    tmux.send_keys %(f() { zle fzf-history-widget; echo $? > #{exit_file}; zle reset-prompt } && zle -N f && bindkey "^R" f), :Enter
+    prepare_ctrl_r_test
+    tmux.until { |lines| assert_operator lines.match_count, :>, 0 }
+    tmux.send_keys 'C-g' # abort
+    tmux.send_keys "cat #{exit_file}", :Enter
+    tmux.until { |lines| assert_equal '130', lines[-1] }
+  ensure
+    FileUtils.rm_f(exit_file)
+  end
+
   test_perl_and_awk 'ctrl_r_accept_or_print_query' do
     set_var('FZF_CTRL_R_OPTS', '--bind enter:accept-or-print-query')
     prepare_ctrl_r_test


### PR DESCRIPTION
fix #4871

- first add a regression test => let it run to see only perl fails
- commit the suggested fix

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:

- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm that this PR meets the above expectations and reflects my own understanding and real-world context.
