### PR TITLE
test(zsh): verify chpwd fires once in alt-c widget

### DIFF
--- a/shell/key-bindings.zsh
+++ b/shell/key-bindings.zsh
@@ -115,7 +115,7 @@ fzf-cd-widget() {
   # working directory.
   # If failed, fallback to the unexpanded path to surface the error to the user.
   # NOTE: Don't use the `:a` modifier as it resolves symlinks like `pwd -P`.
-  dir=$(builtin cd >/dev/null -- "${dir}" && echo "${PWD}" || echo "${dir}")
+  dir=$(builtin cd -q >/dev/null -- "${dir}" && echo "${PWD}" || echo "${dir}")
   zle push-line # Clear buffer. Auto-restored on next prompt.
   BUFFER="builtin cd -- ${(q)dir}"
   zle accept-line

--- a/test/test_shell_integration.rb
+++ b/test/test_shell_integration.rb
@@ -965,6 +965,18 @@ class TestZsh < TestBase
     end
   end
 
+  # Duplicate 'chpwd' calls overcount visits => skews rank tracking tools (e.g. 'zoxide')
+  def test_alt_c_chpwd_hook_once
+    tmux.send_keys "chpwd() { echo 'chpwd hook fired' >&2 }", :Enter
+    tmux.prepare
+    tmux.send_keys :Escape, :c
+    tmux.until { |lines| assert_operator lines.match_count, :>, 0 }
+    tmux.send_keys :Enter
+    tmux.until do |lines|
+      assert_equal 1, lines.count { |l| l.include?('chpwd hook fired') }
+    end
+  end
+
   # Helper function to run test with Perl and again with Awk
   def self.test_perl_and_awk(name, &block)
     define_method(:"test_#{name}") do


### PR DESCRIPTION
fix #4879

- regression test => fails
- commit the suggested fix

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:

- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm that this PR meets the above expectations and reflects my own understanding and real-world context.
