### PR TITLE
fish: Improve custom CTRL-T command execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ CHANGELOG
     - fzf now opens in a tmux or Zellij floating pane by default, so the window it was started from stays visible and can be used while fzf is running
         - Requires tmux 3.7+ or Zellij 0.44+
         - Set `g:fzf_layout` to pick a different layout
+- fish: Fixed custom CTRL-T command not using the prefixed target directory in some cases (#4498)
 
 0.74.3
 ------

--- a/shell/key-bindings.fish
+++ b/shell/key-bindings.fish
@@ -104,7 +104,7 @@ function fzf_key_bindings
   # Store current token in $dir as root for the 'find' command
   function fzf-file-widget -d "List files and folders"
     set -l commandline (__fzf_parse_commandline)
-    set -lx dir $commandline[1]
+    set -l dir $commandline[1]
     set -l fzf_query $commandline[2]
     set -l prefix $commandline[3]
 
@@ -112,10 +112,17 @@ function fzf_key_bindings
       "--reverse --walker=file,dir,follow,hidden --scheme=path" \
       "--multi $FZF_CTRL_T_OPTS --print0")
 
-    set -lx FZF_DEFAULT_COMMAND "$FZF_CTRL_T_COMMAND"
     set -lx FZF_DEFAULT_OPTS_FILE
 
-    set -l result (eval (__fzfcmd) --walker-root=$dir --query=$fzf_query | string split0)
+    set -lx FZF_DEFAULT_COMMAND
+
+    if test -n "$FZF_CTRL_T_COMMAND"
+      set -f result (eval $FZF_CTRL_T_COMMAND \| (__fzfcmd) --query=$fzf_query | string split0)
+    else
+      set -f result (eval (__fzfcmd) --walker-root=$dir --query=$fzf_query | string split0)
+    end
+
+    test -n "$result"
     and commandline -rt -- (string join -- ' ' $prefix(string escape -n -- $result))' '
 
     commandline -f repaint


### PR DESCRIPTION
The custom CTRL-T command is now executed by the script in the current shell session, instead of being called by fzf through a subshell. This ensures that the value of $dir can't be altered by user initialization scripts, and is also a little faster.

Fix #4498

## Contribution Policy

We do not accept pull requests generated primarily by AI without genuine understanding or real-world usage context.

All contributions are expected to demonstrate:
- A clear understanding of the codebase
- Alignment with product direction
- Thoughtful reasoning behind changes
- Evidence of real-world usage or hands-on experience with the problem

If these expectations are not met, we would prefer to implement the changes ourselves rather than spend time reviewing low-effort submissions.

---

## Acknowledgement

- [x] I confirm that this PR meets the above expectations and reflects my own understanding and real-world context.
